### PR TITLE
fix: use $CLAUDE_PROJECT_DIR in hook script instead of hardcoded path

### DIFF
--- a/.claude/hooks/slope-guard.sh
+++ b/.claude/hooks/slope-guard.sh
@@ -5,5 +5,5 @@
 # === SLOPE MANAGED (do not edit above this line) ===
 # Note: Do NOT use `< /dev/stdin` — on WSL2 the /dev/stdin redirect
 # can fail when Claude Code pipes hook input. Use inherited stdin directly.
-node /home/srbryers/slope/dist/cli/index.js guard "$@"
+node "$CLAUDE_PROJECT_DIR/dist/cli/index.js" guard "$@"
 # === SLOPE END ===


### PR DESCRIPTION
## Summary
- Fixed `slope-guard.sh` using a hardcoded WSL2 path (`/home/srbryers/slope/dist/cli/index.js`) that doesn't exist on macOS
- Replaced with `"$CLAUDE_PROJECT_DIR/dist/cli/index.js"` which resolves correctly on any machine via the environment variable Claude Code provides to all hooks

## Test plan
- [x] Verified `dist/cli/index.js` exists at the project root
- [x] Confirmed stop hook runs successfully after the fix (it caught the uncommitted change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration paths to use project-relative references instead of hard-coded system paths, improving system portability and deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->