### PR TITLE
fix(guards): update subagent-gate for Agent tool

### DIFF
--- a/src/cli/guards/subagent-gate.ts
+++ b/src/cli/guards/subagent-gate.ts
@@ -39,14 +39,13 @@ function buildOrientation(cwd: string): string {
 }
 
 /**
- * Subagent gate guard: fires PreToolUse on Task.
- * Forces haiku model and caps max_turns on Explore/Plan subagents.
+ * Subagent gate guard: fires PreToolUse on Agent.
+ * Enforces model selection on Explore/Plan subagents (Agent tool has no max_turns).
  */
 export async function subagentGateGuard(input: HookInput, _cwd: string): Promise<GuardResult> {
   const toolInput = input.tool_input ?? {};
   const subagentType = toolInput.subagent_type as string | undefined;
   const model = toolInput.model as string | undefined;
-  const maxTurns = toolInput.max_turns as number | undefined;
   const resume = toolInput.resume as string | undefined;
 
   // Exempt resumed agents — they inherit prior settings
@@ -58,25 +57,13 @@ export async function subagentGateGuard(input: HookInput, _cwd: string): Promise
   const config = loadConfig();
   const guidance = config.guidance ?? {};
   const allowedModels = guidance.subagentAllowModels ?? ['haiku'];
-  const turnsLimit = subagentType === 'Explore'
-    ? (guidance.subagentExploreTurns ?? 10)
-    : (guidance.subagentPlanTurns ?? 15);
-
-  const violations: string[] = [];
 
   if (model && !allowedModels.includes(model)) {
-    violations.push(`model "${model}" not in allowed list [${allowedModels.join(', ')}]`);
+    return {
+      decision: 'deny',
+      blockReason: `SLOPE subagent-gate: ${subagentType} agent blocked — model "${model}" not in allowed list [${allowedModels.join(', ')}]. Resubmit with model: ${allowedModels[0]}.`,
+    };
   }
 
-  if (maxTurns === undefined || maxTurns > turnsLimit) {
-    const current = maxTurns === undefined ? 'not set' : `${maxTurns}`;
-    violations.push(`max_turns ${current}, limit is ${turnsLimit}`);
-  }
-
-  if (violations.length === 0) return { context: buildOrientation(_cwd) };
-
-  return {
-    decision: 'deny',
-    blockReason: `SLOPE subagent-gate: ${subagentType} agent blocked — ${violations.join('; ')}. Resubmit with model: ${allowedModels[0]}, max_turns: ${turnsLimit}.`,
-  };
+  return { context: buildOrientation(_cwd) };
 }

--- a/src/core/guard.ts
+++ b/src/core/guard.ts
@@ -169,10 +169,10 @@ export const GUARD_DEFINITIONS: GuardDefinition[] = [
   },
   {
     name: 'subagent-gate',
-    description: 'Force haiku model and cap max_turns on Explore/Plan subagents',
+    description: 'Enforce model selection on Explore/Plan subagents',
     hookEvent: 'PreToolUse',
     toolCategories: ['create_subagent'],
-    matcher: 'Task',
+    matcher: 'Agent',
     level: 'full',
   },
   {

--- a/src/core/harness.ts
+++ b/src/core/harness.ts
@@ -70,7 +70,7 @@ export const CLAUDE_CODE_TOOLS: ToolNameMap = {
   search_files: 'Glob',
   search_content: 'Grep',
   execute_command: 'Bash',
-  create_subagent: 'Task',
+  create_subagent: 'Agent',
   exit_plan: 'ExitPlanMode',
 };
 

--- a/tests/cli/guards.test.ts
+++ b/tests/cli/guards.test.ts
@@ -330,7 +330,7 @@ describe('stopCheckGuard', () => {
 });
 
 describe('subagentGateGuard', () => {
-  it('passes through non-Task tool types', async () => {
+  it('passes through non-Explore/Plan agent types', async () => {
     const result = await subagentGateGuard(
       makeInput({ tool_input: { subagent_type: 'Bash', command: 'ls' } }),
       tmpDir,
@@ -348,7 +348,7 @@ describe('subagentGateGuard', () => {
 
   it('denies non-haiku Explore agent', async () => {
     const result = await subagentGateGuard(
-      makeInput({ tool_input: { subagent_type: 'Explore', model: 'sonnet', max_turns: 5 } }),
+      makeInput({ tool_input: { subagent_type: 'Explore', model: 'sonnet' } }),
       tmpDir,
     );
     expect(result.decision).toBe('deny');
@@ -356,27 +356,18 @@ describe('subagentGateGuard', () => {
     expect(result.blockReason).toContain('sonnet');
   });
 
-  it('denies missing max_turns', async () => {
+  it('allows haiku Explore agent without model set', async () => {
     const result = await subagentGateGuard(
-      makeInput({ tool_input: { subagent_type: 'Explore', model: 'haiku' } }),
+      makeInput({ tool_input: { subagent_type: 'Explore' } }),
       tmpDir,
     );
-    expect(result.decision).toBe('deny');
-    expect(result.blockReason).toContain('max_turns');
-  });
-
-  it('denies exceeded max_turns', async () => {
-    const result = await subagentGateGuard(
-      makeInput({ tool_input: { subagent_type: 'Explore', model: 'haiku', max_turns: 50 } }),
-      tmpDir,
-    );
-    expect(result.decision).toBe('deny');
-    expect(result.blockReason).toContain('max_turns');
+    expect(result.decision).toBeUndefined();
+    expect(result.context).toContain('SLOPE subagent tip');
   });
 
   it('allows correct Explore agent with orientation context', async () => {
     const result = await subagentGateGuard(
-      makeInput({ tool_input: { subagent_type: 'Explore', model: 'haiku', max_turns: 8 } }),
+      makeInput({ tool_input: { subagent_type: 'Explore', model: 'haiku' } }),
       tmpDir,
     );
     expect(result.decision).toBeUndefined();
@@ -385,7 +376,7 @@ describe('subagentGateGuard', () => {
 
   it('allows correct Plan agent with orientation context', async () => {
     const result = await subagentGateGuard(
-      makeInput({ tool_input: { subagent_type: 'Plan', model: 'haiku', max_turns: 12 } }),
+      makeInput({ tool_input: { subagent_type: 'Plan', model: 'haiku' } }),
       tmpDir,
     );
     expect(result.decision).toBeUndefined();
@@ -405,7 +396,7 @@ describe('subagentGateGuard', () => {
     writeFileSync(join(tmpDir, 'CODEBASE.md'), frontmatter);
 
     const result = await subagentGateGuard(
-      makeInput({ tool_input: { subagent_type: 'Explore', model: 'haiku', max_turns: 8 } }),
+      makeInput({ tool_input: { subagent_type: 'Explore', model: 'haiku' } }),
       tmpDir,
     );
     expect(result.context).toContain('27 CLI commands');
@@ -416,7 +407,7 @@ describe('subagentGateGuard', () => {
 
   it('returns fallback context when CODEBASE.md is missing', async () => {
     const result = await subagentGateGuard(
-      makeInput({ tool_input: { subagent_type: 'Explore', model: 'haiku', max_turns: 8 } }),
+      makeInput({ tool_input: { subagent_type: 'Explore', model: 'haiku' } }),
       tmpDir,
     );
     expect(result.context).toContain('Glob/Grep');
@@ -425,30 +416,28 @@ describe('subagentGateGuard', () => {
 
   it('returns no context for non-Explore/Plan agents', async () => {
     const result = await subagentGateGuard(
-      makeInput({ tool_input: { subagent_type: 'Bash', model: 'haiku', max_turns: 5 } }),
+      makeInput({ tool_input: { subagent_type: 'Bash', model: 'haiku' } }),
       tmpDir,
     );
     expect(result).toEqual({});
   });
 
-  it('respects custom config thresholds', async () => {
+  it('respects custom config allowed models', async () => {
     mockConfig.guidance = {
-      subagentExploreTurns: 5,
-      subagentPlanTurns: 8,
       subagentAllowModels: ['haiku', 'sonnet'],
     };
 
     // sonnet allowed with custom config
     const result1 = await subagentGateGuard(
-      makeInput({ tool_input: { subagent_type: 'Explore', model: 'sonnet', max_turns: 4 } }),
+      makeInput({ tool_input: { subagent_type: 'Explore', model: 'sonnet' } }),
       tmpDir,
     );
     expect(result1.decision).toBeUndefined();
     expect(result1.context).toContain('SLOPE subagent tip');
 
-    // exceeds custom Explore limit
+    // opus denied even with custom config
     const result2 = await subagentGateGuard(
-      makeInput({ tool_input: { subagent_type: 'Explore', model: 'haiku', max_turns: 6 } }),
+      makeInput({ tool_input: { subagent_type: 'Explore', model: 'opus' } }),
       tmpDir,
     );
     expect(result2.decision).toBe('deny');

--- a/tests/core/adapters/claude-code.test.ts
+++ b/tests/core/adapters/claude-code.test.ts
@@ -95,7 +95,7 @@ describe('ClaudeCodeAdapter', () => {
       expect(adapter.toolNames.read_file).toBe('Read');
       expect(adapter.toolNames.write_file).toBe('Edit|Write');
       expect(adapter.toolNames.execute_command).toBe('Bash');
-      expect(adapter.toolNames.create_subagent).toBe('Task');
+      expect(adapter.toolNames.create_subagent).toBe('Agent');
       expect(adapter.toolNames.exit_plan).toBe('ExitPlanMode');
     });
   });

--- a/tests/core/harness.test.ts
+++ b/tests/core/harness.test.ts
@@ -167,7 +167,7 @@ describe('CLAUDE_CODE_TOOLS', () => {
     expect(CLAUDE_CODE_TOOLS.search_files).toBe('Glob');
     expect(CLAUDE_CODE_TOOLS.search_content).toBe('Grep');
     expect(CLAUDE_CODE_TOOLS.execute_command).toBe('Bash');
-    expect(CLAUDE_CODE_TOOLS.create_subagent).toBe('Task');
+    expect(CLAUDE_CODE_TOOLS.create_subagent).toBe('Agent');
     expect(CLAUDE_CODE_TOOLS.exit_plan).toBe('ExitPlanMode');
   });
 });


### PR DESCRIPTION
## Summary
- The `subagent-gate` guard was designed for the old `Task` tool which had `max_turns`. The `Agent` tool doesn't expose `max_turns`, causing the guard to **always block** Explore/Plan agents.
- Removes `max_turns` check (not available on Agent tool)
- Keeps model enforcement (Agent tool does have `model` param)
- Updates `CLAUDE_CODE_TOOLS` mapping: `create_subagent` → `Agent` (was `Task`)
- Updates guard definition matcher: `Task` → `Agent`

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 2604 tests pass
- [x] Subagent-gate guard allows Explore/Plan agents when model is haiku (or unset)
- [x] Subagent-gate guard still blocks non-allowed models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model enforcement validation for Explore and Plan subagents with more immediate response handling.

* **Refactor**
  * Simplified subagent gating decision logic for faster validation results.
  * Removed max turns limitations on Explore and Plan subagents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->