### PR TITLE
fix(guard): use pgrep in stop-check to avoid false positives

### DIFF
--- a/src/cli/guards/stop-check.ts
+++ b/src/cli/guards/stop-check.ts
@@ -13,7 +13,7 @@ export async function stopCheckGuard(_input: HookInput, cwd: string): Promise<Gu
   // If the autonomous loop is running, dirty state belongs to it — warn instead of blocking
   let loopRunning = false;
   try {
-    const psOut = execSync("ps aux | grep -E 'slope-loop/(run|continuous|parallel)\\.sh' | grep -v grep", { cwd, encoding: 'utf8' }).trim();
+    const psOut = execSync("pgrep -f 'bash.*slope-loop/(run|continuous|parallel)\\.sh'", { cwd, encoding: 'utf8' }).trim();
     loopRunning = psOut.length > 0;
   } catch { /* no matching process */ }
 


### PR DESCRIPTION
## Summary
- Replace `ps aux | grep` with `pgrep -f 'bash.*slope-loop/'` in stop-check guard
- Prevents false loop detection when Aider child processes (spawned by the loop) match the grep pattern
- Fixes test failures that occurred when the autonomous loop was running concurrently with `pnpm test`

## Test plan
- [x] All 2056 tests pass
- [x] `stopCheckGuard` tests pass with and without loop running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal process detection mechanism for improved performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->