### PR TITLE
fix(slope-loop): suppress Aider Ollama warnings

### DIFF
--- a/slope-loop/run.sh
+++ b/slope-loop/run.sh
@@ -26,6 +26,7 @@ BRANCH_PREFIX="slope-loop"
 # ─── Model Tier Configuration ─────────────────────
 MODEL_LOCAL="${MODEL_LOCAL:-ollama/qwen3-coder-next}"
 MODEL_API="${MODEL_API:-openrouter/anthropic/claude-haiku-4-5}"
+export OLLAMA_API_BASE="${OLLAMA_API_BASE:-http://localhost:11434}"
 MODEL_API_TIMEOUT=1800                              # 30min for complex tickets
 MODEL_LOCAL_TIMEOUT=900                             # 15min for simple tickets
 ESCALATE_ON_FAIL="${ESCALATE_ON_FAIL:-true}"
@@ -234,9 +235,9 @@ run_ticket_with_model() {
     --yes
   )
 
-  # Suppress streaming for local models (cleaner logs)
+  # Suppress streaming and model warnings for local models (cleaner logs, no browser popup)
   if [[ "$model" == *"ollama"* ]]; then
-    aider_args+=(--no-stream)
+    aider_args+=(--no-stream --no-show-model-warnings)
   fi
 
   # Inject agent guide skill if within token budget


### PR DESCRIPTION
## Summary
- Export `OLLAMA_API_BASE` with default `http://localhost:11434` so Aider doesn't warn about missing env var
- Add `--no-show-model-warnings` to Aider args for Ollama models to prevent browser popup

## Context
Every time the loop runs with a local Ollama model, Aider opens `https://aider.chat/docs/llms/warnings.html` in the browser and prints a warning about `OLLAMA_API_BASE` not being set.

## Test plan
- [x] `bash -n slope-loop/run.sh` — syntax check passes
- [ ] Run a sprint with local Ollama model — no browser popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)