### PR TITLE
fix(analyze): exclude test files from hotspot source_files

### DIFF
--- a/slope-loop/analyze-scorecards.ts
+++ b/slope-loop/analyze-scorecards.ts
@@ -49,6 +49,8 @@ export function extractFileRefs(texts: string[]): string[] {
       // Skip docs, templates, config, build output, and dotfile directories
       // Note: \b in the regex strips leading dots, so .claude/ becomes claude/
       if (/^(docs|templates|\.?claude|\.?slope|dist|node_modules)\//.test(file)) continue;
+      // Skip test files — hotspots should target production code, not tests
+      if (/\.(test|spec)\.(ts|js)$/.test(file)) continue;
       // Skip bare basenames that are too ambiguous (no path component)
       // e.g., "test.ts", "init.ts", "index.ts" — could match dozens of files
       if (!file.includes('/') && AMBIGUOUS_BASENAMES.has(file.replace(/\.[^.]+$/, ''))) continue;

--- a/tests/cli/extract-file-refs.test.ts
+++ b/tests/cli/extract-file-refs.test.ts
@@ -116,6 +116,25 @@ describe('extractFileRefs', () => {
     expect(result).toContain('continuous.sh');
     expect(result).toContain('dashboard.ts');
   });
+
+  it('excludes .test.ts and .spec.ts files (hotspots target production code)', () => {
+    const result = extractFileRefs([
+      'src/mcp/index.test.ts',
+      'tests/mcp/index-src.test.ts',
+      'src/core/scoring.spec.ts',
+      'guard-runner.test.ts',
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it('keeps production files that contain "test" in path but not as suffix', () => {
+    const result = extractFileRefs([
+      'src/store/test.ts',
+      'src/test-utils/helpers.ts',
+    ]);
+    expect(result).toContain('src/store/test.ts');
+    expect(result).toContain('src/test-utils/helpers.ts');
+  });
 });
 
 describe('AMBIGUOUS_BASENAMES', () => {


### PR DESCRIPTION
## Summary
- `extractFileRefs()` now filters `.test.ts` and `.spec.ts` files from hotspot file references
- Prevents the backlog generator from creating tickets that target test files instead of production code
- Added 2 test cases: exclusion of test/spec files, and preservation of production files with "test" in the path

## Context
After fixing stale file ref pruning (PR #98), the only surviving file refs in hotspots were test files that happened to still exist. This caused the backlog to generate tickets like "Fix rough hazards in src/mcp/index.test.ts" — which agents can't meaningfully act on, producing no-ops.

## Test plan
- [x] 19/19 extractFileRefs tests pass (2 new)
- [x] 2267/2267 full suite passes
- [x] `pnpm typecheck` clean
- [x] `slope loop analyze --regenerate` produces 0 tickets (correct — scorecard data exhausted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)