### PR TITLE
fix: stop guards from trapping ad-hoc sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
         ]
       },
       {
-        "matcher": "Read|Glob|Grep|Edit|Write|Bash",
+        "matcher": "Edit|Write|Bash",
         "hooks": [
           {
             "type": "command",

--- a/src/cli/guards/sprint-completion.ts
+++ b/src/cli/guards/sprint-completion.ts
@@ -96,12 +96,14 @@ function handlePreToolUse(input: HookInput, cwd: string): GuardResult {
   };
 }
 
-/** Block session end when mid-sprint with incomplete gates or missing scorecard. */
+/** Warn at session end when mid-sprint with incomplete gates or missing scorecard.
+ *  Advisory (context), not blocking — avoids trapping ad-hoc sessions that inherit
+ *  sprint state from a previous session. */
 function handleStop(cwd: string): GuardResult {
   const state = loadSprintState(cwd);
   if (!state) return {};
 
-  // Only block during implementing/scoring phases — don't block during planning/reviewing
+  // Only warn during implementing/scoring phases — don't warn during planning/reviewing
   if (state.phase !== 'implementing' && state.phase !== 'scoring') return {};
 
   const scorecardMissing = !scorecardExists(state.sprint, cwd);
@@ -141,7 +143,9 @@ function handleStop(cwd: string): GuardResult {
   }
 
   if (staleWarning) lines.push('', staleWarning);
-  return { blockReason: lines.join('\n') };
+  // Advisory context, not a hard block — ad-hoc sessions shouldn't be trapped
+  // by sprint state left from a previous session.
+  return { context: lines.join('\n') };
 }
 
 /** Check if a scorecard file exists for the given sprint. */

--- a/src/core/guard.ts
+++ b/src/core/guard.ts
@@ -279,8 +279,8 @@ export const GUARD_DEFINITIONS: GuardDefinition[] = [
     name: 'worktree-check',
     description: 'Block concurrent sessions without worktree isolation',
     hookEvent: 'PreToolUse',
-    toolCategories: ['read_file', 'search_files', 'search_content', 'write_file', 'execute_command'],
-    matcher: 'Read|Glob|Grep|Edit|Write|Bash',
+    toolCategories: ['write_file', 'execute_command'],
+    matcher: 'Edit|Write|Bash',
     level: 'full',
   },
   {


### PR DESCRIPTION
## Summary

- **worktree-check**: Remove `Read|Glob|Grep` from matcher — concurrent reads are safe, only writes need worktree isolation. Research/discussion sessions can now read files without being forced into a worktree.
- **sprint-completion Stop**: Downgrade from hard-block (`blockReason`) to advisory (`context`) — sessions can exit cleanly even when sprint state exists from a previous session. The reminder is still injected as context but doesn't create an infinite block loop.

## Problem

Ad-hoc sessions (research, discussion, cross-repo work) were getting trapped by sprint-specific guards:
1. `worktree-check` blocked ALL tool calls (including reads) when another session existed — even for read-only research
2. `sprint-completion` Stop hook hard-blocked session exit when sprint state existed from a previous session, creating an infinite loop where the user couldn't exit without completing gates they never started

## Test plan

- [ ] 49 guard tests pass (`npx vitest run tests/cli/guards.test.ts`)
- [ ] Build + typecheck pass
- [ ] Manual: start a session in a repo with existing sprint state, verify exit works without block
- [ ] Manual: start a second session (without worktree), verify Read/Glob/Grep work but Edit/Write/Bash are blocked
- [ ] Existing sprint workflows unaffected — sprint-completion still advises on Stop, still hard-blocks `gh pr create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)