### PR TITLE
feat: adhoc session mode — silence sprint guards for non-sprint work

### DIFF
--- a/src/cli/commands/claim.ts
+++ b/src/cli/commands/claim.ts
@@ -91,6 +91,13 @@ export async function claimCommand(args: string[]): Promise<void> {
   console.log(`  Target: ${claim.target} (${claim.scope})`);
   if (claim.notes) console.log(`  Notes:  ${claim.notes}`);
 
+  // Flip session mode to sprint — enables sprint-workflow guards
+  const sessionId = process.env.CLAUDE_SESSION_ID || '';
+  if (sessionId) {
+    const { setSessionMode } = await import('../session-state.js');
+    setSessionMode(cwd, sessionId, 'sprint');
+  }
+
   // Adjacent conflicts are informational only
   if (adjacents.length > 0) {
     console.log(`\n  Note: ${adjacents.length} adjacent conflict(s):`);

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -30,6 +30,7 @@ import { reviewStaleGuard } from '../guards/review-stale.js';
 import { formatGuardDocs } from '../guards/docs.js';
 import { recordBaseline } from '../guards/git-utils.js';
 import { execSync } from 'node:child_process';
+import { isAdhocSession } from '../session-state.js';
 
 // Side-effect imports: ensure all adapters are registered for detectAdapter()
 import '../../core/adapters/claude-code.js';
@@ -163,6 +164,12 @@ export async function guardCommand(args: string[]): Promise<void> {
   // If hook_event_name was missing from stdin, fill from the guard definition
   if (!hookEvent) {
     input.hook_event_name = def.hookEvent;
+  }
+
+  // Skip sprint-workflow guards in adhoc sessions
+  const relevance = GUARD_RELEVANCE[name];
+  if (relevance?.when === 'sprint-workflow' && input.session_id && isAdhocSession(cwd, input.session_id)) {
+    return;
   }
 
   // Find and run the handler

--- a/src/cli/guards/session-briefing.ts
+++ b/src/cli/guards/session-briefing.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import type { HookInput, GuardResult, Suggestion } from '../../core/index.js';
 import { loadConfig, parseRoadmap, formatStrategicContext } from '../../core/index.js';
 import { loadSprintState } from '../sprint-state.js';
-import { loadSessionState, updateSessionState } from '../session-state.js';
+import { loadSessionState, updateSessionState, setSessionMode } from '../session-state.js';
 
 /**
  * Session-briefing guard: fires PostToolUse on all tools.
@@ -26,14 +26,17 @@ export async function sessionBriefingGuard(input: HookInput, cwd: string): Promi
   const sprintState = loadSprintState(cwd);
   const lines: string[] = [];
 
-  // Sprint state
-  if (sprintState) {
+  // Sprint state + session mode
+  const hasActiveSprint = sprintState && (sprintState.phase === 'implementing' || sprintState.phase === 'scoring');
+  if (hasActiveSprint) {
+    setSessionMode(cwd, sessionId, 'sprint');
     const gateStatus = Object.entries(sprintState.gates)
       .map(([name, done]) => `${done ? '[x]' : '[ ]'} ${name}`)
       .join('  ');
     lines.push(`Sprint: S${sprintState.sprint}  Phase: ${sprintState.phase}  Gates: ${gateStatus}`);
   } else {
-    lines.push('No active sprint.');
+    setSessionMode(cwd, sessionId, 'adhoc');
+    lines.push('No active sprint. Session mode: adhoc (sprint-workflow guards silenced).');
   }
 
   // Roadmap context (next sprint)

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 
 const SESSION_STATE_FILE = '.slope/.session-state.json';
 
+export type SessionMode = 'sprint' | 'adhoc';
+
 interface SessionState {
   /** Session ID for the briefing guard */
   briefing_session_id?: string;
@@ -12,6 +14,10 @@ interface SessionState {
   claim_warned_session_id?: string;
   /** Session ID for handoff read in explore guard */
   handoff_read_session_id?: string;
+  /** Current session mode — adhoc skips sprint-workflow guards */
+  session_mode?: SessionMode;
+  /** Session ID that set the mode (mode expires when session changes) */
+  session_mode_id?: string;
 }
 
 /** Load consolidated session state. Returns empty object if missing/corrupt. */
@@ -39,6 +45,23 @@ export function saveSessionState(cwd: string, state: SessionState): void {
 /** Update a single field in session state and save atomically. */
 export function updateSessionState(cwd: string, field: keyof SessionState, value: string): void {
   const state = loadSessionState(cwd);
-  state[field] = value;
+  (state as Record<string, unknown>)[field] = value;
   saveSessionState(cwd, state);
+}
+
+/** Set the session mode (adhoc or sprint) for a given session. */
+export function setSessionMode(cwd: string, sessionId: string, mode: SessionMode): void {
+  const state = loadSessionState(cwd);
+  state.session_mode = mode;
+  state.session_mode_id = sessionId;
+  saveSessionState(cwd, state);
+}
+
+/** Check if the current session is in adhoc mode.
+ *  Returns true if mode is explicitly 'adhoc' for this session.
+ *  Returns false if mode is 'sprint', unset, or set by a different session. */
+export function isAdhocSession(cwd: string, sessionId: string): boolean {
+  if (!sessionId) return false;
+  const state = loadSessionState(cwd);
+  return state.session_mode === 'adhoc' && state.session_mode_id === sessionId;
 }


### PR DESCRIPTION
## Summary

- Sessions without an active sprint auto-enter `adhoc` mode on first tool call
- All 10 sprint-workflow guards are silenced in adhoc mode (scope-drift, claim-required, sprint-completion, next-action, pr-review, post-push, phase-boundary, review-tier, workflow-gate, review-stale)
- Running `slope claim` flips mode to `sprint`, re-enabling all guards
- Central dispatcher check — no individual guard modifications needed

## How it works

1. `session-briefing` guard fires on first tool call, checks sprint state
2. If no active sprint (implementing/scoring) → sets `session_mode: 'adhoc'`
3. Guard dispatcher checks `GUARD_RELEVANCE.when === 'sprint-workflow'` + `isAdhocSession()` → silently skips
4. `slope claim` sets `session_mode: 'sprint'` → guards re-activate

## Combined with v1.31.2

Together with the v1.31.2 fixes (worktree-check reads, sprint-completion advisory), this fully resolves the ad-hoc session pain:
- Read-only research: no worktree needed
- Session exit: no blocking loop
- Sprint noise: completely silenced for non-sprint sessions

## Test plan

- [x] Full test suite: 2731 passed, 154 files
- [x] Build + typecheck pass
- [ ] Manual: start session with no active sprint → verify sprint guards don't fire
- [ ] Manual: run `slope claim` → verify guards re-activate

🤖 Generated with [Claude Code](https://claude.com/claude-code)