### PR TITLE
chore(slope-loop): switch MODEL_API to claude-sonnet-4

### DIFF
--- a/slope-loop/run.sh
+++ b/slope-loop/run.sh
@@ -25,7 +25,7 @@ BRANCH_PREFIX="slope-loop"
 
 # ─── Model Tier Configuration ─────────────────────
 MODEL_LOCAL="${MODEL_LOCAL:-ollama/qwen2.5-coder:32b}"
-MODEL_API="${MODEL_API:-openrouter/minimax/minimax-m2.5}"
+MODEL_API="${MODEL_API:-openrouter/anthropic/claude-sonnet-4}"
 MODEL_API_TIMEOUT=1800                              # 30min for complex tickets
 MODEL_LOCAL_TIMEOUT=900                             # 15min for simple tickets
 ESCALATE_ON_FAIL="${ESCALATE_ON_FAIL:-true}"


### PR DESCRIPTION
## Summary
- MiniMax M2.5 via OpenRouter wasn't generating Aider-compatible edit blocks — produced planning text instead
- Switch default MODEL_API to `openrouter/anthropic/claude-sonnet-4` which is a proven Aider-compatible model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated the default API model configuration used when no explicit model is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->