### PR TITLE
fix: slope hook add removes stale SLOPE entries before re-installing

### DIFF
--- a/src/core/adapters/claude-code.ts
+++ b/src/core/adapters/claude-code.ts
@@ -128,31 +128,20 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
       } catch { /* start fresh */ }
     }
 
-    // Merge hooks — preserve existing non-SLOPE hooks
+    // Merge hooks — remove stale SLOPE entries, preserve non-SLOPE hooks
     const existingHooks = (settings.hooks ?? {}) as Record<string, unknown[]>;
     for (const [event, entries] of Object.entries(hooksConfig)) {
       if (!existingHooks[event]) {
         existingHooks[event] = [];
       }
+      // Remove all existing SLOPE hook entries for this event (stale matchers, renamed guards)
+      const existing = existingHooks[event] as Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>;
+      existingHooks[event] = existing.filter(e =>
+        !e.hooks?.some(h => h.command?.includes('slope-guard.sh')),
+      );
+      // Add fresh SLOPE entries
       for (const entry of entries) {
-        const entryWithMatcher = entry as { matcher?: string; hooks: Array<{ command?: string }> };
-        const existing = existingHooks[event] as Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>;
-        // Find an existing entry with the same matcher that already has SLOPE hooks
-        const matchingEntry = existing.find(e =>
-          e.matcher === entryWithMatcher.matcher &&
-          e.hooks?.some(h => h.command?.includes('slope-guard.sh')),
-        );
-        if (matchingEntry?.hooks) {
-          // Merge individual hook commands that don't already exist
-          for (const hook of entryWithMatcher.hooks) {
-            const hookExists = matchingEntry.hooks.some(h => h.command === hook.command);
-            if (!hookExists) {
-              matchingEntry.hooks.push(hook);
-            }
-          }
-        } else {
-          existingHooks[event].push(entry);
-        }
+        existingHooks[event].push(entry);
       }
     }
     settings.hooks = existingHooks;

--- a/tests/core/adapters/claude-code.test.ts
+++ b/tests/core/adapters/claude-code.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtempSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ClaudeCodeAdapter } from '../../../src/core/adapters/claude-code.js';
@@ -160,6 +160,66 @@ describe('ClaudeCodeAdapter', () => {
 
       // Should be identical
       expect(second).toEqual(first);
+    });
+
+    it('removes stale SLOPE hook entries with outdated matchers on re-install', () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), 'slope-cc-stale-'));
+      const settingsPath = join(tmpDir, '.claude', 'settings.json');
+
+      // Simulate a stale install with matcher "Task" instead of "Agent"
+      mkdirSync(join(tmpDir, '.claude', 'hooks'), { recursive: true });
+      writeFileSync(settingsPath, JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Task',
+              hooks: [{ type: 'command', command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/slope-guard.sh subagent-gate', timeout: 10 }],
+            },
+          ],
+        },
+      }));
+
+      // Re-install with current guard definitions
+      adapter.installGuards(tmpDir, GUARD_DEFINITIONS);
+      const result = JSON.parse(readFileSync(settingsPath, 'utf8'));
+
+      // The stale "Task" matcher entry should be gone
+      const preToolEntries = result.hooks.PreToolUse as Array<{ matcher?: string; hooks: unknown[] }>;
+      const taskEntries = preToolEntries.filter(e => e.matcher === 'Task');
+      expect(taskEntries).toHaveLength(0);
+
+      // The correct "Agent" matcher entry should exist
+      const agentEntries = preToolEntries.filter(e => e.matcher === 'Agent');
+      expect(agentEntries.length).toBeGreaterThan(0);
+      const agentHooks = agentEntries[0].hooks as Array<{ command: string }>;
+      expect(agentHooks.some(h => h.command.includes('subagent-gate'))).toBe(true);
+    });
+
+    it('preserves non-SLOPE hooks during re-install', () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), 'slope-cc-preserve-'));
+      const settingsPath = join(tmpDir, '.claude', 'settings.json');
+
+      // Install SLOPE guards first
+      adapter.installGuards(tmpDir, GUARD_DEFINITIONS.slice(0, 2));
+
+      // Manually add a non-SLOPE hook
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+      settings.hooks.PreToolUse.push({
+        matcher: 'Bash',
+        hooks: [{ type: 'command', command: 'my-custom-hook.sh', timeout: 5 }],
+      });
+      writeFileSync(settingsPath, JSON.stringify(settings));
+
+      // Re-install SLOPE guards
+      adapter.installGuards(tmpDir, GUARD_DEFINITIONS.slice(0, 4));
+      const result = JSON.parse(readFileSync(settingsPath, 'utf8'));
+
+      // Non-SLOPE hook should be preserved
+      const preToolEntries = result.hooks.PreToolUse as Array<{ matcher?: string; hooks: Array<{ command: string }> }>;
+      const customEntry = preToolEntries.find(e =>
+        e.hooks.some(h => h.command === 'my-custom-hook.sh'),
+      );
+      expect(customEntry).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- `installGuards` now removes all existing SLOPE hook entries (those containing `slope-guard.sh`) before re-adding fresh ones
- Fixes the stale `matcher: "Task"` issue from #173 — running `slope hook add --level=full` after upgrade will clean up outdated entries
- Non-SLOPE hooks are preserved during re-install

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — 2726 tests pass (28 adapter tests)
- [x] New test: stale "Task" matcher removed, replaced with correct "Agent"
- [x] New test: non-SLOPE hooks preserved during re-install
- [x] Existing test: merge behavior still works
- [x] Existing test: re-install dedup still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guard installation logic to better remove stale entries and ensure fresh configurations are properly applied while preserving custom configurations during re-installation.

* **Tests**
  * Added test coverage for guard re-installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->