### PR TITLE
chore(S40): add sprint 40 scorecard

### DIFF
--- a/docs/retros/sprint-40.json
+++ b/docs/retros/sprint-40.json
@@ -60,7 +60,7 @@
     "fairways_total": 4,
     "greens_in_regulation": 2,
     "greens_total": 4,
-    "putts": 3,
+    "putts": 2,
     "penalties": 0,
     "hazards_hit": 3,
     "hazard_penalties": 0,


### PR DESCRIPTION
## Summary

- Sprint 40 scorecard: The Welcome Mat — par (4/4)
- 2 in_the_hole (getting-started, tutorial docs), 2 green (init summary review fixes, README keyword fix)
- Phase 7 complete

## Test plan

- [x] `npx slope validate docs/retros/sprint-40.json` — valid (2 warnings: no player, no training)
- [x] `npx slope review docs/retros/sprint-40.json` — review generated successfully
- [x] `npx slope card` — handicap card updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an install summary feature to CLI initialization.

* **Documentation**
  * Updated getting-started guide and first-sprint tutorial.
  * Overhauled README documentation.
  * Updated package metadata with new keywords and description.

* **Tests**
  * Added comprehensive test coverage for CLI initialization (16 new tests; 1,818 tests passing).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->