### PR TITLE
chore: bump version to 1.24.0

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -1,10 +1,10 @@
 ---
-generated_at: "2026-03-05T22:02:21.239Z"
-git_sha: "6c9cf5bb6d80d8be8438ae7afa6148d334fa11ed"
+generated_at: "2026-03-10T20:20:53.050Z"
+git_sha: "3ddc378c420de57d371c10945636ea58dda70ae2"
 sprint: 60
-source_files: 180
-test_files: 136
-cli_commands: 39
+source_files: 184
+test_files: 141
+cli_commands: 41
 guards: 21
 flows: 0
 ---
@@ -18,7 +18,7 @@ Sprint Lifecycle & Operational Performance Engine — pluggable-metaphor sprint 
 <!-- AUTO-GENERATED: START packages -->
 
 ### `src/cli`
-- Source files: 86 | Test files: 53
+- Source files: 89 | Test files: 56
 - Key modules:
   - `config`
   - `hooks-config`
@@ -31,7 +31,7 @@ Sprint Lifecycle & Operational Performance Engine — pluggable-metaphor sprint 
   - `template-generator` — SLOPE Template Generator
 
 ### `src/core`
-- Source files: 82 | Test files: 73
+- Source files: 83 | Test files: 74
 - Key modules:
   - `advisor` — --- Module-private constants ---
   - `briefing` — --- Input types ---
@@ -48,10 +48,10 @@ Sprint Lifecycle & Operational Performance Engine — pluggable-metaphor sprint 
   - `embedding` — SLOPE — Embedding Types & Chunking Logic (pure — no HTTP calls)
   - `enrich` — SLOPE — Backlog Enrichment
   - `escalation` — SLOPE — Escalation Rules
-  - ... and 36 more
+  - ... and 37 more
 
 ### `src/mcp`
-- Source files: 3 | Test files: 5
+- Source files: 3 | Test files: 6
 - Key modules:
   - `registry` — ─── Core Scoring Enums ───
   - `sandbox` — SLOPE sandbox — runs agent-written JS in a node:vm context
@@ -120,6 +120,9 @@ Re-exports from `src/core/index.ts`:
 **Config:**
 - `SlopeConfig` (types)
 - `loadConfig`, `createConfig`, `saveConfig`, `resolveConfigPath`
+**Test Plan:**
+- `parseTestPlan`, `getTestPlanSummary`, `getAreasNeedingTest`
+- `TestPlanArea`, `TestPlanSection`, `TestPlanSummary`, `ParsedTestPlan` (types)
 **Loader:**
 - `loadScorecards`, `detectLatestSprint`, `resolveCurrentSprint`
 **Metaphor:**
@@ -261,6 +264,8 @@ Re-exports from `src/core/index.ts`:
 <!-- AUTO-GENERATED: START cli -->
 
 - `slope init` — Initialize .slope/ directory
+- `slope doctor` — Check repo health and auto-fix issues
+- `slope version` — Show version or bump with automated PR workflow
 - `slope session` — Manage live sessions
 - `slope claim` — Claim a ticket or area for the sprint
 - `slope release` — Release a claim by ID or target
@@ -340,6 +345,11 @@ Re-exports from `src/core/index.ts`:
 - `acquire_claim`
 - `check_conflicts`
 - `store_status`
+- `testing_session_start`
+- `testing_session_finding`
+- `testing_session_end`
+- `testing_session_status`
+- `testing_plan_status`
 <!-- AUTO-GENERATED: END mcp -->
 
 ## Test Inventory
@@ -348,14 +358,14 @@ Re-exports from `src/core/index.ts`:
 
 | Directory | Test Files | Command |
 |-----------|-----------|---------|
-| tests/cli | 53 | `pnpm test` |
-| tests/core | 73 | `pnpm test` |
-| tests/mcp | 5 | `pnpm test` |
+| tests/cli | 56 | `pnpm test` |
+| tests/core | 74 | `pnpm test` |
+| tests/mcp | 6 | `pnpm test` |
 | tests/store | 1 | `pnpm test` |
 | tests/store-pg | 2 | `pnpm test` |
 | tests/tokens | 1 | `pnpm test` |
 
-**Total test files:** 135
+**Total test files:** 140
 **Run all:** `pnpm -r test`
 **Typecheck:** `pnpm -r typecheck`
 <!-- AUTO-GENERATED: END tests -->
@@ -379,4 +389,12 @@ Top recurring patterns from common-issues:
 
 <!-- AUTO-GENERATED: START gotchas -->
 
+- **Review-discovered hazards inflate scores** (process, 5 sprints): Every hazard since S43 was found by post-hole review, never during coding. S49: all 3 hazards in autonomous sprint caught by manual code review. The review gate works but is a trailing indicator.
+- **API shape assumptions** (types, 3 sprints): Assuming property names or structure of internal APIs without reading the definition. #1 hazard source across S39-S44.
+- **Shell script boundary values** (shell, 2 sprints): Shell arithmetic comparisons (-lt vs -le, -gt vs -ge) are error-prone. S48: -lt 500 excluded exactly 500 lines. S45: multiple shell hazards.
+- **process.exit() inside try/finally skips cleanup** (control-flow, 2 sprints): process.exit(1) inside a try block with finally { db.close() } — exit runs before finally in Node.js. S46: original store.ts hazard. S49: autonomous agent repeated the same pattern in restore validation.
+- **Threshold/constant consistency across consumers** (calibration, 1 sprint): Changing a default value (e.g. minScore) in one consumer but not all consumers of the same pipeline. S48: context.ts threshold updated to 0.4 but enrich.ts still used 0.55.
+- **AI-generated code duplicates existing abstractions** (autonomous, 1 sprint): Autonomous agents (Aider/Sonnet) may reimplement logic that already exists elsewhere in the file. S49: validateSubcommand duplicated loadRoadmapFile's file-loading and error handling instead of extracting a shared helper.
+- **Compaction drops pending protocol gates** (process, 1 sprint): Advisory guard output (context messages) is lost on compaction. If the agent hasn't acted on the guidance before compaction, the obligation disappears. Post-compaction 'continue without asking' instructions compound the problem by discouraging the agent from re-checking.
+- **gh pr merge --delete-branch fails in worktrees** (git, 1 sprint): gh pr merge --delete-branch succeeds at merging but exits 1 because local branch cleanup tries to switch to main, which is held by the parent worktree. Agent sees error, retries, gets 'already merged'. Hit at least 4 times before S60.
 <!-- AUTO-GENERATED: END gotchas -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps version from 1.23.0 → 1.24.0
- Updates codebase map (184 source files, 141 test files, 41 CLI commands, 21 guards)

### Changes since 1.23.0
- `testing_plan_status` MCP tool + test-plan parser (merged from `feat/testing-plan-status`)
- `testing_session_*` MCP tools (merged in #127)

### Cleanup performed
- Deleted 8 stale local branches
- Removed stale worktree (`.claude/worktrees/demo-script`)
- Cleared 5 abandoned git stashes

## Test plan
- [x] Build passes
- [x] Typecheck passes
- [x] 2462 tests pass (140 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New test plan parsing and analysis APIs available for developers
  * Expanded testing session tooling with additional status and management functions
  * Added two new CLI commands: `slope doctor` and `slope version`

* **Chores**
  * Version bumped to 1.24.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->