### PR TITLE
fix(loop): pass strategy to status display model preview

### DIFF
--- a/src/cli/commands/loop.ts
+++ b/src/cli/commands/loop.ts
@@ -122,7 +122,7 @@ function printSprintSummary(sprint: BacklogSprint, config: LoopConfig, cwd: stri
   console.log(`  Strategy: ${sprint.strategy} | Par: ${sprint.par} | Slope: ${sprint.slope} | Type: ${sprint.type}`);
   console.log(`  Tickets (${sprint.tickets.length}):`);
   for (const t of sprint.tickets) {
-    const model = selectModel(t.club, t.max_files, t.estimated_tokens ?? 0, config, cwd);
+    const model = selectModel(t.club, t.max_files, t.estimated_tokens ?? 0, config, cwd, sprint.strategy);
     const modelShort = model.split('/').pop();
     console.log(`    ${t.key}: ${t.title} [${t.club}, ${t.max_files} file(s) → ${modelShort}]`);
   }


### PR DESCRIPTION
One-liner: status subcommand now passes sprint.strategy to selectModel so docs tickets correctly show API model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Model selection logic during sprint summaries now incorporates strategy parameters for more informed model choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->