### PR TITLE
fix(ci): fix sync-docs workflow failure on push events

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -49,10 +51,8 @@ jobs:
         run: node -e "const s = JSON.parse(require('fs').readFileSync('stats.json','utf8')); if (!s.sprints_completed || !s.handicap) { console.error('Invalid stats'); process.exit(1); } console.log('Stats valid:', s.sprints_completed, 'sprints,', s.cli_commands, 'commands');"
 
       - name: Publish stats to KV
-        if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+        if: env.CLOUDFLARE_API_TOKEN != ''
         run: npx wrangler kv key put --namespace-id=${{ secrets.SLOPE_STATS_KV_NS_ID }} "stats" --path=stats.json --remote
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
       - name: Checkout slope-web
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fixes the persistent `sync-docs.yml` workflow failures that show on every push event.

## Root cause

The step-level `if: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}` expression caused GitHub Actions to fail workflow parsing on push events. Secrets aren't available during workflow file evaluation for events that don't match the workflow's triggers (`release`/`workflow_dispatch`), so GitHub marked every push as a "workflow file issue" failure with zero jobs.

## Fix

Move `CLOUDFLARE_API_TOKEN` to a job-level `env:` block and use `if: env.CLOUDFLARE_API_TOKEN != ''` in the step condition. Job-level env vars are always available during parsing.

## Test plan

- [x] Push this branch — verify sync-docs no longer shows as failed
- [ ] Next release — verify KV publish still works when secret is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow environment variable handling for improved configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->