### PR TITLE
chore: bump version to 1.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.26.1",
+  "version": "1.27.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Version bump for release v1.27.0.

## Features in this release

- **#159** — Tiered staleness in explore guard (0-10 silent, 11-30 warn, 31+ block Edit/Write)
- **#156** — Block sprint completion without scorecard
- **#157** — Auto-update roadmap status on `slope validate` + cross-validation
- **#158** — Structured deferred findings registry (`slope review defer/deferred/resolve`)
- Slash commands for sprint lifecycle (`/start-sprint`, `/post-sprint`, `/review-pr`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)