### PR TITLE
feat(S-LOCAL-047): Harden top hotspot modules

### DIFF
--- a/slope-loop/continuous.sh
+++ b/slope-loop/continuous.sh
@@ -94,8 +94,6 @@ while [ "$completed" -lt "$MAX_SPRINTS" ]; do
       log "Backlog regeneration failed. Stopping."
       break
     fi
-    # Reset failure counter after successful backlog regeneration
-    failures=0
     remaining=$(remaining_sprints)
     if [ -z "$remaining" ]; then
       log "No sprints in regenerated backlog. Nothing to do."

--- a/slope-loop/parallel.sh
+++ b/slope-loop/parallel.sh
@@ -12,7 +12,7 @@ for cmd in jq git pnpm; do
     missing_tools+=("$cmd")
   fi
 done
-if [ ${#missing_tools[@]} -gt 0 ]; then
+if [ "${#missing_tools[@]}" -gt 0 ]; then
   echo "Missing required tools: ${missing_tools[*]}"
   exit 1
 fi
@@ -204,16 +204,18 @@ else
   git -C "$SLOPE_DIR" worktree remove "$WORKTREE_B" --force 2>/dev/null || log "Warning: failed to remove worktree B"
   
   # Only delete branches if they were successfully merged or have no commits
-  if git -C "$SLOPE_DIR" merge-base --is-ancestor "$branch_a" HEAD 2>/dev/null; then
+  if git -C "$SLOPE_DIR" merge-base --is-ancestor "$branch_a" HEAD 2>/dev/null || \
+     [ "$(git -C "$SLOPE_DIR" rev-list --count "$branch_a" 2>/dev/null)" = "0" ] 2>/dev/null; then
     git -C "$SLOPE_DIR" branch -d "$branch_a" 2>/dev/null || log "Note: keeping branch $branch_a (cleanup failed)"
   else
-    log "Note: keeping branch $branch_a (has unmerged changes)"
+    log "Note: keeping branch $branch_a (has unmerged changes or commits)"
   fi
   
-  if git -C "$SLOPE_DIR" merge-base --is-ancestor "$branch_b" HEAD 2>/dev/null; then
+  if git -C "$SLOPE_DIR" merge-base --is-ancestor "$branch_b" HEAD 2>/dev/null || \
+     [ "$(git -C "$SLOPE_DIR" rev-list --count "$branch_b" 2>/dev/null)" = "0" ] 2>/dev/null; then
     git -C "$SLOPE_DIR" branch -d "$branch_b" 2>/dev/null || log "Note: keeping branch $branch_b (cleanup failed)"
   else
-    log "Note: keeping branch $branch_b (has unmerged changes)"
+    log "Note: keeping branch $branch_b (has unmerged changes or commits)"
   fi
 
   log "=== Parallel Runner Complete ==="


### PR DESCRIPTION
## Sprint S-LOCAL-047 — Harden top hotspot modules

**Strategy:** hardening | **Tickets:** 2 | **Passing:** 1 | **No-ops:** 1

### Tickets
- **S-LOCAL-047-1**: Harden: continuous.sh — pass (claude-sonnet-4)
- **S-LOCAL-047-2**: Harden: builder.test.ts — no-op (qwen2.5-coder:32b)

### Verification
- Tests: passing
- Generated by autonomous loop (`slope-loop/run.sh`)