### PR TITLE
chore: bump version to 1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bump version 1.21.0 → 1.22.0

### Changes since 1.21.0
- feat(S61): roadmap refresh (S61-S74, 5 phases, 14 sprints)
- feat(S61): `slope doctor` command — repo health checks and auto-fix
- feat(init): add `.slope/` to `.gitignore` during `slope init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 1.22.0 released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->