### PR TITLE
fix(embedding): resilient batch embedding + skip lock files

### DIFF
--- a/src/core/embedding-client.ts
+++ b/src/core/embedding-client.ts
@@ -59,8 +59,14 @@ export async function embed(
   return sorted.map(d => new Float32Array(d.embedding));
 }
 
+// Safety net: truncate chunks that exceed embedding model context.
+// nomic-embed-text has 8192 token context; dense content can tokenize
+// at ~2 chars/token, so 8000 chars is a safe per-chunk ceiling.
+const MAX_EMBED_CHARS = 8000;
+
 /**
  * Embed code chunks in batches, returning full EmbeddingResults.
+ * Truncates oversized chunks and retries failed batches individually.
  */
 export async function embedBatch(
   chunks: CodeChunk[],
@@ -71,16 +77,35 @@ export async function embedBatch(
 
   for (let i = 0; i < chunks.length; i += batchSize) {
     const batch = chunks.slice(i, i + batchSize);
-    const texts = batch.map(c => c.content);
-    const vectors = await embed(texts, config);
+    const texts = batch.map(c =>
+      c.content.length > MAX_EMBED_CHARS ? c.content.slice(0, MAX_EMBED_CHARS) : c.content,
+    );
 
-    for (let j = 0; j < batch.length; j++) {
-      results.push({
-        filePath: batch[j].filePath,
-        chunkIndex: batch[j].chunkIndex,
-        chunkText: batch[j].content,
-        vector: vectors[j],
-      });
+    try {
+      const vectors = await embed(texts, config);
+      for (let j = 0; j < batch.length; j++) {
+        results.push({
+          filePath: batch[j].filePath,
+          chunkIndex: batch[j].chunkIndex,
+          chunkText: batch[j].content,
+          vector: vectors[j],
+        });
+      }
+    } catch {
+      // Batch failed — retry each chunk individually, skip failures
+      for (let j = 0; j < batch.length; j++) {
+        try {
+          const [vector] = await embed([texts[j]], config);
+          results.push({
+            filePath: batch[j].filePath,
+            chunkIndex: batch[j].chunkIndex,
+            chunkText: batch[j].content,
+            vector,
+          });
+        } catch {
+          // Skip this chunk — content exceeds model context
+        }
+      }
     }
   }
 

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -28,6 +28,11 @@ export const SKIP_EXTENSIONS = new Set([
   '.so', '.dylib', '.lock', '.map',
 ]);
 
+/** Filenames to skip regardless of extension (lock files, generated output). */
+export const SKIP_FILENAMES = new Set([
+  'pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', 'bun.lockb',
+]);
+
 export const SKIP_DIRS = new Set([
   'node_modules', 'dist', '.git', '.slope', 'coverage',
 ]);
@@ -138,6 +143,10 @@ export function shouldSkipFile(filePath: string): boolean {
   for (const part of parts) {
     if (SKIP_DIRS.has(part)) return true;
   }
+
+  // Check filename (lock files with non-.lock extensions)
+  const filename = parts[parts.length - 1];
+  if (SKIP_FILENAMES.has(filename)) return true;
 
   return false;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -613,6 +613,7 @@ export {
   shouldSkipFile,
   MAX_CHUNK_FILE_SIZE,
   SKIP_EXTENSIONS,
+  SKIP_FILENAMES,
   SKIP_DIRS,
 } from './embedding.js';
 export type {


### PR DESCRIPTION
## Summary
- `embedBatch` now retries failed batches individually and skips unencodable chunks instead of crashing the entire index
- Truncates chunks >8000 chars as safety net for dense content
- Adds `SKIP_FILENAMES` set to prevent indexing lock files (`pnpm-lock.yaml`, etc.)

Discovered during E2E validation of the `slope index → prep → enrich` pipeline.

## Test plan
- [x] `pnpm test` — 2028 tests pass
- [x] `pnpm typecheck` — clean
- [x] `slope index --full` — completes successfully (321 files, 374 chunks)
- [x] `slope prep S-LOCAL-040-1` — generates valid plan
- [x] `slope enrich` — enriches 6 tickets across 4 sprints

🤖 Generated with [Claude Code](https://claude.com/claude-code)