### PR TITLE
fix(docs): correct loop-generated CLAUDE.md inaccuracies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Multi-sprint initiatives with structured review gates. Built on top of existing 
 - Specialist selection: keyword-based (`selectSpecialists()`) — backend, ml-engineer, database, frontend, ux-designer
 
 ## Self-Development Loop
-Autonomous sprint execution via the `slope loop` CLI command. The loop orchestrates multi-sprint execution with tiered model selection (local Qwen 32B + MiniMax M2.5 API escalation), backlog regeneration, and result tracking.
+Autonomous sprint execution via the `slope loop` CLI command. The loop orchestrates multi-sprint execution with tiered model selection, backlog regeneration, and result tracking.
 
 ### slope loop Subcommands
 
@@ -94,12 +94,14 @@ Autonomous sprint execution via the `slope loop` CLI command. The loop orchestra
 **Maintenance:**
 - `slope loop clean [--results] [--logs] [--worktrees] [--all]` — Clean up loop artifacts (results, logs, git worktrees)
 
-### Model Tier Rules (Loop Context)
-- **Putter/Wedge** → local Qwen 32B (fast, free)
-- **Short Iron** → local Qwen 32B (default), escalate to M2.5 on failure
-- **Long Iron/Driver** → MiniMax M2.5 API (architect-level planning)
-- **Multi-file tickets** → always M2.5 regardless of club
-- **Local model failure** → auto-escalate to M2.5 before marking as miss
+### Model Routing Rules (Loop Context)
+Model selection is configurable via `slope loop config`. Default routing:
+- **Putter/Wedge/Short Iron** → local model (configurable, default: ollama/qwen3-coder-next-fast)
+- **Long Iron/Driver** → API model (configurable, default: openrouter/anthropic/claude-haiku-4-5)
+- **Multi-file tickets (max_files >= 2)** → API model regardless of club
+- **Documentation strategy** → API model regardless of club (local models struggle with prose)
+- **Token escalation (>24K tokens)** → API model
+- **Local model failure** → auto-escalate to API model before marking as miss
 
 ### Loop Infrastructure (Reference)
 - `slope-loop/analyze-scorecards.ts` — mines scorecard data → `analysis.json` + `backlog.json`
@@ -108,11 +110,11 @@ Autonomous sprint execution via the `slope loop` CLI command. The loop orchestra
 - `slope-loop/slope-loop-guide/SKILL.md` — agent guide skill for sprint execution (auto-injected via Aider `--read` flag)
 
 ### Guard Hooks in Loop Context
-Guard hooks are auto-injected into every automated sprint via Aider's `--read` flag (see SKILL.md). The loop respects guard decisions:
-- `branch-before-commit` — blocks commits to main/master
-- `version-check` — blocks push when versions not bumped
-- `stop-check` — checks for uncommitted/unpushed work before session end
-- Other guards provide context nudges and warnings
+Guard hooks don't run during Aider execution. The loop runs equivalent post-ticket checks:
+- **typecheck**: `pnpm typecheck` after each ticket
+- **tests**: configurable test command (default: `pnpm vitest run`)
+- **auto-revert**: if guards fail, all ticket commits are reverted to pre-ticket SHA
+- **escalation**: failed ticket retried with API model before marking as miss
 
 ### Legacy/Fallback (Shell Scripts)
 The original shell script runners are deprecated but available as fallback:

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -1,11 +1,11 @@
 ---
-generated_at: "2026-03-01T22:36:10.154Z"
-git_sha: "6f93a406e155e313dffc1054acf7892dd3f6401f"
-sprint: 48
-source_files: 157
-test_files: 114
-cli_commands: 36
-guards: 16
+generated_at: "2026-03-03T23:07:58.595Z"
+git_sha: "6be298da3710e2962acbbca6a9eb7f4bdf87a868"
+sprint: 58
+source_files: 173
+test_files: 128
+cli_commands: 38
+guards: 17
 flows: 0
 ---
 
@@ -18,7 +18,7 @@ Sprint Lifecycle & Operational Performance Engine — pluggable-metaphor sprint 
 <!-- AUTO-GENERATED: START packages -->
 
 ### `src/cli`
-- Source files: 64 | Test files: 35
+- Source files: 79 | Test files: 45
 - Key modules:
   - `config`
   - `hooks-config`
@@ -30,7 +30,7 @@ Sprint Lifecycle & Operational Performance Engine — pluggable-metaphor sprint 
   - `template-generator` — SLOPE Template Generator
 
 ### `src/core`
-- Source files: 81 | Test files: 69
+- Source files: 82 | Test files: 73
 - Key modules:
   - `advisor` — --- Module-private constants ---
   - `briefing` — --- Input types ---
@@ -41,13 +41,13 @@ Sprint Lifecycle & Operational Performance Engine — pluggable-metaphor sprint 
   - `context` — SLOPE — Semantic Context Retrieval
   - `dashboard` — --- Dashboard Config ---
   - `dispersion` — --- Helpers ---
+  - `docs` — SLOPE — Documentation Manifest Builder
   - `embedding-client` — SLOPE — HTTP Client for OpenAI-Compatible Embedding Endpoints
   - `embedding-store` — SLOPE — EmbeddingStore Interface
   - `embedding` — SLOPE — Embedding Types & Chunking Logic (pure — no HTTP calls)
   - `enrich` — SLOPE — Backlog Enrichment
   - `escalation` — SLOPE — Escalation Rules
-  - `event-ingestion` — SLOPE — Real-Time Event Ingestion
-  - ... and 35 more
+  - ... and 36 more
 
 ### `src/mcp`
 - Source files: 3 | Test files: 5
@@ -203,6 +203,7 @@ Re-exports from `src/core/index.ts`:
 - `EventIngestionResult` (types)
 **Analyzers:**
 - `runAnalyzers`, `loadRepoProfile`, `saveRepoProfile`
+- `analyzeStack`, `detectPackageManager`
 - `RepoProfile`, `StackProfile`, `StructureProfile`, `GitProfile`, `TestProfile`, `CIProfile`, `DocsProfile`, `AnalyzerName` (types)
 **Complexity:**
 - `estimateComplexity`
@@ -220,11 +221,11 @@ Re-exports from `src/core/index.ts`:
 - `generateConfig`
 - `generateFirstSprint`
 - `generateCommonIssues`
-- `generateRoadmap`
+- `generateRoadmap`, `generateRoadmapFromVision`
 - `GeneratedConfig` (types)
 - `GeneratedSprint` (types)
 **Vision:**
-- `loadVision`, `saveVision`, `validateVision`
+- `loadVision`, `saveVision`, `validateVision`, `createVision`, `updateVision`
 - `VisionDocument` (types)
 **Transcript:**
 - `getTranscriptPath`, `appendTurn`, `readTranscript`, `listTranscripts`
@@ -247,6 +248,9 @@ Re-exports from `src/core/index.ts`:
 **Enrich (Backlog Enrichment):**
 - `enrichTicket`, `enrichBacklog`, `estimateTokens`
 - `EnrichedTicket`, `EnrichedBacklog` (types)
+**Docs (Documentation Manifest):**
+- `buildDocsManifest`, `computeSectionChecksum`
+- `DocsManifest`, `DocsManifestInput`, `ChangelogSection`, `ChangelogEntry`, `ChangelogChange` (types)
 **Built-in metaphors (auto-registers on import):**
 - `golf`, `tennis`, `baseball`, `gaming`, `dnd`, `matrix`, `agile`
 <!-- AUTO-GENERATED: END api -->
@@ -287,10 +291,12 @@ Re-exports from `src/core/index.ts`:
 - `slope roadmap` — Strategic planning and roadmap tools
 - `slope vision` — Display project vision document
 - `slope initiative` — Multi-sprint initiative orchestration
+- `slope loop` — Autonomous sprint execution loop
 - `slope index-cmd` — Semantic embedding index management
 - `slope context` — Semantic context search for agents
 - `slope prep` — Generate execution plan for a ticket
 - `slope enrich` — Batch-enrich backlog with file context
+- `slope docs` — Generate documentation manifest and changelog
 <!-- AUTO-GENERATED: END cli -->
 
 ## Guard Definitions
@@ -315,6 +321,7 @@ Re-exports from `src/core/index.ts`:
 | `pr-review` | PostToolUse | Bash | Prompt for review workflow after PR creation |
 | `transcript` | PostToolUse | — | Append tool call metadata to session transcript |
 | `branch-before-commit` | PreToolUse | Bash | Block git commit on main/master — create a feature branch first |
+| `worktree-check` | PreToolUse | Edit|Write | Warn when editing in main repo instead of a worktree |
 <!-- AUTO-GENERATED: END guards -->
 
 ## MCP Tools
@@ -335,14 +342,14 @@ Re-exports from `src/core/index.ts`:
 
 | Directory | Test Files | Command |
 |-----------|-----------|---------|
-| tests/cli | 35 | `pnpm test` |
-| tests/core | 69 | `pnpm test` |
+| tests/cli | 45 | `pnpm test` |
+| tests/core | 73 | `pnpm test` |
 | tests/mcp | 5 | `pnpm test` |
 | tests/store | 1 | `pnpm test` |
 | tests/store-pg | 2 | `pnpm test` |
 | tests/tokens | 1 | `pnpm test` |
 
-**Total test files:** 113
+**Total test files:** 127
 **Run all:** `pnpm -r test`
 **Typecheck:** `pnpm -r typecheck`
 <!-- AUTO-GENERATED: END tests -->
@@ -353,11 +360,11 @@ Re-exports from `src/core/index.ts`:
 
 | Sprint | Theme | Tickets | Score |
 |--------|-------|---------|-------|
-| **44** | The Data Mine | 4 | bogey |
-| **45** | The Autopilot | 4 | triple_plus |
-| **46** | The Rangefinder | 4 | triple_plus |
-| **47** | The Yardage Book v2 | 4 | par |
-| **48** | Pipeline Calibration | 4 | bogey |
+| **54** | Harden top hotspot modules | 1 | eagle |
+| **55** | Harden top hotspot modules | 3 | birdie |
+| **56** | Harden top hotspot modules | 8 | triple_plus |
+| **57** | Harden top hotspot modules | 2 | birdie |
+| **58** | Harden top hotspot modules | 8 | triple_plus |
 <!-- AUTO-GENERATED: END history -->
 
 ## Known Gotchas
@@ -366,8 +373,10 @@ Top recurring patterns from common-issues:
 
 <!-- AUTO-GENERATED: START gotchas -->
 
-- **Review-discovered hazards inflate scores** (process, 4 sprints): Every hazard since S43 was found by post-hole review, never during coding. The review gate works but is a trailing indicator.
+- **Review-discovered hazards inflate scores** (process, 5 sprints): Every hazard since S43 was found by post-hole review, never during coding. S49: all 3 hazards in autonomous sprint caught by manual code review. The review gate works but is a trailing indicator.
 - **API shape assumptions** (types, 3 sprints): Assuming property names or structure of internal APIs without reading the definition. #1 hazard source across S39-S44.
 - **Shell script boundary values** (shell, 2 sprints): Shell arithmetic comparisons (-lt vs -le, -gt vs -ge) are error-prone. S48: -lt 500 excluded exactly 500 lines. S45: multiple shell hazards.
+- **process.exit() inside try/finally skips cleanup** (control-flow, 2 sprints): process.exit(1) inside a try block with finally { db.close() } — exit runs before finally in Node.js. S46: original store.ts hazard. S49: autonomous agent repeated the same pattern in restore validation.
 - **Threshold/constant consistency across consumers** (calibration, 1 sprint): Changing a default value (e.g. minScore) in one consumer but not all consumers of the same pipeline. S48: context.ts threshold updated to 0.4 but enrich.ts still used 0.55.
+- **AI-generated code duplicates existing abstractions** (autonomous, 1 sprint): Autonomous agents (Aider/Sonnet) may reimplement logic that already exists elsewhere in the file. S49: validateSubcommand duplicated loadRoadmapFile's file-loading and error handling instead of extracting a shared helper.
 <!-- AUTO-GENERATED: END gotchas -->


### PR DESCRIPTION
## Summary
- Remove hardcoded model names (Qwen 32B, MiniMax M2.5) in favor of configurable defaults
- Replace "Model Tier Rules" with accurate "Model Routing Rules" including documentation strategy routing
- Fix "Guard Hooks in Loop Context" — guards don't run in Aider; loop runs post-ticket typecheck/tests/auto-revert
- Update CODEBASE.md via `slope map`

## Test plan
- [x] Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)