### PR TITLE
fix: address review findings for docs manifest sync

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -30,8 +30,17 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Test
+        run: pnpm test
+
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Generate manifest
         run: node dist/cli/index.js docs generate --pretty --stdout > docs-manifest.json
+
+      - name: Validate manifest
+        run: node -e "const m = JSON.parse(require('fs').readFileSync('docs-manifest.json','utf8')); if (!m.commands || !m.guards || !m.mcpTools) { console.error('Invalid manifest'); process.exit(1); } console.log('Manifest valid:', m.commands.length, 'commands,', m.guards.length, 'guards,', m.mcpTools.length, 'MCP tools');"
 
       - name: Checkout slope-web
         uses: actions/checkout@v4
@@ -43,11 +52,14 @@ jobs:
       - name: Copy manifest
         run: cp docs-manifest.json slope-web/src/data/docs-manifest.json
 
+      # SLOPE_WEB_PAT requires repo scope (read/write) on srbryers/slope-web
+      # to checkout, push commits, and create pull requests.
       - name: Create PR on slope-web
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.SLOPE_WEB_PAT }}
           path: slope-web
+          base: main
           commit-message: "chore: update docs manifest from slope ${{ github.event.release.tag_name || 'manual' }}"
           title: "chore: update docs manifest from slope ${{ github.event.release.tag_name || 'manual' }}"
           body: |

--- a/src/cli/commands/docs.ts
+++ b/src/cli/commands/docs.ts
@@ -313,6 +313,7 @@ async function checkSubcommand(args: string[]): Promise<void> {
 async function syncSubcommand(args: string[]): Promise<void> {
   const cwd = process.cwd();
   const targetArg = args.find(a => a.startsWith('--target='));
+  const destArg = args.find(a => a.startsWith('--dest='));
 
   // Default: look for adjacent slope-web repo
   const targetDir = targetArg
@@ -325,17 +326,21 @@ async function syncSubcommand(args: string[]): Promise<void> {
     process.exit(1);
   }
 
+  // Destination subpath within target (default: src/data/docs-manifest.json)
+  const destSubpath = destArg
+    ? destArg.slice('--dest='.length)
+    : 'src/data/docs-manifest.json';
+
   // Generate manifest
   const manifest = buildManifest(cwd, false);
   const json = JSON.stringify(manifest, null, 2);
 
-  // Write to target's src/data/docs-manifest.json
-  const dataDir = join(targetDir, 'src', 'data');
-  if (!existsSync(dataDir)) {
-    mkdirSync(dataDir, { recursive: true });
+  // Write to target at the configured destination subpath
+  const destPath = join(targetDir, destSubpath);
+  const destDir = dirname(destPath);
+  if (!existsSync(destDir)) {
+    mkdirSync(destDir, { recursive: true });
   }
-
-  const destPath = join(dataDir, 'docs-manifest.json');
   writeFileSync(destPath, json + '\n', 'utf8');
 
   console.log(`Manifest synced to ${destPath}`);
@@ -378,7 +383,7 @@ Usage:
   slope docs generate [--output=path] [--pretty] [--incremental] [--stdout]
   slope docs changelog [--since=version] [--format=markdown|json]
   slope docs check [--manifest=path]
-  slope docs sync [--target=path]
+  slope docs sync [--target=path] [--dest=subpath]
 
 Subcommands:
   generate      Build manifest JSON from registries + git history
@@ -395,6 +400,7 @@ Options:
   --format=FORMAT     Changelog output format: markdown (default) or json
   --manifest=path     Path to saved manifest for check (default: .slope/docs.json)
   --target=path       Target directory for sync (default: ../slope-web)
+  --dest=subpath      Destination subpath within target (default: src/data/docs-manifest.json)
 `);
       if (sub) process.exit(1);
   }

--- a/src/core/docs.ts
+++ b/src/core/docs.ts
@@ -6,7 +6,6 @@ import type { CliCommandMeta } from '../cli/registry.js';
 import type { GuardDefinition } from './guard.js';
 import type { MetaphorDefinition } from './metaphor.js';
 import type { RoleDefinition } from './roles.js';
-import type { McpToolMeta } from '../mcp/registry.js';
 import { GUARD_DEFINITIONS } from './guard.js';
 import { listMetaphors } from './metaphor.js';
 import { listRoles } from './roles.js';
@@ -16,6 +15,22 @@ import {
   SCORE_LABELS,
   HAZARD_SEVERITY_PENALTIES,
 } from './constants.js';
+
+// ── MCP Tool Metadata (for documentation manifest) ────────────
+
+export interface McpToolParam {
+  name: string;
+  type: string;
+  desc: string;
+  required?: boolean;
+}
+
+export interface McpToolMeta {
+  name: string;
+  desc: string;
+  params: McpToolParam[];
+  requiresStore: boolean;
+}
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -39,6 +54,8 @@ export interface ChangelogSection {
   reason?: string;
 }
 
+export type ManifestSection = 'commands' | 'guards' | 'mcpTools' | 'metaphors' | 'roles' | 'constants' | 'changelog';
+
 export interface DocsManifestInput {
   version: string;
   gitSha: string;
@@ -51,7 +68,7 @@ export interface DocsManifest {
   version: string;
   generatedAt: string;
   gitSha: string;
-  checksums: Record<string, string>;
+  checksums: Record<ManifestSection, string>;
 
   commands: readonly CliCommandMeta[];
   guards: GuardDefinition[];
@@ -106,7 +123,7 @@ export function buildDocsManifest(input: DocsManifestInput): DocsManifest {
     hazardPenalties: HAZARD_SEVERITY_PENALTIES,
   };
 
-  const sections: Record<string, unknown> = {
+  const sections: Record<ManifestSection, unknown> = {
     commands: input.commands,
     guards,
     mcpTools,
@@ -116,9 +133,9 @@ export function buildDocsManifest(input: DocsManifestInput): DocsManifest {
     changelog: input.changelog,
   };
 
-  const checksums: Record<string, string> = {};
-  for (const [key, value] of Object.entries(sections)) {
-    checksums[key] = computeSectionChecksum(value);
+  const checksums = {} as Record<ManifestSection, string>;
+  for (const key of Object.keys(sections) as ManifestSection[]) {
+    checksums[key] = computeSectionChecksum(sections[key]);
   }
 
   return {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -670,9 +670,12 @@ export {
 export type {
   DocsManifest,
   DocsManifestInput,
+  ManifestSection,
   ChangelogSection,
   ChangelogEntry,
   ChangelogChange,
+  McpToolParam,
+  McpToolMeta,
 } from './docs.js';
 
 // Built-in metaphors (auto-registers on import)

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -1028,19 +1028,8 @@ interface VisionDocument { purpose: string; audience?: string; priorities: strin
 
 // ── MCP Tool Metadata (for documentation manifest) ────────────────
 
-export interface McpToolParam {
-  name: string;
-  type: string;
-  desc: string;
-  required?: boolean;
-}
-
-export interface McpToolMeta {
-  name: string;
-  desc: string;
-  params: McpToolParam[];
-  requiresStore: boolean;
-}
+import type { McpToolParam, McpToolMeta } from '../core/docs.js';
+export type { McpToolParam, McpToolMeta };
 
 export const MCP_TOOL_REGISTRY: readonly McpToolMeta[] = [
   {
@@ -1129,6 +1118,6 @@ export const MCP_TOOL_REGISTRY: readonly McpToolMeta[] = [
     name: 'testing_plan_status',
     desc: 'Show test plan coverage summary: tested, untested, stale, and issue counts per section',
     params: [],
-    requiresStore: true,
+    requiresStore: false,
   },
 ];

--- a/tests/mcp/registry.test.ts
+++ b/tests/mcp/registry.test.ts
@@ -78,12 +78,19 @@ describe('MCP_TOOL_REGISTRY', () => {
 
   it('store tools require store', () => {
     const storeTools = MCP_TOOL_REGISTRY.filter(t =>
-      t.name.startsWith('testing_') || ['session_status', 'acquire_claim', 'check_conflicts', 'store_status'].includes(t.name)
+      (t.name.startsWith('testing_') && t.name !== 'testing_plan_status') ||
+      ['session_status', 'acquire_claim', 'check_conflicts', 'store_status'].includes(t.name)
     );
     expect(storeTools.length).toBeGreaterThan(0);
     for (const tool of storeTools) {
       expect(tool.requiresStore).toBe(true);
     }
+  });
+
+  it('testing_plan_status does not require store', () => {
+    const tool = MCP_TOOL_REGISTRY.find(t => t.name === 'testing_plan_status');
+    expect(tool).toBeDefined();
+    expect(tool!.requiresStore).toBe(false);
   });
 
   it('params have name, type, and desc', () => {


### PR DESCRIPTION
## Summary
Review fixes for PR #129:

- **H1**: Move McpToolMeta/McpToolParam types from mcp to core (fix inverted dependency)
- **H2**: Add test/typecheck gates, manifest validation step, `base: main`, PAT scope comment to sync-docs workflow
- **H3**: Fix `testing_plan_status` requiresStore (false — reads config/filesystem only)
- **M3**: Make sync destination subpath configurable via `--dest` flag
- **M4**: Constrain checksums type to `ManifestSection` union

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 2454 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)