### PR TITLE
feat(slope-loop): improve backlog generator for autonomous execution

### DIFF
--- a/slope-loop/analyze-scorecards.ts
+++ b/slope-loop/analyze-scorecards.ts
@@ -39,8 +39,9 @@ function extractFileRefs(texts: string[]): string[] {
       const file = match[1];
       // Skip non-source bare json files (e.g. "analysis.json")
       if (file.endsWith('.json') && !file.includes('/')) continue;
-      // Skip docs, templates, and config directories
-      if (file.startsWith('docs/') || file.startsWith('templates/') || file.startsWith('.claude/')) continue;
+      // Skip docs, templates, config, build output, and dotfile directories
+      // Note: \b in the regex strips leading dots, so .claude/ becomes claude/
+      if (/^(docs|templates|\.?claude|\.?slope|dist|node_modules)\//.test(file)) continue;
       refs.add(file);
     }
   }
@@ -199,11 +200,15 @@ function analyze(): void {
       }
     }
 
-    // Extract file refs from bunker_locations
+    // Extract file refs from bunker_locations (architectural hazards)
     for (const bunker of card.bunker_locations ?? []) {
       const refs = extractFileRefs([bunker]);
-      if (!hazardTypeFiles['rough']) hazardTypeFiles['rough'] = new Set();
-      for (const ref of refs) hazardTypeFiles['rough'].add(ref);
+      if (refs.length > 0) {
+        if (!hazardTypeFiles['bunker']) hazardTypeFiles['bunker'] = new Set();
+        for (const ref of refs) hazardTypeFiles['bunker'].add(ref);
+        if (!hazardTypeDescs['bunker']) hazardTypeDescs['bunker'] = [];
+        hazardTypeDescs['bunker'].push(bunker);
+      }
     }
   }
 
@@ -559,6 +564,7 @@ function generateBacklog(analysis: Analysis, sprintCount: number): void {
         };
       }),
     });
+    counter++;
   }
 
   writeFileSync(

--- a/slope-loop/run.sh
+++ b/slope-loop/run.sh
@@ -178,8 +178,10 @@ run_ticket_with_model() {
 
   # Add primary files from enriched ticket as --file flags (editable context)
   if [ -n "${TICKET_PRIMARY_FILES:-}" ]; then
-    FILE_COUNT=0
+    local FILE_COUNT=0
+    local MAX_EDIT_FILES=5
     while IFS= read -r f; do
+      if [ "$FILE_COUNT" -ge "$MAX_EDIT_FILES" ]; then break; fi
       if [ -n "$f" ] && [ -f "$f" ] && [[ "$f" == *.ts || "$f" == *.js || "$f" == *.sh ]]; then
         aider_args+=(--file "$f")
         FILE_COUNT=$((FILE_COUNT + 1))
@@ -332,7 +334,6 @@ while read -r TICKET; do
   EST_TOKENS=$(echo "$TICKET" | jq -r '.estimated_tokens // 0')
   # Extract primary files from enriched ticket (set by slope enrich)
   TICKET_PRIMARY_FILES=$(echo "$TICKET" | jq -r '.files.primary[]? // empty' 2>/dev/null)
-  export TICKET_PRIMARY_FILES
 
   log "-- Ticket: $TICKET_KEY — $TICKET_TITLE --"
   log "   Club: $TICKET_CLUB (max_files: $TICKET_MAX_FILES, est_tokens: $EST_TOKENS)"


### PR DESCRIPTION
## Summary

- **Extract file references from hazard descriptions** — new `extractFileRefs()` helper mines `.ts`/`.js`/`.sh` file paths from scorecard text so tickets target specific source files instead of vague shot titles like "Backup/restore + docs"
- **Improve all 5 backlog strategies** — hardening and cleanup strategies now filter to hotspots with identifiable files, populate `modules[]` with real paths, and include hazard descriptions for context. Documentation strategy targets specific high-risk files. Meta strategy replaced with hardening overflow for uncovered hotspot files
- **Pass `files.primary` to Aider in run.sh** — enriched ticket files are now added as `--file` flags (editable context) and listed in the prompt under `FILES TO MODIFY:` so Aider knows exactly what to change

## Motivation

S-LOCAL-040 had wrong file mappings (docs/templates instead of source files) and S-LOCAL-041 was a complete no-op — Aider couldn't figure out what to do with "Fix recurring: rough hazard". Root causes: hotspot "areas" came from shot titles not file paths, cleanup tickets had empty `modules[]`, and `run.sh` never passed files to Aider.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 2039 tests pass
- [x] `npx tsx slope-loop/analyze-scorecards.ts` generates backlog with specific file targets
- [x] Inspected `backlog.json` — tickets have file names in titles, non-empty `modules[]`, no docs/meta-only tickets
- [ ] `slope enrich slope-loop/backlog.json` — verify enrichment resolves basenames to full paths
- [ ] Dry-run `run.sh` to verify `--file` flags appear in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analysis now captures source-file references and short hazard descriptions per area and hazard type.
  * Backlog generation produces file-scoped tickets for recurring hazards, documentation needs, and hardening/overflow work.

* **Improvements**
  * Tickets include specific source files and contextual descriptions for clearer scope.
  * Ticket prompts now surface primary files to guide modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->