### PR TITLE
fix(loop): route documentation tickets to API model

### DIFF
--- a/src/cli/loop/executor.ts
+++ b/src/cli/loop/executor.ts
@@ -107,7 +107,7 @@ export async function runSprint(flags: Record<string, string>, cwd: string): Pro
           log.warn('Shutdown requested — stopping ticket processing');
           break;
         }
-        const result = await processTicket(ticket, config, worktreeCwd, log);
+        const result = await processTicket(ticket, config, worktreeCwd, log, sprint.strategy);
         ticketResults.push(result);
 
         // Log model usage (JSONL)
@@ -222,12 +222,13 @@ async function processTicket(
   config: LoopConfig,
   cwd: string,
   log: Logger,
+  strategy?: BacklogSprint['strategy'],
 ): Promise<TicketResult> {
   const tLog = log.child(`ticket:${ticket.key}`);
   tLog.info(`-- ${ticket.key}: ${ticket.title} --`);
   tLog.info(`Club: ${ticket.club} (max_files: ${ticket.max_files}, est_tokens: ${ticket.estimated_tokens ?? 0})`);
 
-  const primaryModel = selectModel(ticket.club, ticket.max_files, ticket.estimated_tokens ?? 0, config, cwd);
+  const primaryModel = selectModel(ticket.club, ticket.max_files, ticket.estimated_tokens ?? 0, config, cwd, strategy);
   const timeout = selectTimeout(primaryModel, config);
   tLog.info(`Model: ${primaryModel} (timeout: ${timeout}s)`);
 
@@ -534,7 +535,7 @@ RULES:
 function dryRunSprint(sprint: BacklogSprint, config: LoopConfig, cwd: string, log: Logger): null {
   log.info('--- Dry run mode ---');
   for (const t of sprint.tickets) {
-    const model = selectModel(t.club, t.max_files, t.estimated_tokens ?? 0, config, cwd);
+    const model = selectModel(t.club, t.max_files, t.estimated_tokens ?? 0, config, cwd, sprint.strategy);
     const modelShort = model.split('/').pop();
     log.info(`  ${t.key}: ${t.title} [club=${t.club}, files=${t.max_files}] → ${modelShort}`);
   }

--- a/src/cli/loop/model-selector.ts
+++ b/src/cli/loop/model-selector.ts
@@ -1,13 +1,14 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import type { Club, LoopConfig, ModelConfig } from './types.js';
+import type { Club, LoopConfig, ModelConfig, BacklogSprint } from './types.js';
 
 /**
- * Multi-factor model routing matching run.sh logic exactly:
+ * Multi-factor model routing:
  *  1. Token-based: est_tokens > 24000 → API
  *  2. File-based: max_files >= 2 → API
- *  3. Data-driven: check model-config.json recommendations per club
- *  4. Club defaults: putter/wedge/short_iron → local, long_iron/driver → API
+ *  3. Strategy-based: documentation → API (local models can't reliably edit prose)
+ *  4. Data-driven: check model-config.json recommendations per club
+ *  5. Club defaults: putter/wedge/short_iron → local, long_iron/driver → API
  */
 export function selectModel(
   club: Club,
@@ -15,6 +16,7 @@ export function selectModel(
   estTokens: number,
   config: LoopConfig,
   cwd: string,
+  strategy?: BacklogSprint['strategy'],
 ): string {
   // 1. Token-based escalation: won't fit in Qwen 32K context
   if (estTokens > 24000) return config.modelApi;
@@ -22,7 +24,10 @@ export function selectModel(
   // 2. Multi-file routing: 2+ files → API
   if (maxFiles >= 2) return config.modelApi;
 
-  // 3. Data-driven overrides from model-config.json
+  // 3. Strategy-based: documentation tickets need API model
+  if (strategy === 'documentation') return config.modelApi;
+
+  // 4. Data-driven overrides from model-config.json
   const modelConfig = loadModelConfig(cwd);
   if (modelConfig) {
     const rec = modelConfig.recommendations[club];
@@ -30,7 +35,7 @@ export function selectModel(
     if (rec?.model === 'local') return config.modelLocal;
   }
 
-  // 4. Club defaults
+  // 5. Club defaults
   switch (club) {
     case 'putter':
     case 'wedge':

--- a/tests/cli/loop/model-selector.test.ts
+++ b/tests/cli/loop/model-selector.test.ts
@@ -96,6 +96,35 @@ describe('selectModel', () => {
     expect(selectModel('driver', 1, 0, config, tmpDir)).toBe(config.modelApi);
   });
 
+  // Factor 5: Strategy-based routing
+  it('routes documentation strategy to API regardless of club', () => {
+    expect(selectModel('putter', 1, 0, config, tmpDir, 'documentation')).toBe(config.modelApi);
+  });
+
+  it('does not escalate non-documentation strategies', () => {
+    expect(selectModel('putter', 1, 0, config, tmpDir, 'hardening')).toBe(config.modelLocal);
+  });
+
+  it('strategy is optional (backward compat)', () => {
+    expect(selectModel('putter', 1, 0, config, tmpDir)).toBe(config.modelLocal);
+  });
+
+  it('documentation strategy beats model-config.json local recommendation', () => {
+    writeFileSync(join(tmpDir, 'slope-loop/model-config.json'), JSON.stringify({
+      generated_at: '2026-01-01T00:00:00Z',
+      ticket_count: 20,
+      escalation_save_rate: 0.5,
+      success_rates: {},
+      cost_per_success: {},
+      recommendations: {
+        putter: { model: 'local', reason: 'high local success rate' },
+      },
+      notes: [],
+    }));
+    const model = selectModel('putter', 1, 0, config, tmpDir, 'documentation');
+    expect(model).toBe(config.modelApi);
+  });
+
   // Priority: token check beats club default
   it('token escalation takes priority over club default', () => {
     const model = selectModel('putter', 1, 30000, config, tmpDir);


### PR DESCRIPTION
## Summary
- Adds `strategy` parameter to `selectModel` — `documentation` strategy routes to API model
- Local model had 0% success on docs tickets (6/6 failed across S-LOCAL-060 and S-LOCAL-062)
- Backward-compatible: `strategy` is optional, existing callers unaffected

## Test plan
- [x] 3 new tests: docs→API, non-docs→local, omitted strategy backward compat
- [x] All 2247 tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)