### PR TITLE
fix(docs): correct MiniMax API endpoint URL

### DIFF
--- a/docs/slope-dev-loop-plan.md
+++ b/docs/slope-dev-loop-plan.md
@@ -105,8 +105,8 @@ MiniMax M2.5 is the heavy hitter for complex tickets. At 230B params (10B active
 # Sign up at https://www.minimax.io and get an API key
 export MINIMAX_API_KEY="your-key-here"
 
-# Test via curl
-curl https://api.minimax.chat/v1/text/chatcompletion_v2 \
+# Test via curl (OpenAI-compatible endpoint)
+curl https://api.minimax.io/v1/chat/completions \
   -H "Authorization: Bearer $MINIMAX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{


### PR DESCRIPTION
## Summary
- Fixes incorrect MiniMax API endpoint in `docs/slope-dev-loop-plan.md`
- `api.minimax.chat/v1/text/chatcompletion_v2` → `api.minimax.io/v1/chat/completions`
- The correct URL is the OpenAI-compatible endpoint per MiniMax platform docs

## Test plan
- [x] Verified correct URL against https://platform.minimax.io/docs/api-reference/text-openai-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API endpoint documentation to reflect the OpenAI-compatible endpoint for the Minimax API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->