### PR TITLE
feat(S-LOCAL-067): Context budget per ticket

### DIFF
--- a/src/cli/loop/executor.ts
+++ b/src/cli/loop/executor.ts
@@ -495,6 +495,17 @@ async function runAider(
 export function buildPrompt(ticket: BacklogTicket, model: string): string {
   const local = isLocalModel(model);
 
+  // Calculate token budget based on club and model tier
+  const clubBudgets: Record<string, number> = {
+    putter: 4000,
+    wedge: 4000,
+    short_iron: 8000,
+    long_iron: 16000,
+    driver: 24000,
+  };
+  const baseBudget = clubBudgets[ticket.club] ?? 8000;
+  const tokenBudget = local ? Math.floor(baseBudget / 2) : baseBudget;
+
   // Build structured file list from enriched primary files or modules
   const targetFiles = ticket.files?.primary?.slice(0, 5) ?? ticket.modules?.slice(0, 5) ?? [];
   const fileSection = targetFiles.length > 0
@@ -520,6 +531,9 @@ ${fileSection}
 
 ## Acceptance Criteria (ALL must pass)
 ${acSection}
+
+## Token Budget
+You have ~${tokenBudget} tokens — focus on the core change. Avoid verbose explanations or refactoring unrelated code.
 
 ## Verification Commands
   1. pnpm typecheck

--- a/tests/cli/loop/executor.test.ts
+++ b/tests/cli/loop/executor.test.ts
@@ -129,6 +129,50 @@ describe('buildPrompt', () => {
     expect(prompt).toContain('do NOT add only comments');
   });
 
+  it('includes token budget section', () => {
+    const prompt = buildPrompt(baseTicket, 'qwen2.5:32b');
+
+    expect(prompt).toContain('Token Budget');
+    expect(prompt).toContain('tokens');
+    expect(prompt).toContain('focus on the core change');
+  });
+
+  it('calculates budget based on club (short_iron = 8K for API)', () => {
+    const prompt = buildPrompt(baseTicket, 'openrouter/anthropic/claude-haiku-4-5');
+
+    expect(prompt).toContain('~8000 tokens');
+  });
+
+  it('halves budget for local models (short_iron = 4K for local)', () => {
+    const prompt = buildPrompt(baseTicket, 'ollama/qwen3-coder-next-fast');
+
+    expect(prompt).toContain('~4000 tokens');
+  });
+
+  it('uses putter budget (4K API, 2K local)', () => {
+    const putterTicket: BacklogTicket = {
+      ...baseTicket,
+      club: 'putter',
+    };
+    const apiPrompt = buildPrompt(putterTicket, 'openrouter/anthropic/claude-haiku-4-5');
+    const localPrompt = buildPrompt(putterTicket, 'ollama/qwen3-coder-next-fast');
+
+    expect(apiPrompt).toContain('~4000 tokens');
+    expect(localPrompt).toContain('~2000 tokens');
+  });
+
+  it('uses driver budget (24K API, 12K local)', () => {
+    const driverTicket: BacklogTicket = {
+      ...baseTicket,
+      club: 'driver',
+    };
+    const apiPrompt = buildPrompt(driverTicket, 'openrouter/anthropic/claude-haiku-4-5');
+    const localPrompt = buildPrompt(driverTicket, 'ollama/qwen3-coder-next-fast');
+
+    expect(apiPrompt).toContain('~24000 tokens');
+    expect(localPrompt).toContain('~12000 tokens');
+  });
+
   it('includes verification commands', () => {
     const prompt = buildPrompt(baseTicket, 'qwen2.5:32b');
 


### PR DESCRIPTION
## Sprint S-LOCAL-067 — Context budget per ticket

**Strategy:** roadmap | **Tickets:** 1 | **Passing:** 1 | **No-ops:** 0

### Tickets
- **S-LOCAL-067-1**: Add token budget instruction to Aider prompt based on club/model — pass (claude-haiku-4-5)

### Verification
- Tests: passing
- Generated by autonomous loop (`slope loop run`)