### PR TITLE
feat(s63): help, quickstart, and guard docs commands

### DIFF
--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -21,6 +21,7 @@ import { branchBeforeCommitGuard } from '../guards/branch-before-commit.js';
 import { worktreeCheckGuard } from '../guards/worktree-check.js';
 import { sprintCompletionGuard } from '../guards/sprint-completion.js';
 import { worktreeMergeGuard } from '../guards/worktree-merge.js';
+import { formatGuardDocs } from '../guards/docs.js';
 import { recordBaseline } from '../guards/git-utils.js';
 import { execSync } from 'node:child_process';
 
@@ -333,6 +334,10 @@ export async function guardManageCommand(args: string[]): Promise<void> {
       console.log(`  PreCompact:        ${hasPreCompact ? 'yes' : 'no'}`);
 
       console.log('\nLegend: [+] active  [-] disabled  [~] unsupported by harness\n');
+      break;
+    }
+    case 'docs': {
+      formatGuardDocs(name);
       break;
     }
     case 'enable':

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -1,0 +1,112 @@
+import { CLI_COMMAND_REGISTRY, CLI_INTERNAL_MODULES } from '../registry.js';
+import type { CliCommandMeta } from '../registry.js';
+
+/**
+ * slope help [command] — Show detailed per-command usage from the registry.
+ */
+export async function helpCommand(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(`
+slope help — Command reference
+
+Usage:
+  slope help              Show all commands grouped by category
+  slope help <command>    Show detailed usage for a command
+`);
+    return;
+  }
+
+  const commandName = args[0];
+
+  if (!commandName) {
+    printCategoryList();
+    return;
+  }
+
+  const meta = CLI_COMMAND_REGISTRY.find(c => c.cmd === commandName);
+  if (!meta) {
+    suggestClosest(commandName);
+    return;
+  }
+
+  printCommandDetail(meta);
+}
+
+function printCategoryList(): void {
+  const categories: Record<string, CliCommandMeta[]> = {};
+  for (const cmd of CLI_COMMAND_REGISTRY) {
+    if ((CLI_INTERNAL_MODULES as readonly string[]).includes(cmd.cmd)) continue;
+    const cat = cmd.category;
+    if (!categories[cat]) categories[cat] = [];
+    categories[cat].push(cmd);
+  }
+
+  console.log('\nSLOPE CLI — Command Reference\n');
+
+  const categoryOrder = ['lifecycle', 'scoring', 'analysis', 'planning', 'tooling'] as const;
+  const categoryLabels: Record<string, string> = {
+    lifecycle: 'Lifecycle',
+    scoring: 'Scoring',
+    analysis: 'Analysis',
+    planning: 'Planning',
+    tooling: 'Tooling',
+  };
+
+  for (const cat of categoryOrder) {
+    const cmds = categories[cat];
+    if (!cmds || cmds.length === 0) continue;
+
+    console.log(`  ${categoryLabels[cat]}:`);
+    for (const cmd of cmds) {
+      const name = cmd.cmd === 'index-cmd' ? 'index' : cmd.cmd;
+      console.log(`    ${name.padEnd(18)} ${cmd.desc}`);
+    }
+    console.log('');
+  }
+
+  console.log('Run `slope help <command>` for detailed usage.\n');
+}
+
+function printCommandDetail(meta: CliCommandMeta): void {
+  const displayName = meta.cmd === 'index-cmd' ? 'index' : meta.cmd;
+  console.log(`\nslope ${displayName} — ${meta.desc}\n`);
+  console.log(`  Category: ${meta.category}\n`);
+
+  if (meta.subcommands && meta.subcommands.length > 0) {
+    console.log('  Subcommands:\n');
+    for (const sub of meta.subcommands) {
+      console.log(`    slope ${displayName} ${sub.name}`);
+      console.log(`      ${sub.desc}`);
+      if (sub.flags && sub.flags.length > 0) {
+        for (const f of sub.flags) {
+          console.log(`      ${f.flag.padEnd(24)} ${f.desc}`);
+        }
+      }
+      console.log('');
+    }
+  }
+
+  if (meta.flags && meta.flags.length > 0) {
+    console.log('  Flags:\n');
+    for (const f of meta.flags) {
+      console.log(`    ${f.flag.padEnd(26)} ${f.desc}`);
+    }
+    console.log('');
+  }
+}
+
+function suggestClosest(input: string): void {
+  const names = CLI_COMMAND_REGISTRY
+    .filter(c => !(CLI_INTERNAL_MODULES as readonly string[]).includes(c.cmd))
+    .map(c => c.cmd === 'index-cmd' ? 'index' : c.cmd);
+
+  // Simple substring match for suggestions
+  const matches = names.filter(n => n.includes(input) || input.includes(n));
+
+  console.error(`Unknown command: "${input}"`);
+  if (matches.length > 0) {
+    console.error(`Did you mean: ${matches.join(', ')}?`);
+  }
+  console.error(`\nRun \`slope help\` to see all commands.`);
+  process.exit(1);
+}

--- a/src/cli/commands/quickstart.ts
+++ b/src/cli/commands/quickstart.ts
@@ -1,0 +1,138 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import * as p from '@clack/prompts';
+
+/**
+ * slope quickstart — Interactive tutorial for new users.
+ * Walks through the core SLOPE workflow, checking current state along the way.
+ */
+export async function quickstartCommand(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(`
+slope quickstart — Interactive SLOPE tutorial
+
+Usage:
+  slope quickstart    Walk through the core SLOPE workflow step by step
+
+Non-destructive — shows commands to run, does not modify your project.
+`);
+    return;
+  }
+
+  const cwd = process.cwd();
+
+  p.intro('SLOPE Quickstart');
+
+  console.log(`
+  SLOPE (Sprint Lifecycle & Operational Performance Engine) helps you
+  track, score, and improve your sprint execution over time.
+
+  This guide walks through the core workflow. No files will be modified.
+`);
+
+  // ── Step 0: Check prerequisites ──────────────────────────────────
+
+  const slopeDir = join(cwd, '.slope');
+  const hasSlope = existsSync(join(slopeDir, 'config.json'));
+  const retrosDir = join(cwd, 'docs', 'retros');
+  const hasScorecards = existsSync(retrosDir) && readdirSync(retrosDir).some(f => f.endsWith('.json'));
+
+  if (!hasSlope) {
+    p.note(
+      'Your project has not been initialized with SLOPE yet.\n\n' +
+      'Run one of:\n' +
+      '  slope init                       Basic setup\n' +
+      '  slope init --interactive         Guided wizard\n' +
+      '  slope init --claude-code         Setup with Claude Code hooks\n' +
+      '  slope init --cursor              Setup with Cursor IDE rules',
+      'Step 0 — Initialize',
+    );
+
+    const shouldContinue = await p.confirm({
+      message: 'Continue the tutorial anyway?',
+      initialValue: true,
+    });
+
+    if (p.isCancel(shouldContinue) || !shouldContinue) {
+      p.outro('Run `slope init` first, then `slope quickstart` again.');
+      return;
+    }
+  } else {
+    p.log.success('Project initialized — .slope/config.json found');
+  }
+
+  // ── Step 1: Pre-Sprint Briefing ──────────────────────────────────
+
+  p.note(
+    'Before starting a sprint, get a briefing on your current state:\n\n' +
+    '  slope briefing\n\n' +
+    'This shows:\n' +
+    '  - Handicap snapshot (trending performance)\n' +
+    '  - Hazard index (known gotchas in your code areas)\n' +
+    '  - Session continuity (active claims, unfinished work)\n\n' +
+    'Filter by area:  slope briefing --categories=testing,api\n' +
+    'Filter by keyword: slope briefing --keywords=migration',
+    'Step 1 — Pre-Sprint Briefing',
+  );
+
+  // ── Step 2: Sprint Planning ──────────────────────────────────────
+
+  p.note(
+    'Plan each ticket before writing code:\n\n' +
+    '  slope plan --complexity=medium\n\n' +
+    'This recommends:\n' +
+    '  - Club selection (approach complexity: putter → driver)\n' +
+    '  - Known hazards for the code areas you\'ll touch\n' +
+    '  - Training tips based on your miss patterns\n\n' +
+    'Claim tickets to avoid conflicts in multi-agent setups:\n' +
+    '  slope claim --target=S1-1 --sprint=1',
+    'Step 2 — Planning & Claims',
+  );
+
+  // ── Step 3: Scoring ──────────────────────────────────────────────
+
+  p.note(
+    'After completing sprint work, score and validate:\n\n' +
+    '  slope validate docs/retros/sprint-1.json\n' +
+    '  slope review docs/retros/sprint-1.json\n\n' +
+    'Or auto-generate a scorecard from git history:\n' +
+    '  slope auto-card --sprint=1\n\n' +
+    'View your performance trend:\n' +
+    '  slope card',
+    'Step 3 — Scoring & Review',
+  );
+
+  // ── Step 4: Guards & Hooks ───────────────────────────────────────
+
+  p.note(
+    'Guards are hooks that guide your agent during coding:\n\n' +
+    '  slope hook add --level=full     Install all guards\n' +
+    '  slope guard list                See available guards\n' +
+    '  slope guard status              Check installation state\n' +
+    '  slope guard docs                Detailed guard documentation\n\n' +
+    'Guards can:\n' +
+    '  - Nudge you to commit/push regularly\n' +
+    '  - Warn about known hazards in files you\'re editing\n' +
+    '  - Block commits on main (branch discipline)\n' +
+    '  - Detect scope drift outside your claimed tickets',
+    'Step 4 — Guards & Hooks',
+  );
+
+  // ── Next Steps ───────────────────────────────────────────────────
+
+  const nextSteps: string[] = [];
+
+  if (!hasSlope) {
+    nextSteps.push('slope init --interactive     Initialize SLOPE for this project');
+  }
+  if (!hasScorecards) {
+    nextSteps.push('slope auto-card --sprint=1   Generate your first scorecard from git');
+  }
+  nextSteps.push('slope briefing               Get a pre-sprint briefing');
+  nextSteps.push('slope help                   Browse all commands');
+  nextSteps.push('slope doctor                 Check repo health');
+
+  p.note(nextSteps.join('\n'), 'Next Steps');
+
+  p.outro('Ready to score your sprints!');
+}

--- a/src/cli/guards/docs.ts
+++ b/src/cli/guards/docs.ts
@@ -1,0 +1,205 @@
+// Guard Documentation — extended per-guard documentation for `slope guard docs`
+
+export interface GuardDoc {
+  /** What problem this guard solves */
+  purpose: string;
+  /** Hook event + matcher (what tools/actions fire it) */
+  triggers: string;
+  /** What it does when fired (block vs advisory vs context injection) */
+  behavior: string;
+  /** How to enable/disable, relevant config.json fields */
+  configuration: string;
+  /** Which --level installs it */
+  level: 'scoring' | 'full';
+}
+
+export const GUARD_DOCS: Record<string, GuardDoc> = {
+  explore: {
+    purpose: 'Prevents unnecessary deep codebase exploration when a codebase map (CODEBASE.md) exists. Reminds the agent to check the map before reading files or searching.',
+    triggers: 'PreToolUse on Read, Glob, Grep. Fires when the agent tries to read or search files.',
+    behavior: 'Advisory — injects a context reminder suggesting the agent read CODEBASE.md or use `search({ module: \'map\' })` before exploring. Does not block.',
+    configuration: 'guidance.indexPaths in config.json controls which index files to check for. Disable: add "explore" to guidance.disabled.',
+    level: 'full',
+  },
+  hazard: {
+    purpose: 'Warns about known issues and recurring patterns in file areas being edited. Prevents the agent from repeating past mistakes.',
+    triggers: 'PreToolUse on Edit, Write. Fires when the agent is about to modify a file.',
+    behavior: 'Advisory — injects context with relevant hazards from common-issues.json and recent scorecard hazards for the file area being edited.',
+    configuration: 'guidance.hazardRecency (default: 5) controls how many sprints back to look for hazards. Disable: add "hazard" to guidance.disabled.',
+    level: 'full',
+  },
+  'commit-nudge': {
+    purpose: 'Nudges the agent to commit after prolonged editing. Prevents lost work from uncommitted changes.',
+    triggers: 'PostToolUse on Edit, Write. Fires after a file modification completes.',
+    behavior: 'Advisory — injects a commit reminder when the time since last commit exceeds the configured interval. Does not block.',
+    configuration: 'guidance.commitInterval (default: 15 minutes) controls the nudge threshold. Disable: add "commit-nudge" to guidance.disabled.',
+    level: 'full',
+  },
+  'scope-drift': {
+    purpose: 'Warns when the agent edits files outside the claimed ticket scope. Keeps work focused and prevents unintended changes.',
+    triggers: 'PreToolUse on Edit, Write. Fires when a file modification is attempted.',
+    behavior: 'Advisory — if the file being edited is outside the current ticket\'s claimed scope (from `slope claim`), injects a warning. Does not block.',
+    configuration: 'guidance.scopeDrift (default: true) enables/disables. Disable: add "scope-drift" to guidance.disabled.',
+    level: 'full',
+  },
+  compaction: {
+    purpose: 'Extracts session events before Claude Code compacts context. Preserves sprint data that would otherwise be lost during context compression.',
+    triggers: 'PreCompact. Fires before Claude Code compresses the conversation context.',
+    behavior: 'Side-effect — writes a handoff file with session events to the handoffs directory. No agent-visible output.',
+    configuration: 'guidance.handoffsDir (default: .slope/handoffs) controls where handoff files are written. Disable: add "compaction" to guidance.disabled.',
+    level: 'full',
+  },
+  'stop-check': {
+    purpose: 'Checks for uncommitted or unpushed work before session end. Prevents data loss from abandoned changes.',
+    triggers: 'Stop. Fires when the agent session is ending.',
+    behavior: 'Block — if there are uncommitted changes or unpushed commits, blocks the session end and reminds the agent to commit/push first.',
+    configuration: 'Disable: add "stop-check" to guidance.disabled.',
+    level: 'full',
+  },
+  'subagent-gate': {
+    purpose: 'Controls subagent resource usage by forcing haiku model and capping max_turns on Explore/Plan subagents. Prevents expensive long-running subagent calls.',
+    triggers: 'PreToolUse on Task (Agent tool). Fires when the agent launches a subagent.',
+    behavior: 'Modifies input — overrides model to haiku and caps max_turns for Explore and Plan subagent types.',
+    configuration: 'guidance.subagentExploreTurns (default: 10), guidance.subagentPlanTurns (default: 15), guidance.subagentAllowModels (default: [\'haiku\']). Disable: add "subagent-gate" to guidance.disabled.',
+    level: 'full',
+  },
+  'push-nudge': {
+    purpose: 'Nudges the agent to push after accumulating too many unpushed commits. Ensures recovery points exist on the remote.',
+    triggers: 'PostToolUse on Bash. Fires after a shell command completes (checks if it was a git commit).',
+    behavior: 'Advisory — when unpushed commit count exceeds the threshold, injects a push reminder. Does not block.',
+    configuration: 'guidance.pushInterval (default: 30 minutes), guidance.pushCommitThreshold (default: 5 commits). Disable: add "push-nudge" to guidance.disabled.',
+    level: 'full',
+  },
+  'workflow-gate': {
+    purpose: 'Blocks exit from plan mode until review rounds are complete. Enforces the plan review workflow.',
+    triggers: 'PreToolUse on ExitPlanMode. Fires when the agent tries to leave plan mode.',
+    behavior: 'Block — denies ExitPlanMode if the configured review rounds have not been completed (tracked via `slope review` state).',
+    configuration: 'Review tier and rounds are set via `slope review start --tier=<tier>`. Disable: add "workflow-gate" to guidance.disabled.',
+    level: 'full',
+  },
+  'review-tier': {
+    purpose: 'Suggests starting a plan review after writing a plan file. Prompts the agent to follow the review workflow.',
+    triggers: 'PostToolUse on Edit, Write. Fires after a file modification (checks if the file looks like a plan).',
+    behavior: 'Advisory — if the written file appears to be a sprint plan, injects a suggestion to run `slope review start`. Does not block.',
+    configuration: 'Disable: add "review-tier" to guidance.disabled.',
+    level: 'full',
+  },
+  'version-check': {
+    purpose: 'Blocks pushes to main when package versions have not been bumped. Prevents releasing unbumped code.',
+    triggers: 'PreToolUse on Bash. Fires when a shell command is about to run (checks for git push to main).',
+    behavior: 'Block — denies the Bash command if it\'s a push to main/master and package.json versions haven\'t been bumped since the last release.',
+    configuration: 'Disable: add "version-check" to guidance.disabled.',
+    level: 'full',
+  },
+  'stale-flows': {
+    purpose: 'Warns when editing files that belong to a stale flow definition. Keeps flow definitions up to date.',
+    triggers: 'PreToolUse on Edit, Write. Fires when editing a file listed in a flow definition.',
+    behavior: 'Advisory — if the file being edited is part of a flow whose definition is stale, injects a warning to update the flow.',
+    configuration: 'Flow definitions are in .slope/flows.json. Disable: add "stale-flows" to guidance.disabled.',
+    level: 'full',
+  },
+  'next-action': {
+    purpose: 'Suggests next actions before session end. Helps the agent wrap up cleanly with a clear handoff.',
+    triggers: 'Stop. Fires when the agent session is ending.',
+    behavior: 'Advisory — injects suggestions for what to do next based on current session state (e.g., create scorecard, push, PR).',
+    configuration: 'Disable: add "next-action" to guidance.disabled.',
+    level: 'full',
+  },
+  'pr-review': {
+    purpose: 'Prompts for the review workflow after PR creation. Ensures sprint review artifacts are created.',
+    triggers: 'PostToolUse on Bash. Fires after a shell command completes (checks for `gh pr create`).',
+    behavior: 'Advisory — if the command created a PR, injects a reminder to run `slope review recommend` and create review artifacts.',
+    configuration: 'Disable: add "pr-review" to guidance.disabled.',
+    level: 'full',
+  },
+  transcript: {
+    purpose: 'Records tool call metadata to the session transcript. Enables post-session analysis and auto-card generation.',
+    triggers: 'PostToolUse on all tools. Fires after every tool call.',
+    behavior: 'Side-effect — appends tool call data to the session transcript store. No agent-visible output.',
+    configuration: 'Disable: add "transcript" to guidance.disabled.',
+    level: 'full',
+  },
+  'branch-before-commit': {
+    purpose: 'Blocks git commit on main/master. Enforces branch discipline by requiring a feature branch first.',
+    triggers: 'PreToolUse on Bash. Fires when a shell command is about to run (checks for git commit on a protected branch).',
+    behavior: 'Block — denies the Bash command if it\'s a git commit on main/master. Suggests creating a feature branch first.',
+    configuration: 'guidance.protectedBranches (default: [\'main\', \'master\']), guidance.allowMainCommitPatterns for exceptions. Disable: add "branch-before-commit" to guidance.disabled.',
+    level: 'full',
+  },
+  'worktree-check': {
+    purpose: 'Blocks concurrent sessions from operating in the same directory without worktree isolation. Prevents file conflicts between agents.',
+    triggers: 'PreToolUse on Read, Glob, Grep, Edit, Write, Bash. Fires on most tool calls.',
+    behavior: 'Block — if another session is active in the same directory, denies the tool call and requires `EnterWorktree` for isolation.',
+    configuration: 'Disable: add "worktree-check" to guidance.disabled.',
+    level: 'full',
+  },
+  'sprint-completion': {
+    purpose: 'Enforces sprint lifecycle gates. Blocks PR creation and session end when required gates (build, test, scorecard) are incomplete.',
+    triggers: 'PreToolUse on Bash (blocks `gh pr create`), PostToolUse on Bash (auto-detects test pass), Stop (blocks session end).',
+    behavior: 'Block + side-effect — blocks PR/session-end when gates are incomplete. Auto-marks the test gate when a test run passes.',
+    configuration: 'Sprint gates are managed via `slope sprint start/gate/status`. Disable: add "sprint-completion" to guidance.disabled.',
+    level: 'full',
+  },
+  'worktree-merge': {
+    purpose: 'Blocks `gh pr merge --delete-branch` in worktrees. Deleting the branch while in a worktree causes a false failure state.',
+    triggers: 'PreToolUse on Bash. Fires when a shell command is about to run (checks for gh pr merge with --delete-branch).',
+    behavior: 'Block — denies the command and suggests merging without --delete-branch, then cleaning up the worktree separately.',
+    configuration: 'Disable: add "worktree-merge" to guidance.disabled.',
+    level: 'full',
+  },
+};
+
+/**
+ * Format guard documentation for console output.
+ * @param name — specific guard name, or undefined for all guards
+ */
+export function formatGuardDocs(name?: string): void {
+  if (name) {
+    const doc = GUARD_DOCS[name];
+    if (!doc) {
+      console.error(`Unknown guard: "${name}"`);
+      console.error(`Available guards: ${Object.keys(GUARD_DOCS).join(', ')}`);
+      process.exit(1);
+    }
+    printGuardDoc(name, doc);
+    return;
+  }
+
+  // Group by hook event for overview
+  const byEvent: Record<string, string[]> = {};
+  for (const [guardName, doc] of Object.entries(GUARD_DOCS)) {
+    // Extract primary event from triggers string
+    const eventMatch = doc.triggers.match(/^(\w+)/);
+    const event = eventMatch?.[1] ?? 'Other';
+    if (!byEvent[event]) byEvent[event] = [];
+    byEvent[event].push(guardName);
+  }
+
+  console.log('\nSLOPE Guard Documentation\n');
+
+  const eventOrder = ['PreToolUse', 'PostToolUse', 'Stop', 'PreCompact'];
+  for (const event of eventOrder) {
+    const guards = byEvent[event];
+    if (!guards || guards.length === 0) continue;
+
+    console.log(`  ${event}:`);
+    for (const g of guards) {
+      const doc = GUARD_DOCS[g];
+      const levelTag = doc.level === 'scoring' ? '[scoring]' : '[full]   ';
+      console.log(`    ${levelTag} ${g.padEnd(22)} ${doc.purpose.split('.')[0]}`);
+    }
+    console.log('');
+  }
+
+  console.log('Run `slope guard docs <name>` for detailed documentation.\n');
+}
+
+function printGuardDoc(name: string, doc: GuardDoc): void {
+  console.log(`\n${name}\n${'='.repeat(name.length)}\n`);
+  console.log(`  Purpose:        ${doc.purpose}`);
+  console.log(`  Triggers:       ${doc.triggers}`);
+  console.log(`  Behavior:       ${doc.behavior}`);
+  console.log(`  Configuration:  ${doc.configuration}`);
+  console.log(`  Install level:  ${doc.level}`);
+  console.log('');
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -58,6 +58,8 @@ import { loopCommand } from './commands/loop.js';
 import { sprintCommand } from './commands/sprint.js';
 import { doctorCommand } from './commands/doctor.js';
 import { versionCommand } from './commands/version.js';
+import { helpCommand } from './commands/help.js';
+import { quickstartCommand } from './commands/quickstart.js';
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -216,7 +218,7 @@ switch (subcommand) {
   case 'guard': {
     const guardArgs = process.argv.slice(3);
     const guardSub = guardArgs[0];
-    if (guardSub === 'list' || guardSub === 'status' || guardSub === 'enable' || guardSub === 'disable') {
+    if (guardSub === 'list' || guardSub === 'status' || guardSub === 'enable' || guardSub === 'disable' || guardSub === 'docs') {
       guardManageCommand(guardArgs).catch(err => {
         console.error('Error:', err.message);
         process.exit(1);
@@ -339,6 +341,18 @@ switch (subcommand) {
     break;
   case 'version':
     versionCommand(process.argv.slice(3)).catch(err => {
+      console.error('Error:', err.message);
+      process.exit(1);
+    });
+    break;
+  case 'help':
+    helpCommand(process.argv.slice(3)).catch(err => {
+      console.error('Error:', err.message);
+      process.exit(1);
+    });
+    break;
+  case 'quickstart':
+    quickstartCommand(process.argv.slice(3)).catch(err => {
       console.error('Error:', err.message);
       process.exit(1);
     });

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -42,6 +42,13 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
+    cmd: 'help', desc: 'Show detailed per-command usage', category: 'lifecycle',
+    flags: [{ flag: '<command>', desc: 'Command name to show details for' }],
+  },
+  {
+    cmd: 'quickstart', desc: 'Interactive tutorial for new users', category: 'lifecycle',
+  },
+  {
     cmd: 'doctor', desc: 'Check repo health and auto-fix issues', category: 'lifecycle',
     flags: [{ flag: '--fix', desc: 'Auto-fix detected issues' }],
   },
@@ -200,6 +207,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
       { flag: '--complexity=<level>', desc: 'Complexity (trivial, small, medium, large)' },
       { flag: '--slope-factors=<list>', desc: 'Comma-separated slope factors' },
       { flag: '--areas=<list>', desc: 'Comma-separated code areas' },
+      { flag: '--sprint=<N>', desc: 'Sprint number for context' },
     ],
   },
   {
@@ -258,6 +266,9 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
       { name: '<name>', desc: 'Run a guard (reads hook JSON from stdin)' },
       { name: 'list', desc: 'Show all available guards' },
       { name: 'status', desc: 'Show per-harness guard installation state' },
+      { name: 'docs', desc: 'Show detailed guard documentation', flags: [
+        { flag: '<name>', desc: 'Guard name (optional — shows all if omitted)' },
+      ]},
       { name: 'enable', desc: 'Enable a disabled guard', flags: [
         { flag: '<name>', desc: 'Guard name to enable' },
       ]},


### PR DESCRIPTION
## Summary

- **S63-1: `slope help [command]`** — category-grouped command list with per-command detail (subcommands, flags) from CLI_COMMAND_REGISTRY metadata. Closest-match suggestion for unknown commands.
- **S63-2: `slope quickstart`** — interactive tutorial using @clack/prompts that walks new users through briefing, planning, scoring, and guards. Detects current project state and adjusts guidance.
- **S63-3: `slope guard docs [name]`** — detailed per-guard documentation (purpose, triggers, behavior, configuration, install level) for all 18 guards. Overview grouped by hook event or single-guard detail view.

Also adds `--sprint=<N>` flag to `plan` command registry entry.

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 2571 tests pass (144 files)
- [ ] `slope help` — shows category-grouped command list
- [ ] `slope help card` — shows card command details with flags
- [ ] `slope help review` — shows subcommands + flags
- [ ] `slope quickstart` — interactive walkthrough runs
- [ ] `slope guard docs` — shows all guards grouped by event
- [ ] `slope guard docs explore` — shows detailed explore guard docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New `help` command displays detailed command usage with suggestions for unknown commands
  * New interactive `quickstart` command guides users through setup and configuration
  * New `guard docs` subcommand displays guard documentation filtered by event type
  * Added `--sprint=<N>` flag to the plan command for sprint context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->