### PR TITLE
fix: remove stale max_turns references from subagent-gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/guards/docs.ts
+++ b/src/cli/guards/docs.ts
@@ -57,10 +57,10 @@ export const GUARD_DOCS: Record<string, GuardDoc> = {
     level: 'full',
   },
   'subagent-gate': {
-    purpose: 'Controls subagent resource usage by forcing haiku model and capping max_turns on Explore/Plan subagents. Prevents expensive long-running subagent calls.',
-    triggers: 'PreToolUse on Task (Agent tool). Fires when the agent launches a subagent.',
-    behavior: 'Modifies input — overrides model to haiku and caps max_turns for Explore and Plan subagent types.',
-    configuration: 'guidance.subagentExploreTurns (default: 10), guidance.subagentPlanTurns (default: 15), guidance.subagentAllowModels (default: [\'haiku\']). Disable: add "subagent-gate" to guidance.disabled.',
+    purpose: 'Controls subagent resource usage by enforcing model selection on Explore/Plan subagents. Prevents expensive long-running subagent calls.',
+    triggers: 'PreToolUse on Agent. Fires when the agent launches a subagent.',
+    behavior: 'Blocks subagents using models not in the allowed list. Injects codebase orientation context for allowed subagents.',
+    configuration: 'guidance.subagentAllowModels (default: [\'haiku\']). Disable: add "subagent-gate" to guidance.disabled.',
     level: 'full',
   },
   'push-nudge': {

--- a/src/cli/guards/subagent-gate.ts
+++ b/src/cli/guards/subagent-gate.ts
@@ -40,7 +40,7 @@ function buildOrientation(cwd: string): string {
 
 /**
  * Subagent gate guard: fires PreToolUse on Agent.
- * Enforces model selection on Explore/Plan subagents (Agent tool has no max_turns).
+ * Enforces model selection on Explore/Plan subagents.
  */
 export async function subagentGateGuard(input: HookInput, _cwd: string): Promise<GuardResult> {
   const toolInput = input.tool_input ?? {};


### PR DESCRIPTION
## Summary

Removes stale `max_turns` references from subagent-gate guard documentation. The guard itself was fixed in PR #155 but the docs and comments still referenced the old behavior.

## Problem

Users installing SLOPE v1.27.0 and running `slope guard docs subagent-gate` see documentation referencing `max_turns` capping and `Task` matcher, which no longer match the actual guard behavior. Projects that previously installed hooks with an older SLOPE version also have stale `.claude/settings.json` with `Task` matcher instead of `Agent`.

## Changes

- `src/cli/guards/docs.ts` — updated purpose, triggers, behavior, configuration to match current guard (model-only enforcement, Agent matcher)
- `src/cli/guards/subagent-gate.ts` — removed parenthetical comment about max_turns
- Version bump to 1.27.1

## Fix for affected users

After updating to v1.27.1, re-run `npx slope hook add --level=full` to regenerate `.claude/settings.json` with the correct `Agent` matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Patch version 1.27.1 released

* **Documentation**
  * Clarified subagent-gate guard documentation regarding model selection enforcement and allowed model configuration guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->