### PR TITLE
fix(slope-loop): blocking typecheck + tests with auto-revert

### DIFF
--- a/slope-loop/run.sh
+++ b/slope-loop/run.sh
@@ -347,16 +347,18 @@ run_ticket_with_model() {
 
   # Guard 1: Typecheck — catches wrong imports, missing types
   if ! pnpm typecheck > /dev/null 2>&1; then
-    log "   REVERT: typecheck failing after $ticket_id — reverting $(git rev-list --count "$pre_aider_sha".."$post_aider_sha") commit(s)"
+    log "   REVERT: typecheck failing after $ticket_id — reverting $(git rev-list --count "$pre_aider_sha".."$post_aider_sha" 2>/dev/null || echo '?') commit(s)"
     git reset --hard "$pre_aider_sha"
+    git clean -fd 2>/dev/null || true  # Remove untracked files Aider may have created
     return 1
   fi
 
   # Guard 2: Tests — catches broken behavior, removed used imports
   # Uses LOOP_TEST_CMD which excludes guards.test.ts (false positive from stop-check)
   if ! $LOOP_TEST_CMD > /dev/null 2>&1; then
-    log "   REVERT: tests failing after $ticket_id — reverting $(git rev-list --count "$pre_aider_sha".."$post_aider_sha") commit(s)"
+    log "   REVERT: tests failing after $ticket_id — reverting $(git rev-list --count "$pre_aider_sha".."$post_aider_sha" 2>/dev/null || echo '?') commit(s)"
     git reset --hard "$pre_aider_sha"
+    git clean -fd 2>/dev/null || true  # Remove untracked files Aider may have created
     return 1
   fi
 
@@ -668,13 +670,9 @@ START by reading the relevant source files, then implement the change."
       FINAL_MODEL="$MODEL_API"
       ESCALATED="true"
 
-      # Reset changes from failed attempt (stash for recovery)
-      log "   Stashing failed changes for recovery (git stash)"
-      git stash push -m "slope-loop: failed $TICKET_KEY ($(date '+%Y%m%d-%H%M%S'))" 2>/dev/null || {
-        log "   Warning: git stash failed, resetting"
-        git checkout -- . 2>/dev/null || true
-        git clean -fd 2>/dev/null || true
-      }
+      # run_ticket_with_model already reverted commits via git reset --hard,
+      # but clean up any untracked files that survived the reset
+      git clean -fd 2>/dev/null || true
 
       PRE_ESCALATION_SHA=$(git rev-parse HEAD)
       if run_ticket_with_model "$TICKET_KEY" "$MODEL_API" "$MODEL_API_TIMEOUT" "$PROMPT"; then


### PR DESCRIPTION
## Summary
- **Typecheck is now blocking** — if typecheck fails after Aider runs, all commits for that ticket are reverted (`git reset --hard` to pre-aider SHA)
- **Tests run post-ticket with auto-revert** — even for local models (which don't have `--auto-test`), tests run after each ticket and revert on failure
- **Excludes `guards.test.ts` from loop test runs** — the stop-check guard detects the loop's own uncommitted changes as a false positive, masking real failures. Uses `LOOP_TEST_CMD` consistently across per-ticket checks, Aider `--test-cmd`, and auto-merge safeguards

## Motivation
Sprint S-LOCAL-057 produced 2 bad commits from Qwen3-Coder-Next (wrong import path, removed used import). Both would have been caught by typecheck or tests, but:
1. Typecheck was warning-only (non-blocking)
2. Tests were skipped for local models (no `--auto-test`)
3. `guards.test.ts` false positive masked real test failures

## Test plan
- [x] `bash -n slope-loop/run.sh` — syntax OK
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 2056 passed
- [x] `pnpm vitest run --exclude '**/guards.test.ts'` — 2007 passed (113 files, guards.test.ts correctly excluded)
- [x] `bash slope-loop/run.sh --dry-run` — dry run works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced test execution to exclude known-false-positive tests and allow configurable test commands.
  * Captures the pre-run repository state to enable reliable, reversible changes made by automation.
  * Added post-run safeguards that automatically revert automation changes if type checks or tests fail and simplified the recovery flow for more reliable rollbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->