### PR TITLE
docs: backfill missing scorecards S30, S37, S41

### DIFF
--- a/docs/retros/sprint-30.json
+++ b/docs/retros/sprint-30.json
@@ -1,0 +1,97 @@
+{
+  "sprint_number": 30,
+  "theme": "The Surveyor",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-02-25",
+  "type": "feature",
+  "backfilled": true,
+  "shots": [
+    {
+      "ticket_key": "S30-1",
+      "title": "Analyzer types + pipeline runner",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "AnalyzerType union, RepoProfile aggregate type, and runAnalyzerPipeline orchestrator. Clean single-commit implementation."
+    },
+    {
+      "ticket_key": "S30-2",
+      "title": "Stack + structure analyzers",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "walkDir utility for recursive file traversal, stack analyzer (package.json detection, framework inference), structure analyzer (directory depth, file count, monorepo detection)."
+    },
+    {
+      "ticket_key": "S30-3",
+      "title": "Git history + testing analyzers",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Git analyzer (commit count, contributors, cadence, latest tag), testing analyzer (framework detection, coverage config, test file patterns)."
+    },
+    {
+      "ticket_key": "S30-4",
+      "title": "Vision document + slope analyze CLI command",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Two commits — vision document + CLI wiring, then MCP registry entries. Wired slope analyze command and added analyzer + vision entries to MCP search."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 3,
+    "greens_total": 4,
+    "putts": 1,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "altitude",
+      "description": "New analyzers/ subsystem — first time building repo introspection in SLOPE",
+      "impact": "none"
+    }
+  ],
+  "special_plays": [],
+  "training": [],
+  "nutrition": [
+    {
+      "category": "hydration",
+      "description": "Build + test verified. All tickets committed individually with conventional commit messages.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Clean sprint — all 4 tickets landed without hazards. The analyzer pipeline pattern (type + runner + individual analyzers) proved to be a solid foundation that S31 built on directly.",
+    "advice_for_next_player": "walkDir utility is reusable beyond analyzers. The RepoProfile type aggregates all analyzer outputs — add new analyzers by extending the profile interface.",
+    "what_surprised_you": "No scorecard was filed for this sprint — it was bundled into the S31 PR and the post-hole routine was skipped.",
+    "excited_about_next": "S31 (Course Designer) will use these analyzers to auto-generate SLOPE configuration from any repo."
+  },
+  "bunker_locations": [],
+  "yardage_book_updates": [
+    "src/core/analyzers/types.ts: AnalyzerType, RepoProfile, individual analyzer result types",
+    "src/core/analyzers/stack.ts: detectStack — package.json, framework, language inference",
+    "src/core/analyzers/structure.ts: analyzeStructure — depth, file counts, monorepo detection",
+    "src/core/analyzers/git.ts: analyzeGit — commits, contributors, cadence, tags",
+    "src/core/analyzers/testing.ts: analyzeTesting — test framework, coverage, patterns",
+    "src/core/analyzers/walk.ts: walkDir — recursive file traversal utility"
+  ],
+  "course_management_notes": [
+    "4 tickets, par 4, score 4 — clean par with no hazards",
+    "Backfilled retroactively — scorecard was missed during original sprint execution",
+    "Work was committed 2026-02-25 and merged as part of the S31 Course Designer PR"
+  ]
+}

--- a/docs/retros/sprint-37.json
+++ b/docs/retros/sprint-37.json
@@ -1,0 +1,99 @@
+{
+  "sprint_number": 37,
+  "theme": "The Adapter Interface",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-02-27",
+  "type": "feature",
+  "backfilled": true,
+  "shots": [
+    {
+      "ticket_key": "S37-1",
+      "title": "Add supportedEvents + hooksConfigPath() to HarnessAdapter interface",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Extended HarnessAdapter interface with supportedEvents, supportsContextInjection, and hooksConfigPath(cwd) — three self-describing members."
+    },
+    {
+      "ticket_key": "S37-2",
+      "title": "Implement new methods on all 4 built-in adapters",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Implemented on claude-code, cursor, windsurf, and generic adapters. Each adapter now declares its own capabilities rather than relying on static maps."
+    },
+    {
+      "ticket_key": "S37-3",
+      "title": "Migrate guard status + consumers to use adapter methods",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Migrated guard status command from HARNESS_EVENT_SUPPORT static map and isEventSupported()/getHooksConfigPath() to adapter.supportedEvents and adapter.hooksConfigPath(). Output unchanged — pure refactor."
+    },
+    {
+      "ticket_key": "S37-4",
+      "title": "Deprecate static maps, update docs + tests",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added @deprecated JSDoc to static maps. Updated harness-research.md authoring guide. Regenerated CODEBASE.md. 62 new tests passing."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 2,
+    "greens_total": 4,
+    "putts": 2,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "wind",
+      "description": "Motivated by S36 review finding — tech debt flagged in HARNESS_EVENT_SUPPORT static maps",
+      "impact": "tailwind"
+    }
+  ],
+  "special_plays": [],
+  "training": [],
+  "nutrition": [
+    {
+      "category": "hydration",
+      "description": "Build + typecheck + 1740 tests passing at completion.",
+      "status": "healthy"
+    },
+    {
+      "category": "supplements",
+      "description": "62 new tests across adapter and guard status test files.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Clean refactor sprint. The adapter interface extension was well-scoped — each ticket had a clear boundary. Moving from static maps to adapter methods was straightforward.",
+    "advice_for_next_player": "When adding new harness adapters, implement all three self-describing members. The deprecated static maps will eventually be removed.",
+    "what_surprised_you": "No scorecard was filed — the post-hole routine was skipped after PR merge.",
+    "excited_about_next": "S38 (The Vault) builds the PostgreSQL store, completing the persistence layer."
+  },
+  "bunker_locations": [],
+  "yardage_book_updates": [
+    "src/core/harness.ts: HarnessAdapter — supportedEvents, supportsContextInjection, hooksConfigPath(cwd)",
+    "src/core/harness.ts: HARNESS_EVENT_SUPPORT, isEventSupported(), getHooksConfigPath() — @deprecated",
+    "All 4 adapters (claude-code, cursor, windsurf, generic) now self-describing"
+  ],
+  "course_management_notes": [
+    "4 tickets, par 4, score 4 — clean par with no hazards",
+    "Backfilled retroactively — scorecard was missed during original sprint execution",
+    "Merged via PR #18 on 2026-02-27"
+  ]
+}

--- a/docs/retros/sprint-41.json
+++ b/docs/retros/sprint-41.json
@@ -1,0 +1,96 @@
+{
+  "sprint_number": 41,
+  "theme": "The Metaphor Studio",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-02-28",
+  "type": "feature",
+  "backfilled": true,
+  "shots": [
+    {
+      "ticket_key": "S41-1",
+      "title": "Selection UX — metaphor browser with preview + search",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Added saveConfig(), METAPHOR_SCHEMA, and saveCustomMetaphor() to core. Validate, save, register, and activate custom metaphors in one call."
+    },
+    {
+      "ticket_key": "S41-2",
+      "title": "Custom metaphor generation — LLM-powered vocabulary builder",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Replaced free-text metaphor prompt in slope init --interactive with a numbered menu built from listMetaphors(), including a 'custom' option that prints agent generation instructions."
+    },
+    {
+      "ticket_key": "S41-3",
+      "title": "CLI metaphor management — list, show, create, validate commands",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Added metaphor module to MCP search tool returning schema, built-in list, and example definition. Added saveCustomMetaphor and saveConfig sandbox helpers with cwd pre-bound."
+    },
+    {
+      "ticket_key": "S41-4",
+      "title": "MCP metaphor tools — search and generation via sandbox",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added slope metaphor list|set|show CLI command for metaphor management with [active] and [custom] markers."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 3,
+    "greens_total": 4,
+    "putts": 1,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "altitude",
+      "description": "First time building interactive metaphor selection UX and custom metaphor generation",
+      "impact": "none"
+    }
+  ],
+  "special_plays": [],
+  "training": [],
+  "nutrition": [
+    {
+      "category": "hydration",
+      "description": "Build + typecheck + 1842 tests passing at completion. 22 new tests added.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Smooth sprint. The metaphor system was already well-structured from earlier work — this sprint extended it with management tooling and interactive selection.",
+    "advice_for_next_player": "Custom metaphors are saved to .slope/metaphors/ and auto-registered. The METAPHOR_SCHEMA validates vocabulary completeness.",
+    "what_surprised_you": "No scorecard was filed — the post-hole routine was skipped after PR merge.",
+    "excited_about_next": "S42 (The Caddy Interview) extends the interactive init flow with smart defaults from the analyzer pipeline."
+  },
+  "bunker_locations": [],
+  "yardage_book_updates": [
+    "src/core/metaphor.ts: saveCustomMetaphor(), METAPHOR_SCHEMA — custom metaphor persistence + validation",
+    "src/core/config.ts: saveConfig() — write config back to disk",
+    "src/cli/commands/metaphor.ts: slope metaphor list|set|show",
+    "slope init --interactive: numbered metaphor menu with custom option",
+    "MCP: metaphor module in search tool, saveCustomMetaphor + saveConfig sandbox helpers"
+  ],
+  "course_management_notes": [
+    "4 tickets, par 4, score 4 — clean par with no hazards",
+    "Backfilled retroactively — scorecard was missed during original sprint execution",
+    "Merged via PR #26 on 2026-02-28"
+  ]
+}


### PR DESCRIPTION
## Summary

- Backfill 3 missing scorecards where code was merged but post-hole routine was skipped
- **S30 (The Surveyor)**: Analyzer pipeline — types, stack/structure/git/testing analyzers, CLI command. Bundled into S31 PR, scorecard missed.
- **S37 (The Adapter Interface)**: Self-describing harness adapters — supportedEvents, hooksConfigPath(). PR #18, scorecard missed.
- **S41 (The Metaphor Studio)**: Selection UX, custom generation, CLI management. PR #26, scorecard missed.
- All scored par (4/4) with no hazards. Each marked `backfilled: true`.

## Test plan

- [x] Valid JSON verified for all 3 files
- [x] Scorecard format matches existing retros (S31 used as template)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added retrospectives for sprints 30, 37, and 41 documenting team progress, completed work, and system improvements across recent development cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->