### PR TITLE
fix(ci): fix sync-docs workflow expression syntax

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -63,7 +63,7 @@ jobs:
           commit-message: "chore: update docs manifest from slope ${{ github.event.release.tag_name || 'manual' }}"
           title: "chore: update docs manifest from slope ${{ github.event.release.tag_name || 'manual' }}"
           body: |
-            Automated manifest sync from [slope release](${{ github.event.release.html_url || github.server_url + '/' + github.repository }}).
+            Automated manifest sync from [slope release](${{ github.event.release.html_url || format('{0}/{1}', github.server_url, github.repository) }}).
 
             Updates `src/data/docs-manifest.json` with the latest CLI commands, guards, MCP tools, metaphors, and changelog.
 


### PR DESCRIPTION
## Summary

- Fix invalid `+` string concatenation in GitHub Actions expression on line 65 of sync-docs.yml
- Replace with `format()` function which is the correct syntax
- This has been broken since v1.24.0 — docs manifest on slope-web is stale

## Test plan

- [x] `gh workflow run sync-docs.yml` no longer returns HTTP 422 parse error
- [ ] After merge, trigger sync-docs manually to update slope-web manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)