### PR TITLE
feat(hardening): S-LOCAL-040 harden hotspot modules

### DIFF
--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -31,16 +31,15 @@ function resolveRoadmapPath(flags: Record<string, string>, cwd: string): string 
   return join(cwd, config.roadmapPath);
 }
 
-function loadRoadmapFile(flags: Record<string, string>, cwd: string): RoadmapDefinition | null {
+function loadRawRoadmap(flags: Record<string, string>, cwd: string): { path: string; raw: unknown } | null {
   const path = resolveRoadmapPath(flags, cwd);
-  let raw: unknown;
   try {
     const content = readFileSync(path, 'utf8');
     if (!content.trim()) {
       console.error(`\nRoadmap file is empty: ${path}\n`);
       return null;
     }
-    raw = JSON.parse(content);
+    return { path, raw: JSON.parse(content) };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       console.error(`\nNo roadmap file found at: ${path}`);
@@ -51,8 +50,13 @@ function loadRoadmapFile(flags: Record<string, string>, cwd: string): RoadmapDef
     }
     return null;
   }
+}
 
-  const { roadmap, validation } = parseRoadmap(raw);
+function loadRoadmapFile(flags: Record<string, string>, cwd: string): RoadmapDefinition | null {
+  const loaded = loadRawRoadmap(flags, cwd);
+  if (!loaded) return null;
+
+  const { roadmap, validation } = parseRoadmap(loaded.raw);
   if (!roadmap) {
     console.error('\nRoadmap file has structural errors:\n');
     for (const e of validation.errors) {
@@ -85,26 +89,10 @@ function resolveSprint(flags: Record<string, string>, cwd: string): number {
 // --- Subcommands ---
 
 function validateSubcommand(flags: Record<string, string>, cwd: string): void {
-  const path = resolveRoadmapPath(flags, cwd);
-  let raw: unknown;
-  try {
-    const content = readFileSync(path, 'utf8');
-    if (!content.trim()) {
-      console.error(`\nRoadmap file is empty: ${path}\n`);
-      process.exit(1);
-    }
-    raw = JSON.parse(content);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      console.error(`\nNo roadmap file found at: ${path}`);
-      console.error('Create one with "slope init" or specify --path=<file>\n');
-    } else {
-      console.error(`\nFailed to parse roadmap file: ${path}`);
-      console.error(`Error: ${(error as Error).message}\n`);
-    }
-    process.exit(1);
-  }
+  const loaded = loadRawRoadmap(flags, cwd);
+  if (!loaded) process.exit(1);
 
+  const { path, raw } = loaded;
   const { roadmap, validation } = parseRoadmap(raw);
 
   console.log(`\nRoadmap: ${path}`);

--- a/src/cli/commands/store.ts
+++ b/src/cli/commands/store.ts
@@ -205,32 +205,33 @@ async function restoreStore(flags: Record<string, string>, cwd: string): Promise
   // Validate the backup file is a valid SLOPE database
   try {
     const db = new Database(fromPath, { readonly: true });
+    let validationError: string | null = null;
     try {
-      // Check if schema_version table exists
       const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'").get();
       if (!tables) {
-        console.error('Error: Backup file is not a valid SLOPE database (missing schema_version table)');
-        process.exit(1);
-      }
-
-      const row = db.prepare('SELECT MAX(version) as v FROM schema_version').get() as { v: number | null } | undefined;
-      const version = row?.v ?? 0;
-      if (version === 0) {
-        console.error('Error: Backup file has no schema version — not a valid SLOPE database');
-        process.exit(1);
-      }
-
-      // Verify core tables exist
-      const coreTables = ['sessions', 'claims', 'scorecards', 'events'];
-      for (const table of coreTables) {
-        const exists = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table);
-        if (!exists) {
-          console.error(`Error: Backup file is missing required table: ${table}`);
-          process.exit(1);
+        validationError = 'Backup file is not a valid SLOPE database (missing schema_version table)';
+      } else {
+        const row = db.prepare('SELECT MAX(version) as v FROM schema_version').get() as { v: number | null } | undefined;
+        const version = row?.v ?? 0;
+        if (version === 0) {
+          validationError = 'Backup file has no schema version — not a valid SLOPE database';
+        } else {
+          const coreTables = ['sessions', 'claims', 'scorecards', 'events'];
+          for (const table of coreTables) {
+            const exists = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table);
+            if (!exists) {
+              validationError = `Backup file is missing required table: ${table}`;
+              break;
+            }
+          }
         }
       }
     } finally {
       db.close();
+    }
+    if (validationError) {
+      console.error(`Error: ${validationError}`);
+      process.exit(1);
     }
   } catch (err) {
     console.error(`Error: Cannot read backup file: ${(err as Error).message}`);


### PR DESCRIPTION
## Summary
Autonomous sprint (Claude Sonnet via Aider) hardening top hotspot modules:

- **store.ts**: Hardened backup/restore with output path validation, proper error handling for DB open/copy failures, schema validation on restore (checks schema_version table + core tables exist), target directory existence checks
- **roadmap.ts**: Robust error handling for file loading (empty file, ENOENT vs parse errors), sprint number validation, null-safe access for tickets/phases/theme fields, empty sprints guard in scope balance

## Fixes applied post-generation
- `Database` namespace used as type → `ReturnType<typeof Database>` (TS2709)
- Removed `{ readonly: true }` on backup DB open — WAL checkpoint requires write access (known S38 hazard)

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 2062 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Aider (Claude Sonnet)