### PR TITLE
fix: sprint-completion tests + hook add <platform> shorthand

### DIFF
--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -93,6 +93,11 @@ function parseArgs(args: string[]): Record<string, string> {
   return result;
 }
 
+/** Check if a name matches a known harness adapter (claude-code, cursor, windsurf, etc.) */
+function isKnownAdapter(name: string): boolean {
+  return listAdapters().includes(name);
+}
+
 export async function hookCommand(args: string[]): Promise<void> {
   const sub = args[0];
   const hookName = args[1];
@@ -103,6 +108,9 @@ export async function hookCommand(args: string[]): Promise<void> {
     case 'add':
       if (flags.level === 'full' || flags.level === 'scoring') {
         installGuardHooks(cwd, flags.level as 'scoring' | 'full', flags.harness);
+      } else if (hookName && isKnownAdapter(hookName)) {
+        // `slope hook add claude-code` → shorthand for `--level=full --harness=claude-code`
+        installGuardHooks(cwd, 'full', hookName);
       } else {
         addHook(hookName, cwd);
       }

--- a/tests/cli/guards/sprint-completion.test.ts
+++ b/tests/cli/guards/sprint-completion.test.ts
@@ -152,10 +152,10 @@ describe('sprint-completion guard', () => {
       expect(result.blockReason).not.toContain('Tests passing');
     });
 
-    it('blocks Stop with gate list', async () => {
+    it('advises on Stop with gate list', async () => {
       const result = await sprintCompletionGuard(makeStop(), tmpDir);
-      expect(result.blockReason).toContain('Sprint 22');
-      expect(result.blockReason).toContain('Code review');
+      expect(result.context).toContain('Sprint 22');
+      expect(result.context).toContain('Code review');
     });
 
     it('does not block non-PR Bash commands', async () => {
@@ -177,10 +177,10 @@ describe('sprint-completion guard', () => {
       expect(result).toEqual({});
     });
 
-    it('blocks during scoring phase', async () => {
+    it('advises during scoring phase', async () => {
       saveSprintState(tmpDir, createSprintState(22, 'scoring'));
       const result = await sprintCompletionGuard(makeStop(), tmpDir);
-      expect(result.blockReason).toContain('Sprint 22');
+      expect(result.context).toContain('Sprint 22');
     });
   });
 
@@ -296,7 +296,7 @@ describe('sprint-completion guard', () => {
       expect(result).toEqual({});
     });
 
-    it('blocks Stop when scorecard is missing during implementing phase', async () => {
+    it('advises on Stop when scorecard is missing during implementing phase', async () => {
       const state = createSprintState(22, 'implementing');
       state.gates.tests = true;
       state.gates.code_review = true;
@@ -307,7 +307,7 @@ describe('sprint-completion guard', () => {
       // No scorecard file
 
       const result = await sprintCompletionGuard(makeStop(), tmpDir);
-      expect(result.blockReason).toContain('scorecard not found');
+      expect(result.context).toContain('scorecard not found');
     });
 
     it('shows both scorecard and gate errors when both are missing', async () => {


### PR DESCRIPTION
## Summary

- Fix 3 failing tests from v1.31.1 — sprint-completion Stop handler changed from `blockReason` to `context` but tests weren't updated
- Add `slope hook add <platform>` shorthand (e.g. `slope hook add claude-code`) that auto-routes to `--level=full --harness=<platform>` instead of erroring with "unknown hook"

## What went wrong with v1.31.1

The guard fix PR only ran `tests/cli/guards.test.ts` (49 generic tests) locally. The sprint-completion-specific tests live in `tests/cli/guards/sprint-completion.test.ts` — a separate file that wasn't run. Full `pnpm test` would have caught this.

## Test plan

- [x] Full test suite passes: 2731 passed, 154 files
- [x] Build + typecheck pass
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)