### PR TITLE
fix(loop): mirror .slope/ config into worktrees

### DIFF
--- a/src/cli/loop/worktree.ts
+++ b/src/cli/loop/worktree.ts
@@ -1,5 +1,5 @@
 import { execSync, execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, copyFileSync, symlinkSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Logger } from './logger.js';
 
@@ -9,6 +9,46 @@ export interface WorktreeInfo {
   path: string;
   branch: string;
   created: boolean;
+}
+
+/**
+ * Mirror .slope/ directory from main repo into worktree.
+ * - Config files (*.json) are copied (small, static)
+ * - Database files (*.db) are symlinked (shared state, embeddings)
+ * - WAL/SHM files are NOT symlinked (SQLite manages them per-connection)
+ */
+function mirrorSlopeDir(mainRepo: string, worktreePath: string, log: Logger): void {
+  const srcDir = join(mainRepo, '.slope');
+  if (!existsSync(srcDir)) return;
+
+  const destDir = join(worktreePath, '.slope');
+  try {
+    mkdirSync(destDir, { recursive: true });
+  } catch { return; }
+
+  try {
+    const entries = readdirSync(srcDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const srcPath = join(srcDir, entry.name);
+      const destPath = join(destDir, entry.name);
+
+      if (entry.name.endsWith('.db')) {
+        // Symlink database so worktree shares the same store
+        try {
+          symlinkSync(srcPath, destPath);
+        } catch { /* already exists or permission issue */ }
+      } else if (entry.name.endsWith('.json')) {
+        // Copy config files
+        try {
+          copyFileSync(srcPath, destPath);
+        } catch { /* ok */ }
+      }
+    }
+    log.info('Mirrored .slope/ config into worktree');
+  } catch {
+    log.warn('Failed to mirror .slope/ into worktree — index/context may be unavailable');
+  }
 }
 
 /**
@@ -43,6 +83,9 @@ export function createWorktree(
   }
 
   log.info(`Created worktree: ${worktreePath} (branch: ${branch})`);
+
+  // Mirror .slope/ config into worktree (gitignored, so not present by default)
+  mirrorSlopeDir(mainRepo, worktreePath, log);
 
   // Install deps and build in the new worktree
   log.info('Installing dependencies in worktree...');

--- a/tests/cli/loop/worktree.test.ts
+++ b/tests/cli/loop/worktree.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { execSync, execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, copyFileSync, symlinkSync, readdirSync } from 'node:fs';
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
@@ -8,6 +8,10 @@ vi.mock('node:child_process', () => ({
 }));
 vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  copyFileSync: vi.fn(),
+  symlinkSync: vi.fn(),
+  readdirSync: vi.fn(() => []),
 }));
 
 import { createWorktree, removeWorktree, getHeadSha, countCommits, pushBranch, refreshIndex } from '../../../src/cli/loop/worktree.js';
@@ -53,6 +57,26 @@ describe('createWorktree', () => {
       'pnpm build',
       expect.any(Object),
     );
+  });
+
+  it('mirrors .slope/ dir into new worktree', () => {
+    (existsSync as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(false)  // worktree path doesn't exist
+      .mockReturnValueOnce(true);  // .slope/ dir exists in main repo
+    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue('');
+    (execSync as ReturnType<typeof vi.fn>).mockReturnValue('');
+    (readdirSync as ReturnType<typeof vi.fn>).mockReturnValue([
+      { name: 'config.json', isFile: () => true },
+      { name: 'slope.db', isFile: () => true },
+      { name: 'hooks.json', isFile: () => true },
+      { name: 'handoffs', isFile: () => false }, // directory, should be skipped
+    ]);
+    createWorktree('S-004', '/repo', mockLog);
+    expect(mkdirSync).toHaveBeenCalledWith('/repo/.slope-loop-worktree-S-004/.slope', { recursive: true });
+    expect(copyFileSync).toHaveBeenCalledWith('/repo/.slope/config.json', '/repo/.slope-loop-worktree-S-004/.slope/config.json');
+    expect(copyFileSync).toHaveBeenCalledWith('/repo/.slope/hooks.json', '/repo/.slope-loop-worktree-S-004/.slope/hooks.json');
+    expect(symlinkSync).toHaveBeenCalledWith('/repo/.slope/slope.db', '/repo/.slope-loop-worktree-S-004/.slope/slope.db');
+    expect(mockLog.info).toHaveBeenCalledWith('Mirrored .slope/ config into worktree');
   });
 
   it('throws on worktree creation failure', () => {


### PR DESCRIPTION
## Summary
- Copies `.slope/*.json` config files and symlinks `.slope/*.db` database into worktrees after creation
- Fixes the root cause of `slope index`, `slope context`, and `slope prep` all failing in loop worktrees with "No embedding config"
- This was the #1 bottleneck in the loop pipeline test — 3/8 tickets no-oped and 2/8 failed typecheck partly due to missing context

## Test plan
- [x] New unit test for `mirrorSlopeDir` behavior (JSON copied, DB symlinked, directories skipped)
- [x] All 2244 tests pass
- [x] Typecheck clean
- [ ] Run `slope loop run --dry-run` to validate worktree setup includes `.slope/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)