### PR TITLE
chore(slope-loop): default API model to Claude Haiku 4.5

### DIFF
--- a/slope-loop/run.sh
+++ b/slope-loop/run.sh
@@ -25,7 +25,7 @@ BRANCH_PREFIX="slope-loop"
 
 # ─── Model Tier Configuration ─────────────────────
 MODEL_LOCAL="${MODEL_LOCAL:-ollama/qwen2.5-coder:32b}"
-MODEL_API="${MODEL_API:-openrouter/anthropic/claude-sonnet-4}"
+MODEL_API="${MODEL_API:-openrouter/anthropic/claude-haiku-4-5}"
 MODEL_API_TIMEOUT=1800                              # 30min for complex tickets
 MODEL_LOCAL_TIMEOUT=900                             # 15min for simple tickets
 ESCALATE_ON_FAIL="${ESCALATE_ON_FAIL:-true}"


### PR DESCRIPTION
## Summary
- Switch default API model from Claude Sonnet 4 to Claude Haiku 4.5 (~10x cheaper)
- Haiku passed all safeguards on short_iron/wedge tasks with comparable speed (90s vs 86s)
- Gemini 2.5 Flash was tested but failed typecheck (hallucinated API method)
- Can still override per-run with `MODEL_API=openrouter/anthropic/claude-sonnet-4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)