### PR TITLE
test(slope-loop): add unit tests for extractFileRefs

### DIFF
--- a/slope-loop/analyze-scorecards.ts
+++ b/slope-loop/analyze-scorecards.ts
@@ -30,9 +30,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // --- File Reference Extraction ---
 
 // Match patterns like "enrich.ts", "src/core/prep.ts", "run.sh"
-const FILE_REF_PATTERN = /\b((?:[\w.-]+\/)*[\w.-]+\.(?:ts|js|sh|json))\b/g;
+export const FILE_REF_PATTERN = /\b((?:[\w.-]+\/)*[\w.-]+\.(?:ts|js|sh|json))\b/g;
 
-function extractFileRefs(texts: string[]): string[] {
+export function extractFileRefs(texts: string[]): string[] {
   const refs = new Set<string>();
   for (const text of texts) {
     for (const match of text.matchAll(FILE_REF_PATTERN)) {

--- a/tests/cli/extract-file-refs.test.ts
+++ b/tests/cli/extract-file-refs.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { extractFileRefs, FILE_REF_PATTERN } from '../../slope-loop/analyze-scorecards.js';
+
+describe('extractFileRefs', () => {
+  it('extracts bare filenames and relative paths', () => {
+    const result = extractFileRefs([
+      'enrich.ts',
+      'run.sh',
+      'src/core/prep.ts',
+    ]);
+    expect(result).toContain('enrich.ts');
+    expect(result).toContain('run.sh');
+    expect(result).toContain('src/core/prep.ts');
+  });
+
+  it('matches .ts, .js, and .sh extensions', () => {
+    const result = extractFileRefs([
+      'foo.ts bar.js baz.sh',
+    ]);
+    expect(result).toEqual(expect.arrayContaining(['foo.ts', 'bar.js', 'baz.sh']));
+  });
+
+  it('matches .json only with a path prefix', () => {
+    const result = extractFileRefs([
+      'analysis.json',
+      'config/settings.json',
+    ]);
+    expect(result).not.toContain('analysis.json');
+    expect(result).toContain('config/settings.json');
+  });
+
+  it('excludes docs/, templates/, dist/, node_modules/, .claude/, .slope/ directories', () => {
+    const inputs = [
+      'docs/retros/sprint-1.json',
+      'templates/init.ts',
+      'dist/index.js',
+      'node_modules/foo/bar.ts',
+      '.claude/hooks/test.sh',
+      '.slope/config.json',
+    ];
+    const result = extractFileRefs(inputs);
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes dot-stripped directory variants (claude/, slope/)', () => {
+    // The \\b in the regex strips leading dots, so .claude/ may match as claude/
+    const result = extractFileRefs([
+      'claude/hooks/test.sh',
+      'slope/config.json',
+    ]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('deduplicates across multiple texts', () => {
+    const result = extractFileRefs([
+      'Fixed enrich.ts threshold',
+      'enrich.ts still used old 0.55 threshold',
+    ]);
+    expect(result).toEqual(['enrich.ts']);
+  });
+
+  it('returns empty array for empty inputs', () => {
+    expect(extractFileRefs([])).toEqual([]);
+    expect(extractFileRefs([''])).toEqual([]);
+    expect(extractFileRefs(['no file references here'])).toEqual([]);
+  });
+
+  it('extracts file refs embedded in prose', () => {
+    const result = extractFileRefs([
+      'enrich.ts still used old 0.55 threshold',
+    ]);
+    expect(result).toEqual(['enrich.ts']);
+  });
+
+  it('extracts multiple files from a single string', () => {
+    const result = extractFileRefs([
+      'Fixed run.sh and continuous.sh',
+    ]);
+    expect(result).toContain('run.sh');
+    expect(result).toContain('continuous.sh');
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('FILE_REF_PATTERN', () => {
+  it('is a global regex', () => {
+    expect(FILE_REF_PATTERN.flags).toContain('g');
+  });
+
+  it('matches expected file extensions', () => {
+    const input = 'foo.ts bar.js baz.sh config/x.json skip.py';
+    const matches = [...input.matchAll(FILE_REF_PATTERN)].map(m => m[1]);
+    expect(matches).toEqual(['foo.ts', 'bar.js', 'baz.sh', 'config/x.json']);
+    expect(matches).not.toContain('skip.py');
+  });
+});


### PR DESCRIPTION
## Summary
- Export `extractFileRefs` and `FILE_REF_PATTERN` from `slope-loop/analyze-scorecards.ts` for testability
- Add 11 unit tests in `tests/cli/extract-file-refs.test.ts` covering basic extraction, extension filtering, bare JSON rejection, directory exclusions, deduplication, empty inputs, embedded-in-prose parsing, and multi-file strings
- `extractFileRefs` is the critical-path function driving all backlog ticket generation (PR #52) and previously had zero test coverage

## Test plan
- [x] `pnpm test` — all 2050 tests pass (114 files), including 11 new ones
- [x] `pnpm typecheck` — passes
- [x] Script still runs standalone via `npx tsx slope-loop/analyze-scorecards.ts` (confirmed during test collection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)