### PR TITLE
chore: bump version to 1.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 1.28.0 for release with context_search MCP tool + richer codebase map signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)