### PR TITLE
Expand priority synonym matching for vision roadmaps

### DIFF
--- a/src/core/generators/roadmap.ts
+++ b/src/core/generators/roadmap.ts
@@ -251,7 +251,7 @@ const PRIORITY_SYNONYMS: Record<string, string[]> = {
   // Implementation domains
   api: ['endpoint', 'route', 'rest', 'graphql', 'webhook', 'fetch', 'request', 'response', 'middleware', 'handler', 'controller'],
   data: ['database', 'db', 'supabase', 'postgres', 'sqlite', 'mongo', 'redis', 'query', 'insert', 'migration', 'schema', 'model', 'orm', 'prisma', 'drizzle'],
-  ai: ['summarize', 'summarization', 'claude', 'openai', 'gpt', 'llm', 'embedding', 'relevance', 'scoring', 'ml', 'inference', 'prompt', 'generate', 'classify'],
+  ai: ['summarize', 'summarization', 'claude', 'openai', 'gpt', 'llm', 'embedding', 'relevance', 'scoring', 'ml', 'inference', 'prompt', 'classify'],
   delivery: ['email', 'notification', 'send', 'smtp', 'resend', 'mailgun', 'push', 'sms', 'alert', 'subscribe', 'newsletter', 'briefing'],
   ingestion: ['feed', 'rss', 'news', 'scrape', 'crawl', 'import', 'ingest', 'source', 'poll', 'newsapi'],
   pipeline: ['cron', 'processing', 'batch', 'queue', 'job', 'worker', 'scheduler', 'schedule', 'pipeline', 'workflow', 'step'],
@@ -269,7 +269,7 @@ function matchesPriority(text: string, priority: string): boolean {
   // Check if any path segments exactly match the priority or its synonyms
   // e.g., "src/lib/delivery/deliver.ts" → segments ["src", "lib", "delivery", "deliver"]
   const segments = lower.split(/[/\\.]/).filter(s => s.length > 2);
-  if (segments.some(seg => seg === priorityLower || priorityLower === seg)) return true;
+  if (segments.some(seg => seg === priorityLower)) return true;
   return synonyms.some(syn => segments.some(seg => seg === syn));
 }
 


### PR DESCRIPTION
## Summary

- Expands `PRIORITY_SYNONYMS` in `generateRoadmapFromVision()` to cover both quality attributes and implementation domains
- Adds domain categories: `api`, `data`, `ai`, `delivery`, `ingestion`, `pipeline`, `infra`, `payments`, `auth`
- Broadens existing quality-attribute synonyms (`speed`, `reliability`, `ux`, `security`, etc.) to catch more implementation tasks
- Adds exact path-segment matching so files under e.g. `src/lib/delivery/` match a `delivery` priority

**Before:** 0/19 TODOs matched priorities on a real project (justbriefme) — all went to overflow  
**After:** 9/19 with quality-attribute priorities (`speed, reliability, ux`), 17/19 with domain priorities (`ingestion, ai, delivery, reliability`)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 2111 passed, 0 failed
- [x] Dry-run against `/Development/justbriefme` with both quality-attribute and domain-specific priorities
- [ ] Verify existing `roadmap-from-vision.test.ts` still passes synonym and label matching tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roadmap generation now groups backlog items by vision priorities, producing optimized phases and sprints and handling overflow items.
  * Improved priority detection with broader semantic coverage (quality attributes, domains) and path-segment plus synonym-based matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->