### PR TITLE
feat(S60): compaction-proof review gates

### DIFF
--- a/src/cli/guards/compaction.ts
+++ b/src/cli/guards/compaction.ts
@@ -18,6 +18,12 @@ interface HandoffData {
     number?: number;
   };
   claims?: Array<{ target: string; scope: string; player: string }>;
+  review?: {
+    tier: string;
+    rounds_required: number;
+    rounds_completed: number;
+  };
+  sprint_phase?: string;
 }
 
 /**
@@ -79,6 +85,32 @@ export async function compactionGuard(input: HookInput, cwd: string): Promise<Gu
     }
     store.close();
   } catch { /* store not available */ }
+
+  // Gather review state (defense-in-depth: survives compaction)
+  try {
+    const reviewPath = join(cwd, '.slope', 'review-state.json');
+    if (existsSync(reviewPath)) {
+      const rs = JSON.parse(readFileSync(reviewPath, 'utf8'));
+      if (typeof rs.rounds_required === 'number' && typeof rs.rounds_completed === 'number') {
+        handoff.review = {
+          tier: rs.tier ?? 'unknown',
+          rounds_required: rs.rounds_required,
+          rounds_completed: rs.rounds_completed,
+        };
+      }
+    }
+  } catch { /* best-effort */ }
+
+  // Gather sprint phase
+  try {
+    const sprintStatePath = join(cwd, '.slope', 'sprint-state.json');
+    if (existsSync(sprintStatePath)) {
+      const ss = JSON.parse(readFileSync(sprintStatePath, 'utf8'));
+      if (ss.phase) {
+        handoff.sprint_phase = ss.phase;
+      }
+    }
+  } catch { /* best-effort */ }
 
   // Write handoff file (primary output)
   try {

--- a/src/cli/guards/review-tier.ts
+++ b/src/cli/guards/review-tier.ts
@@ -5,6 +5,7 @@ import { selectSpecialists } from '../../core/index.js';
 import type { CommonIssuesFile } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { loadSprintState, saveSprintState, createSprintState } from '../sprint-state.js';
+import { saveReviewState, type ReviewState } from '../commands/review-state.js';
 import {
   findPlanContent,
   countTickets,
@@ -13,12 +14,6 @@ import {
   extractTicketInfo,
   type PlanFile,
 } from './plan-analysis.js';
-
-interface ReviewState {
-  rounds_required: number;
-  rounds_completed: number;
-  plan_file?: string;
-}
 
 /**
  * Review-tier guard: fires PostToolUse on Write.
@@ -80,8 +75,8 @@ export async function reviewTierGuard(input: HookInput, cwd: string): Promise<Gu
   const statePath = join(cwd, '.slope', 'review-state.json');
   if (existsSync(statePath)) {
     try {
-      const state: ReviewState = JSON.parse(readFileSync(statePath, 'utf8'));
-      if (state.rounds_required >= rounds) {
+      const existing: ReviewState = JSON.parse(readFileSync(statePath, 'utf8'));
+      if (existing.rounds_required >= rounds) {
         return {};
       }
     } catch { /* malformed — proceed */ }
@@ -136,6 +131,18 @@ export async function reviewTierGuard(input: HookInput, cwd: string): Promise<Gu
       saveSprintState(cwd, state);
     }
   }
+
+  // Write review-state.json so workflow-gate can mechanically block ExitPlanMode
+  // until reviews are complete. Advisory context can be lost to compaction;
+  // disk state cannot.
+  const reviewState: ReviewState = {
+    rounds_required: rounds,
+    rounds_completed: 0,
+    plan_file: plan.path,
+    tier: tier.toLowerCase(),
+    started_at: new Date().toISOString(),
+  };
+  saveReviewState(cwd, reviewState);
 
   return { context: lines.join('\n') };
 }

--- a/src/cli/guards/workflow-gate.ts
+++ b/src/cli/guards/workflow-gate.ts
@@ -41,9 +41,16 @@ export async function workflowGateGuard(input: HookInput, cwd: string): Promise<
     return {};
   }
 
-  const planRef = state.plan_file ? ` (${state.plan_file})` : '';
+  const remaining = state.rounds_required - state.rounds_completed;
   return {
     decision: 'deny',
-    blockReason: `SLOPE workflow-gate: Review incomplete. ${state.rounds_completed}/${state.rounds_required} rounds done${planRef}. Complete remaining review rounds before exiting plan mode.`,
+    blockReason: [
+      `SLOPE workflow-gate: Review incomplete (${state.rounds_completed}/${state.rounds_required} rounds). You MUST:`,
+      `1. Ask the user to confirm or change the review tier (slope review start --tier=<tier>)`,
+      `2. Conduct each review round, then run \`slope review round\` after each`,
+      `3. Only call ExitPlanMode after all ${remaining} remaining round${remaining !== 1 ? 's are' : ' is'} complete`,
+      ``,
+      `To skip reviews: run \`slope review start --tier=skip\``,
+    ].join('\n'),
   };
 }

--- a/tests/cli/guards.test.ts
+++ b/tests/cli/guards.test.ts
@@ -532,7 +532,7 @@ describe('workflowGateGuard', () => {
     expect(result).toEqual({});
   });
 
-  it('includes plan_file in deny message', async () => {
+  it('includes actionable recovery steps in deny message', async () => {
     mkdirSync(join(tmpDir, '.slope'), { recursive: true });
     writeFileSync(join(tmpDir, '.slope/review-state.json'), JSON.stringify({
       rounds_required: 2,
@@ -542,7 +542,10 @@ describe('workflowGateGuard', () => {
 
     const result = await workflowGateGuard(makeInput(), tmpDir);
     expect(result.decision).toBe('deny');
-    expect(result.blockReason).toContain('sprint-22-plan.md');
+    expect(result.blockReason).toContain('0/2');
+    expect(result.blockReason).toContain('slope review start --tier=');
+    expect(result.blockReason).toContain('slope review round');
+    expect(result.blockReason).toContain('slope review start --tier=skip');
   });
 
   it('passes through when state has invalid types', async () => {

--- a/tests/cli/guards/review-tier.test.ts
+++ b/tests/cli/guards/review-tier.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { reviewTierGuard } from '../../../src/cli/guards/review-tier.js';
+import { workflowGateGuard } from '../../../src/cli/guards/workflow-gate.js';
 import type { HookInput } from '../../../src/core/index.js';
 
 const TMP = join(import.meta.dirname ?? __dirname, '..', '..', '..', '.test-tmp-review-tier');
@@ -286,6 +287,103 @@ describe('reviewTierGuard', () => {
     // which has no plans either — should return empty.
     const input = makeInput(join(TMP, '.claude', 'plans', 'nonexistent.md'));
     const result = await reviewTierGuard(input, TMP);
+    expect(result).toEqual({});
+  });
+
+  it('writes review-state.json when plan is detected', async () => {
+    const planPath = writePlan([
+      '# Sprint 60 Plan',
+      '### S60-1: First ticket',
+      '### S60-2: Second ticket',
+      '### S60-3: Third ticket',
+    ].join('\n'));
+    const input = makeInput(planPath);
+    await reviewTierGuard(input, TMP);
+
+    const statePath = join(TMP, '.slope', 'review-state.json');
+    expect(existsSync(statePath)).toBe(true);
+    const state = JSON.parse(readFileSync(statePath, 'utf8'));
+    expect(state.rounds_required).toBe(2); // Standard tier
+    expect(state.rounds_completed).toBe(0);
+    expect(state.tier).toBe('standard');
+    expect(state.started_at).toBeDefined();
+  });
+
+  it('does not overwrite review-state.json when re-fired with same tier', async () => {
+    const planPath = writePlan([
+      '# Sprint Plan',
+      '### T1: Task one',
+      '### T2: Task two',
+      '### T3: Task three',
+    ].join('\n'));
+    const input = makeInput(planPath);
+
+    // First fire — creates state
+    await reviewTierGuard(input, TMP);
+    const statePath = join(TMP, '.slope', 'review-state.json');
+    const firstState = JSON.parse(readFileSync(statePath, 'utf8'));
+
+    // Second fire — same plan, same tier → early return, no overwrite
+    const result = await reviewTierGuard(input, TMP);
+    expect(result).toEqual({});
+    const secondState = JSON.parse(readFileSync(statePath, 'utf8'));
+    expect(secondState.started_at).toBe(firstState.started_at);
+  });
+
+  it('does not write review-state.json for Skip tier (0 rounds)', async () => {
+    const planPath = writePlan('# Research Spike\n\nJust exploring ideas.');
+    const input = makeInput(planPath);
+    await reviewTierGuard(input, TMP);
+
+    const statePath = join(TMP, '.slope', 'review-state.json');
+    // Skip tier writes 0 rounds — file is still created but gate won't block
+    if (existsSync(statePath)) {
+      const state = JSON.parse(readFileSync(statePath, 'utf8'));
+      expect(state.rounds_required).toBe(0);
+    }
+  });
+});
+
+describe('workflowGateGuard', () => {
+  beforeEach(() => {
+    mkdirSync(TMP, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TMP)) {
+      rmSync(TMP, { recursive: true, force: true });
+    }
+  });
+
+  function makeGateInput(): HookInput {
+    return {
+      session_id: 'test-session',
+      cwd: TMP,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'ExitPlanMode',
+      tool_input: {},
+      tool_response: {},
+    };
+  }
+
+  it('allows ExitPlanMode when no review-state exists', async () => {
+    const result = await workflowGateGuard(makeGateInput(), TMP);
+    expect(result).toEqual({});
+  });
+
+  it('blocks ExitPlanMode when rounds_completed < rounds_required', async () => {
+    writeReviewState({ rounds_required: 3, rounds_completed: 0 });
+    const result = await workflowGateGuard(makeGateInput(), TMP);
+    expect(result.decision).toBe('deny');
+    expect(result.blockReason).toContain('0/3');
+    expect(result.blockReason).toContain('slope review start --tier=');
+    expect(result.blockReason).toContain('slope review round');
+    expect(result.blockReason).toContain('slope review start --tier=skip');
+  });
+
+  it('allows ExitPlanMode when rounds are complete', async () => {
+    writeReviewState({ rounds_required: 2, rounds_completed: 2 });
+    const result = await workflowGateGuard(makeGateInput(), TMP);
     expect(result).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary

- **review-tier guard** now writes `review-state.json` on plan detection, so workflow-gate mechanically blocks ExitPlanMode even if advisory context is lost to compaction
- **compaction guard** captures review state (tier, rounds) and sprint phase in handoff data for defense-in-depth
- **workflow-gate** deny message replaced with actionable recovery steps (exact commands to run)
- Added "Compaction drops pending protocol gates" to common-issues (local `.slope/` state)
- 6 new tests (review-state creation, re-fire idempotency, workflow-gate block/allow)

## Test plan

- [x] `pnpm build` — compiles clean
- [x] `pnpm typecheck` — no errors
- [x] Full test suite — 2384 passed, 0 failed
- [ ] Manual: write plan with 5 tickets → verify `review-state.json` created with `rounds_required: 3`
- [ ] Manual: try ExitPlanMode → should be blocked with actionable message
- [ ] Manual: `slope review start --tier=skip` → should unblock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced review progress tracking with rounds required and completed visibility.
  * Improved workflow guidance messages when reviews remain incomplete, with actionable next steps.
  * Added sprint phase state management for better workflow context.

* **Tests**
  * Extended test coverage for review state persistence and workflow gating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->