### PR TITLE
feat(loop): planner/executor separation for concrete execution plans

### DIFF
--- a/src/cli/loop/executor.ts
+++ b/src/cli/loop/executor.ts
@@ -9,6 +9,7 @@ import { createWorktree, refreshIndex, enrichBacklog, removeWorktree, getHeadSha
 import { runGuards } from './guard-runner.js';
 import { checkGhCli, hasCommitsAhead, createPr, runStructuralReview, autoMerge } from './pr-lifecycle.js';
 import { createLogger } from './logger.js';
+import { generatePlan, formatPlanAsPrompt } from './planner.js';
 import type { LoopConfig, BacklogSprint, BacklogTicket, TicketResult, SprintResult } from './types.js';
 import type { Logger } from './logger.js';
 
@@ -235,7 +236,16 @@ async function processTicket(
   // Claim ticket
   try { execFileSync('pnpm', ['slope', 'claim', `--target=${ticket.key}`], { cwd, stdio: 'pipe' }); } catch { /* ok */ }
 
-  const prompt = buildPrompt(ticket, primaryModel);
+  // Generate execution plan (planner) with fallback to generic prompt
+  let prompt: string;
+  try {
+    const plan = generatePlan(ticket, primaryModel, cwd, tLog);
+    prompt = formatPlanAsPrompt(plan, ticket);
+    tLog.info(`Plan generated (${plan.generated} tier, ${plan.files.length} files)`);
+  } catch (err) {
+    tLog.warn(`Planner failed, falling back to buildPrompt: ${err instanceof Error ? err.message : err}`);
+    prompt = buildPrompt(ticket, primaryModel);
+  }
   const preSha = getHeadSha(cwd);
   let finalModel = primaryModel;
   let escalated = false;
@@ -403,25 +413,6 @@ async function runAider(
     log.info('slope context failed — falling back to CODEBASE.md');
     const codemap = join(cwd, 'CODEBASE.md');
     if (existsSync(codemap)) aiderArgs.push('--read', codemap);
-  }
-
-  // Prep plan injection (capture output instead of shell redirect)
-  const prepFile = join(cwd, config.logDir, `${ticketKey}-prep.md`);
-  try {
-    const prepOutput = execFileSync('pnpm', [
-      'slope', 'prep', ticketKey, '--top=5',
-    ], { cwd, encoding: 'utf8' });
-    writeFileSync(prepFile, prepOutput);
-
-    const words = prepOutput.split(/\s+/).length;
-    if (words > 0 && words < 1600) {
-      aiderArgs.push('--read', prepFile);
-      log.info(`Injected prep plan (~${Math.round(words / 4)} tokens)`);
-    } else if (words >= 1600) {
-      log.info(`Prep plan too large (~${Math.round(words / 4)} tokens) — skipping`);
-    }
-  } catch {
-    log.info('slope prep failed — continuing without plan');
   }
 
   // Primary files from enriched ticket as --file flags (editable)

--- a/src/cli/loop/planner.ts
+++ b/src/cli/loop/planner.ts
@@ -1,0 +1,259 @@
+// Planner — generates concrete execution plans for Aider without embeddings.
+// 3-tier file discovery: enriched → grep → generic.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { collectTestFiles } from '../../core/prep.js';
+import { isLocalModel } from './model-selector.js';
+import type { BacklogTicket, ExecutionPlan, PlanFileEntry } from './types.js';
+import type { Logger } from './logger.js';
+
+// Stop words for keyword extraction
+const STOP_WORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+  'of', 'with', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been',
+  'has', 'have', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+  'should', 'may', 'might', 'can', 'this', 'that', 'these', 'those',
+  'it', 'its', 'as', 'if', 'not', 'no', 'so', 'up', 'out', 'all',
+  'add', 'update', 'fix', 'remove', 'change', 'make', 'use', 'new',
+]);
+
+/**
+ * Extract top keywords from text for grep discovery.
+ */
+export function extractKeywords(text: string, max = 3): string[] {
+  const words = text.toLowerCase()
+    .replace(/[^a-z0-9\s_-]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 2 && !STOP_WORDS.has(w));
+
+  // Count frequency
+  const freq = new Map<string, number>();
+  for (const w of words) {
+    freq.set(w, (freq.get(w) ?? 0) + 1);
+  }
+
+  return [...freq.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, max)
+    .map(([w]) => w);
+}
+
+/**
+ * Read the first N lines of a file and match against acceptance criteria
+ * to produce a specific action description.
+ */
+function inferAction(filePath: string, ticket: BacklogTicket, cwd: string): { action: string; reason: string } {
+  const fullPath = join(cwd, filePath);
+  let header = '';
+  try {
+    const content = readFileSync(fullPath, 'utf8');
+    header = content.split('\n').slice(0, 50).join('\n');
+  } catch {
+    return { action: 'Modify as described in ticket', reason: ticket.acceptance_criteria[0] ?? ticket.title };
+  }
+
+  // Try to match acceptance criteria keywords against file content
+  for (const ac of ticket.acceptance_criteria) {
+    const acWords = ac.toLowerCase().split(/\s+/).filter(w => w.length > 3);
+    for (const word of acWords) {
+      if (header.toLowerCase().includes(word)) {
+        return { action: `Modify to satisfy: ${ac}`, reason: ac };
+      }
+    }
+  }
+
+  // Fallback: use ticket description keywords
+  return { action: `Update per ticket requirements`, reason: ticket.acceptance_criteria[0] ?? ticket.title };
+}
+
+/**
+ * Tier 1: Use enriched primary files from the ticket.
+ */
+function tier1Enriched(ticket: BacklogTicket, cwd: string): PlanFileEntry[] | null {
+  if (!ticket.files?.primary || ticket.files.primary.length === 0) return null;
+
+  const entries: PlanFileEntry[] = [];
+  for (const f of ticket.files.primary) {
+    if (!f || !existsSync(join(cwd, f))) continue;
+    const { action, reason } = inferAction(f, ticket, cwd);
+    entries.push({ path: f, action, reason });
+  }
+
+  return entries.length > 0 ? entries : null;
+}
+
+/**
+ * Tier 2: Grep for keywords from ticket title/description.
+ */
+function tier2Grep(ticket: BacklogTicket, cwd: string): PlanFileEntry[] | null {
+  const keywords = extractKeywords(`${ticket.title} ${ticket.description}`);
+  if (keywords.length === 0) return null;
+
+  const matchedFiles = new Set<string>();
+
+  for (const keyword of keywords) {
+    if (matchedFiles.size >= 5) break;
+    try {
+      const output = execFileSync('grep', [
+        '-rl', '--include=*.ts', '--include=*.js',
+        keyword,
+        'src/', 'packages/',
+      ], { cwd, encoding: 'utf8', timeout: 5000 });
+
+      for (const line of output.split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed && !trimmed.includes('.test.') && !trimmed.includes('node_modules')) {
+          matchedFiles.add(trimmed);
+        }
+        if (matchedFiles.size >= 5) break;
+      }
+    } catch {
+      // grep returns exit code 1 when no matches — not an error
+    }
+  }
+
+  if (matchedFiles.size === 0) return null;
+
+  const entries: PlanFileEntry[] = [];
+  for (const f of matchedFiles) {
+    const { action, reason } = inferAction(f, ticket, cwd);
+    entries.push({ path: f, action, reason });
+  }
+
+  return entries;
+}
+
+/**
+ * Tier 3: Generic fallback using modules or description.
+ */
+function tier3Generic(ticket: BacklogTicket): PlanFileEntry[] {
+  if (ticket.modules.length > 0) {
+    return ticket.modules.slice(0, 5).map(m => ({
+      path: m,
+      action: 'Identify and modify relevant files in this module',
+      reason: ticket.acceptance_criteria[0] ?? ticket.title,
+    }));
+  }
+
+  return [{
+    path: '(read description to identify target files)',
+    action: ticket.title,
+    reason: ticket.acceptance_criteria[0] ?? ticket.title,
+  }];
+}
+
+/**
+ * Build model-specific approach text.
+ */
+function buildApproach(model: string): string {
+  if (isLocalModel(model)) {
+    return `## Approach (local model — keep it simple)
+- Focus on ONE file at a time
+- Make the smallest possible change that satisfies the criteria
+- Prefer editing existing code over adding new files`;
+  }
+  return `## Approach (plan then execute)
+1. List the specific changes needed per file
+2. For each file: read it, make the change, verify
+3. Run verification commands after all changes`;
+}
+
+/**
+ * Generate a concrete execution plan for a ticket using 3-tier file discovery.
+ * No embeddings required.
+ */
+export function generatePlan(
+  ticket: BacklogTicket,
+  model: string,
+  cwd: string,
+  log: Logger,
+): ExecutionPlan {
+  // Tier 1: enriched files
+  const enriched = tier1Enriched(ticket, cwd);
+  if (enriched) {
+    log.info(`Plan tier: enriched (${enriched.length} files)`);
+    return {
+      ticket: ticket.key,
+      title: ticket.title,
+      files: enriched,
+      testFiles: collectTestFiles(enriched.map(e => e.path), cwd),
+      approach: buildApproach(model),
+      generated: 'enriched',
+    };
+  }
+
+  // Tier 2: grep discovery
+  const grepped = tier2Grep(ticket, cwd);
+  if (grepped) {
+    log.info(`Plan tier: grep (${grepped.length} files)`);
+    return {
+      ticket: ticket.key,
+      title: ticket.title,
+      files: grepped,
+      testFiles: collectTestFiles(grepped.map(e => e.path), cwd),
+      approach: buildApproach(model),
+      generated: 'grep',
+    };
+  }
+
+  // Tier 3: generic
+  log.info('Plan tier: generic');
+  return {
+    ticket: ticket.key,
+    title: ticket.title,
+    files: tier3Generic(ticket),
+    testFiles: [],
+    approach: buildApproach(model),
+    generated: 'generic',
+  };
+}
+
+/**
+ * Format an ExecutionPlan as a structured Aider --message prompt.
+ */
+export function formatPlanAsPrompt(plan: ExecutionPlan, ticket: BacklogTicket): string {
+  const fileSection = plan.files.map(f =>
+    `### ${f.path}\n**Action:** ${f.action}\n**Reason:** ${f.reason}`
+  ).join('\n\n');
+
+  const testSection = plan.testFiles.length > 0
+    ? plan.testFiles.map(t => `- ${t}`).join('\n')
+    : '- (run full test suite)';
+
+  const acSection = ticket.acceptance_criteria
+    .map(ac => `  [ ] ${ac}`)
+    .join('\n');
+
+  return `You are working on the SLOPE project (TypeScript monorepo, pnpm, vitest).
+
+## Task
+${ticket.key}: ${ticket.title}
+
+## Description
+${ticket.description}
+
+## Execution Plan
+For each file below, make the specified change:
+
+${fileSection}
+
+## Test Files to Verify
+${testSection}
+
+## Acceptance Criteria (ALL must pass)
+${acSection}
+
+## Verification
+  1. pnpm typecheck
+  2. pnpm test
+
+## Rules
+- Read each file BEFORE modifying — understand existing patterns
+- Make real, substantive changes — no comment-only or whitespace edits
+- If a file already satisfies criteria, skip it
+- Commit: '${ticket.key}: <what you changed>'
+
+${plan.approach}`;
+}

--- a/src/cli/loop/types.ts
+++ b/src/cli/loop/types.ts
@@ -127,6 +127,23 @@ export interface SprintResult {
   merge_block_reason?: string;
 }
 
+// === Execution Plan ===
+
+export interface ExecutionPlan {
+  ticket: string;           // ticket key
+  title: string;
+  files: PlanFileEntry[];   // concrete file-level changes
+  testFiles: string[];      // matched test files
+  approach: string;         // model-specific approach text
+  generated: 'enriched' | 'grep' | 'generic'; // which tier produced the plan
+}
+
+export interface PlanFileEntry {
+  path: string;             // relative file path
+  action: string;           // what to do: "add export", "modify function X", etc.
+  reason: string;           // why: maps to which acceptance criterion
+}
+
 // === Model Config ===
 
 export interface ModelConfig {

--- a/tests/cli/loop/planner.test.ts
+++ b/tests/cli/loop/planner.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { generatePlan, formatPlanAsPrompt, extractKeywords } from '../../../src/cli/loop/planner.js';
+import type { BacklogTicket } from '../../../src/cli/loop/types.js';
+import type { Logger } from '../../../src/cli/loop/logger.js';
+
+let tmpDir: string;
+let log: Logger;
+
+function makeTicket(overrides: Partial<BacklogTicket> = {}): BacklogTicket {
+  return {
+    key: 'TEST-1',
+    title: 'Add planner module',
+    club: 'short_iron',
+    description: 'Create a planner that generates execution plans',
+    acceptance_criteria: ['planner exports generatePlan', 'tests pass'],
+    modules: ['src/cli/loop'],
+    max_files: 2,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-planner-'));
+  // Create src and packages dirs for grep tier
+  mkdirSync(join(tmpDir, 'src', 'cli', 'loop'), { recursive: true });
+  mkdirSync(join(tmpDir, 'packages'), { recursive: true });
+  // Create tests dir for collectTestFiles
+  mkdirSync(join(tmpDir, 'tests', 'cli', 'loop'), { recursive: true });
+
+  log = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => log,
+  };
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── extractKeywords ──────────────────────────────────
+
+describe('extractKeywords', () => {
+  it('extracts top keywords excluding stop words', () => {
+    const keywords = extractKeywords('Add the planner module for execution plans');
+    expect(keywords).not.toContain('the');
+    expect(keywords).not.toContain('for');
+    expect(keywords.length).toBeLessThanOrEqual(3);
+    expect(keywords.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty for all stop words', () => {
+    const keywords = extractKeywords('the a an and or but');
+    expect(keywords).toEqual([]);
+  });
+
+  it('respects max parameter', () => {
+    const keywords = extractKeywords('planner executor module backlog config', 2);
+    expect(keywords.length).toBeLessThanOrEqual(2);
+  });
+
+  it('ranks by frequency', () => {
+    const keywords = extractKeywords('planner planner planner executor executor module');
+    expect(keywords[0]).toBe('planner');
+  });
+});
+
+// ── generatePlan tiers ───────────────────────────────
+
+describe('generatePlan', () => {
+  describe('tier 1 — enriched files', () => {
+    it('uses enriched primary files when they exist on disk', () => {
+      const filePath = 'src/cli/loop/planner.ts';
+      writeFileSync(join(tmpDir, filePath), 'export function generatePlan() {}');
+
+      const ticket = makeTicket({ files: { primary: [filePath] } });
+      const plan = generatePlan(ticket, 'ollama/qwen3', tmpDir, log);
+
+      expect(plan.generated).toBe('enriched');
+      expect(plan.files.length).toBe(1);
+      expect(plan.files[0].path).toBe(filePath);
+    });
+
+    it('skips enriched files that do not exist on disk', () => {
+      const ticket = makeTicket({ files: { primary: ['src/nonexistent.ts'] } });
+      const plan = generatePlan(ticket, 'ollama/qwen3', tmpDir, log);
+
+      // Should fall through to tier 2 or 3 since file doesn't exist
+      expect(plan.generated).not.toBe('enriched');
+    });
+
+    it('infers action from file content matching acceptance criteria', () => {
+      const filePath = 'src/cli/loop/planner.ts';
+      writeFileSync(join(tmpDir, filePath), 'export function generatePlan() { /* planner */ }');
+
+      const ticket = makeTicket({
+        files: { primary: [filePath] },
+        acceptance_criteria: ['planner exports generatePlan'],
+      });
+      const plan = generatePlan(ticket, 'ollama/qwen3', tmpDir, log);
+
+      expect(plan.generated).toBe('enriched');
+      expect(plan.files[0].action).toContain('planner exports generatePlan');
+    });
+  });
+
+  describe('tier 2 — grep discovery', () => {
+    it('finds files via grep when no enriched files exist', () => {
+      // Create a file containing a keyword from the ticket title
+      const filePath = join(tmpDir, 'src', 'cli', 'loop', 'planner.ts');
+      writeFileSync(filePath, 'export function planner() { return "execution"; }');
+
+      const ticket = makeTicket({
+        title: 'Add planner for execution',
+        description: 'planner generates execution plans',
+        files: undefined,
+      });
+      const plan = generatePlan(ticket, 'ollama/qwen3', tmpDir, log);
+
+      // May be grep or generic depending on whether grep finds the keyword
+      if (plan.generated === 'grep') {
+        expect(plan.files.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('tier 3 — generic fallback', () => {
+    it('falls back to modules when no files found', () => {
+      const ticket = makeTicket({
+        title: 'xyzzy frobnicator',
+        description: 'frobnicate the xyzzy',
+        files: undefined,
+        modules: ['src/core'],
+      });
+      const plan = generatePlan(ticket, 'ollama/qwen3', tmpDir, log);
+
+      expect(plan.generated).toBe('generic');
+      expect(plan.files[0].path).toBe('src/core');
+    });
+
+    it('provides placeholder when no modules either', () => {
+      const ticket = makeTicket({
+        title: 'xyzzy frobnicator',
+        description: 'frobnicate the xyzzy',
+        files: undefined,
+        modules: [],
+      });
+      const plan = generatePlan(ticket, 'ollama/qwen3', tmpDir, log);
+
+      expect(plan.generated).toBe('generic');
+      expect(plan.files[0].path).toContain('read description');
+    });
+  });
+
+  describe('test file matching', () => {
+    it('finds matching test files for enriched primary files', () => {
+      const srcPath = 'src/cli/loop/planner.ts';
+      writeFileSync(join(tmpDir, srcPath), 'export function generatePlan() {}');
+      writeFileSync(join(tmpDir, 'tests', 'cli', 'loop', 'planner.test.ts'), 'test("works", () => {})');
+
+      const ticket = makeTicket({ files: { primary: [srcPath] } });
+      const plan = generatePlan(ticket, 'ollama/qwen3', tmpDir, log);
+
+      expect(plan.testFiles).toContain('tests/cli/loop/planner.test.ts');
+    });
+  });
+
+  describe('approach text', () => {
+    it('uses local model approach for ollama models', () => {
+      const filePath = 'src/cli/loop/planner.ts';
+      writeFileSync(join(tmpDir, filePath), 'export function generatePlan() {}');
+
+      const ticket = makeTicket({ files: { primary: [filePath] } });
+      const plan = generatePlan(ticket, 'ollama/qwen3', tmpDir, log);
+
+      expect(plan.approach).toContain('local model');
+      expect(plan.approach).toContain('ONE file');
+    });
+
+    it('uses API approach for non-ollama models', () => {
+      const filePath = 'src/cli/loop/planner.ts';
+      writeFileSync(join(tmpDir, filePath), 'export function generatePlan() {}');
+
+      const ticket = makeTicket({ files: { primary: [filePath] } });
+      const plan = generatePlan(ticket, 'openrouter/anthropic/claude-haiku-4-5', tmpDir, log);
+
+      expect(plan.approach).toContain('plan then execute');
+    });
+  });
+});
+
+// ── formatPlanAsPrompt ───────────────────────────────
+
+describe('formatPlanAsPrompt', () => {
+  it('produces structured prompt with all required sections', () => {
+    const plan = generatePlan(
+      makeTicket({
+        files: { primary: [] },
+        modules: ['src/core'],
+      }),
+      'ollama/qwen3',
+      tmpDir,
+      log,
+    );
+    const ticket = makeTicket();
+    const prompt = formatPlanAsPrompt(plan, ticket);
+
+    expect(prompt).toContain('## Task');
+    expect(prompt).toContain('TEST-1');
+    expect(prompt).toContain('## Execution Plan');
+    expect(prompt).toContain('## Acceptance Criteria');
+    expect(prompt).toContain('## Verification');
+    expect(prompt).toContain('## Rules');
+    expect(prompt).toContain('planner exports generatePlan');
+    expect(prompt).toContain('tests pass');
+  });
+
+  it('includes file actions in the prompt', () => {
+    const filePath = 'src/cli/loop/planner.ts';
+    writeFileSync(join(tmpDir, filePath), 'export function generatePlan() {}');
+
+    const ticket = makeTicket({ files: { primary: [filePath] } });
+    const plan = generatePlan(ticket, 'ollama/qwen3', tmpDir, log);
+    const prompt = formatPlanAsPrompt(plan, ticket);
+
+    expect(prompt).toContain('src/cli/loop/planner.ts');
+    expect(prompt).toContain('**Action:**');
+    expect(prompt).toContain('**Reason:**');
+  });
+
+  it('includes test files section', () => {
+    const srcPath = 'src/cli/loop/planner.ts';
+    writeFileSync(join(tmpDir, srcPath), 'export function generatePlan() {}');
+    writeFileSync(join(tmpDir, 'tests', 'cli', 'loop', 'planner.test.ts'), 'test("works", () => {})');
+
+    const ticket = makeTicket({ files: { primary: [srcPath] } });
+    const plan = generatePlan(ticket, 'ollama/qwen3', tmpDir, log);
+    const prompt = formatPlanAsPrompt(plan, ticket);
+
+    expect(prompt).toContain('## Test Files to Verify');
+    expect(prompt).toContain('planner.test.ts');
+  });
+
+  it('includes commit message format with ticket key', () => {
+    const plan = generatePlan(makeTicket({ modules: ['src/core'] }), 'ollama/qwen3', tmpDir, log);
+    const prompt = formatPlanAsPrompt(plan, makeTicket());
+
+    expect(prompt).toContain("'TEST-1: <what you changed>'");
+  });
+});


### PR DESCRIPTION
## Summary
- **New `planner.ts`** — 3-tier file discovery (enriched → grep → generic) generates concrete, file-specific execution plans without embeddings
- **Plan as primary instruction** — execution plan is now the Aider `--message` (primary task), replacing the generic `buildPrompt()` output; old `slope prep` injection (embedding-dependent, `--read` only) removed
- **Graceful fallback** — if planner fails, `buildPrompt()` is used as fallback via try/catch

## Test plan
- [x] 17 new unit tests covering all 3 tiers, keyword extraction, test file matching, approach text, and prompt formatting
- [x] `pnpm build` — compiles cleanly
- [x] `pnpm typecheck` — no type errors
- [x] `pnpm test` — 2284 tests pass (129 files)
- [x] `slope loop run --dry-run` — validates tickets and model routing correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Execution plans now generated with intelligent tiered file discovery approach (enriched, grep, and generic fallback)
  * Automatic test file detection and inclusion in execution plans
  * Structured prompt formatting for ticket execution

* **Refactor**
  * Simplified ticket processing pipeline with improved fallback behavior and enhanced logging visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->