### PR TITLE
fix(loop): start backlog counter after highest result file

### DIFF
--- a/slope-loop/analyze-scorecards.ts
+++ b/slope-loop/analyze-scorecards.ts
@@ -21,7 +21,7 @@ import {
 import type {
   DispersionReport,
 } from '../dist/index.js';
-import { writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { writeFileSync, readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { BacklogSprint, PlannedSprint } from '../src/cli/loop/types.js';
@@ -465,7 +465,19 @@ export function convertPlannedSprints(
 
 function generateBacklog(analysis: Analysis, sprintCount: number): void {
   const sprints: BacklogSprint[] = [];
-  let counter = sprintCount + 1;
+
+  // Start counter after both scorecards AND existing result files.
+  // The loop may have run sprints that don't have scorecards yet,
+  // so we need to check both to avoid ID collisions.
+  const resultsDir = join(__dirname, 'results');
+  let maxResultNum = 0;
+  if (existsSync(resultsDir)) {
+    for (const f of readdirSync(resultsDir)) {
+      const m = f.match(/^S-LOCAL-(\d+)\.json$/);
+      if (m) maxResultNum = Math.max(maxResultNum, Number(m[1]));
+    }
+  }
+  let counter = Math.max(sprintCount, maxResultNum) + 1;
 
   // Determine safe club from success rates
   const clubSuccessMap: Record<string, number> = {};


### PR DESCRIPTION
## Summary

- The backlog counter was starting at `sprintCount + 1` (number of scorecards), but loop result files extend well beyond that number. This caused all roadmap-driven sprints to collide with existing result IDs and get silently skipped.
- Now scans `slope-loop/results/` for the highest `S-LOCAL-NNN` number and starts the counter at `max(sprintCount, maxResultNum) + 1`.

## Test plan

- [x] Existing analyze-scorecards tests still pass (13/13)
- [x] `pnpm build` + `pnpm typecheck` clean
- [x] Manual verification: with 55 scorecards and results up to S-LOCAL-066, counter now starts at 067 instead of 056

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced backlog identifier generation to prevent potential collisions by intelligently considering existing data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->