### PR TITLE
fix(slope-loop): push after each ticket

### DIFF
--- a/slope-loop/run.sh
+++ b/slope-loop/run.sh
@@ -451,6 +451,10 @@ START by reading the relevant source files, then implement the change."
   TICKET_RESULTS=$(echo "$TICKET_RESULTS" | jq ". + [$TICKET_RESULT]")
 
   slope release --target="$TICKET_KEY" 2>/dev/null || true
+
+  # Push after each ticket — last push is the recovery point
+  git push -u origin "$BRANCH" 2>/dev/null || log "   Warning: git push failed for $TICKET_KEY"
+
   log "-- Ticket $TICKET_KEY complete --"
 done < <(echo "$SPRINT" | jq -c '.tickets[]')
 


### PR DESCRIPTION
## Summary

- Adds `git push -u origin` after each completed ticket in the autonomous loop's ticket processing loop
- Without this, the loop created branches and committed via Aider's `--auto-commits` but never pushed, leaving all work unrecoverable on crash or context loss
- Matches commit discipline spec: "push after each completed ticket (Post-Shot Routine)"

## Test plan

- [x] Verified the push is placed after `slope release` and before the ticket-complete log
- [ ] Next autonomous sprint run will confirm pushes happen per-ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced recovery mechanism for ticket processing workflows with improved checkpointing during batch operations. Push failures are now logged without interrupting the processing pipeline, ensuring greater stability and recoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->