### PR TITLE
feat(S-LOCAL-064): Update docs for slope loop CLI migration

### DIFF
--- a/slope-loop/slope-loop-guide/SKILL.md
+++ b/slope-loop/slope-loop-guide/SKILL.md
@@ -32,20 +32,26 @@ flag. It evolves automatically as the loop discovers patterns. It supplements
 - 30 CLI commands, SQLite store, MCP server, 16 guard hooks
 - Scoring: golf metaphors (handicap, par, birdie, bogey, hazards)
 
-## Sprint Execution Protocol
-1. Run `slope briefing` before starting any ticket
-2. Claim tickets with `slope claim --target=<id>`
-3. Make minimal, focused changes per ticket
-4. Run `pnpm test` and `pnpm typecheck` before committing
-5. Commit messages start with the ticket ID
-6. Release tickets with `slope release --target=<id>`
-7. After all tickets: `slope auto-card --sprint=<id>` then `slope review`
+## Sprint Execution Protocol (Loop Context)
+When running within the automated loop (via Aider with `--read` flag):
+
+1. **Pre-sprint:** `slope briefing` shows hazards and nutrition trends
+2. **Claim work:** `slope claim --target=<id>` to claim a ticket or area
+3. **Focused changes:** Make minimal, targeted edits per ticket
+4. **Validation:** Run `pnpm test` and `pnpm typecheck` before committing
+5. **Commit:** Message format: `<ticket-id>: <description>`
+6. **Release:** `slope release --target=<id>` to release the claim
+7. **Post-sprint:** `slope auto-card --sprint=<id>` generates scorecard from git + CI signals
+8. **Review:** `slope review` formats the sprint review
+
+**Note:** The loop orchestrates sprint execution automatically. Do not manually invoke shell scripts (run.sh, continuous.sh, parallel.sh) — these are internal to the loop infrastructure.
 
 ## Testing Conventions
 - Tests use vitest — look for *.test.ts files adjacent to source
 - Prefer snapshot tests for complex output structures
 - Guard hooks run automatically during Claude Code sessions — respect their guidance
 - Property-based tests cover scoring math invariants
+- **In loop context:** `pnpm test` runs before auto-card generation; failures block sprint completion
 
 ## Model Tier Rules
 - Putter/Wedge → local Qwen 32B (fast, free)
@@ -58,16 +64,33 @@ flag. It evolves automatically as the loop discovers patterns. It supplements
 <!-- Patterns that caused failures will appear here -->
 <!-- Format: - [module]: [what went wrong] — [what to do differently] -->
 
+**Loop-specific hazards:**
+- Do not assume shell script execution — the loop runs via Aider/Claude Code hooks
+- Do not commit directly to main/master — the `branch-before-commit` guard blocks this
+- Do not skip test validation — loop auto-card generation requires passing tests
+
 ## Anti-Patterns (auto-populated from failure analysis)
 - Do not refactor unrelated code in a ticket
 - Do not add dependencies without explicit acceptance criteria
 - Do not modify test infrastructure unless the ticket specifically requires it
 - Do not skip `pnpm typecheck` — strict TypeScript catches real bugs
 
-## Error Handling
-- If `slope auto-card` fails: check that the sprint has commits on the branch
-- If `slope store status` reports issues: run `slope store backup` then `slope store restore`
-- If Ollama returns empty responses: verify model is loaded with `ollama list`
-- If aider edit blocks fail to parse: try `--edit-format diff` or `--edit-format whole`
+## Error Handling (Loop Context)
+- **If `slope auto-card` fails:** Check that the sprint has commits on the branch and tests pass
+- **If `slope store status` reports issues:** Run `slope store backup` then `slope store restore`
+- **If Ollama returns empty responses:** Verify model is loaded with `ollama list`
+- **If aider edit blocks fail to parse:** Try `--edit-format diff` or `--edit-format whole`
+- **If loop stalls:** Check guard output in transcript — guards may be blocking tool use
+- **If escalation triggers:** Review `slope escalate` output and model tier rules (Putter/Wedge → local, Driver → M2.5)
+
+## Loop Infrastructure (Reference)
+
+The continuous loop is orchestrated by:
+- **Backlog generation:** `npx tsx slope-loop/analyze-scorecards.ts` (regenerates sprint queue)
+- **Sprint execution:** Aider runs with `--read slope-loop/slope-loop-guide/SKILL.md` and guard hooks
+- **Result tracking:** Sprints stored in `slope-loop/results/` as JSON
+- **Logging:** Session logs in `slope-loop/logs/`
+
+Do not manually invoke `run.sh`, `continuous.sh`, or `parallel.sh` — these are internal orchestration scripts. Use `slope` CLI commands instead.
 
 For full sprint-by-sprint history, see `references/sprint-history.md`.


### PR DESCRIPTION
## Sprint S-LOCAL-064 — Update docs for slope loop CLI migration

**Strategy:** documentation | **Tickets:** 2 | **Passing:** 1 | **No-ops:** 0

### Tickets
- **S-LOCAL-064-1**: Update CLAUDE.md Self-Development Loop section — fail (claude-haiku-4-5)
- **S-LOCAL-064-2**: Update SKILL.md agent guide for TS loop — pass (claude-haiku-4-5)

### Verification
- Tests: passing
- Generated by autonomous loop (`slope loop run`)