### PR TITLE
chore: bump version to 1.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Version bump for patch release v1.13.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)