### PR TITLE
feat: worktree-reuse guard for persistent worktree support (#185)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -93,6 +93,17 @@
         ]
       },
       {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/slope-guard.sh worktree-reuse",
+            "timeout": 15,
+            "statusMessage": "SLOPE: Guide agent to reuse existing worktrees instead of recreating"
+          }
+        ]
+      },
+      {
         "matcher": "ExitPlanMode",
         "hooks": [
           {

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -1,11 +1,11 @@
 ---
-generated_at: "2026-03-15T19:10:26.666Z"
-git_sha: "28e860a312e36351ff69a77f1eb0c06f1794194b"
+generated_at: "2026-03-16T20:08:02.303Z"
+git_sha: "1a890174948daf614dd171630d157b5c78498add"
 sprint: 66
-source_files: 199
+source_files: 208
 test_files: 155
 cli_commands: 46
-guards: 22
+guards: 28
 flows: 0
 ---
 
@@ -18,14 +18,16 @@ Sprint Lifecycle & Operational Performance Engine — pluggable-metaphor sprint 
 <!-- AUTO-GENERATED: START packages -->
 
 ### `src/cli`
-- Source files: 99 | Test files: 65
+- Source files: 108 | Test files: 65
 - Key modules:
   - `config`
   - `hooks-config`
   - `interactive-init` — SLOPE — Rich Interactive Init (powered by @clack/prompts)
   - `loader`
   - `metaphor` — CLI metaphor resolution
+  - `phase-cleanup` — Load phase cleanup state. Returns empty state if missing/corrupt.
   - `registry` — CLI Command Registry — metadata for CLI commands (map generation, documentation, slope-web)
+  - `session-state` — Session ID for the briefing guard
   - `sprint-state` — Sprint lifecycle phases
   - `store` — Store info from config — no store connection required
   - `template-generator` — SLOPE Template Generator
@@ -493,12 +495,18 @@ Re-exports from `src/core/index.ts`:
 | `pr-review` | PostToolUse | Bash | Prompt for review workflow after PR creation |
 | `transcript` | PostToolUse | — | Append tool call metadata to session transcript |
 | `branch-before-commit` | PreToolUse | Bash | Block git commit on main/master — create a feature branch first |
-| `worktree-check` | PreToolUse | Read|Glob|Grep|Edit|Write|Bash | Block concurrent sessions without worktree isolation |
+| `worktree-check` | PreToolUse | Edit|Write|Bash | Block concurrent sessions without worktree isolation |
 | `sprint-completion` | PreToolUse | Bash | Block PR creation when sprint gates are incomplete |
 | `sprint-completion` | Stop | — | Block session end when sprint gates are incomplete |
 | `sprint-completion` | PostToolUse | Bash | Auto-detect test pass and mark gate complete |
 | `worktree-merge` | PreToolUse | Bash | Block gh pr merge --delete-branch in worktrees (causes false failure) |
 | `worktree-self-remove` | PreToolUse | Bash | Block git worktree remove when targeting own cwd |
+| `phase-boundary` | PreToolUse | Bash | Block starting sprint in new phase if previous phase cleanup incomplete |
+| `claim-required` | PreToolUse | Edit|Write | Warn when editing code without an active sprint claim |
+| `post-push` | PostToolUse | Bash | Suggest next workflow step after git push |
+| `session-briefing` | PostToolUse | — | Inject sprint context on first tool call of session |
+| `review-stale` | Stop | — | Warn about scored sprints with missing reviews at session end |
+| `worktree-reuse` | PreToolUse | EnterWorktree | Guide agent to reuse existing worktrees instead of recreating |
 <!-- AUTO-GENERATED: END guards -->
 
 ## MCP Tools

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -22,6 +22,7 @@ import { worktreeCheckGuard } from '../guards/worktree-check.js';
 import { sprintCompletionGuard } from '../guards/sprint-completion.js';
 import { worktreeMergeGuard } from '../guards/worktree-merge.js';
 import { worktreeSelfRemoveGuard } from '../guards/worktree-self-remove.js';
+import { worktreeReuseGuard } from '../guards/worktree-reuse.js';
 import { sessionBriefingGuard } from '../guards/session-briefing.js';
 import { postPushGuard } from '../guards/post-push.js';
 import { phaseBoundaryGuard } from '../guards/phase-boundary.js';
@@ -98,6 +99,7 @@ const handlers: Partial<Record<GuardName, GuardHandler>> = {
   'phase-boundary': phaseBoundaryGuard,
   'claim-required': claimRequiredGuard,
   'review-stale': reviewStaleGuard,
+  'worktree-reuse': worktreeReuseGuard,
 };
 
 /** Register a guard handler */

--- a/src/cli/guards/worktree-reuse.ts
+++ b/src/cli/guards/worktree-reuse.ts
@@ -1,0 +1,102 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import type { HookInput, GuardResult } from '../../core/index.js';
+
+/**
+ * Worktree-reuse guard: fires PreToolUse on EnterWorktree.
+ * When the requested worktree name already exists, injects context
+ * guiding the agent to reuse it (with sync commands) instead of
+ * letting EnterWorktree fail on duplicate creation.
+ */
+export async function worktreeReuseGuard(input: HookInput, cwd: string): Promise<GuardResult> {
+  const name = input.tool_input?.name as string | undefined;
+  if (!name) return {};
+
+  // Check if a worktree with this name already exists
+  const projectDir = resolveProjectDir(cwd);
+  const worktreePath = join(projectDir, '.claude', 'worktrees', name);
+
+  if (!existsSync(worktreePath)) return {};
+
+  // Worktree exists — check its state
+  let branch = 'unknown';
+  let behind = 0;
+  let baseBranch = 'main';
+  try {
+    branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: worktreePath, encoding: 'utf8' }).trim();
+    // Detect base branch
+    for (const candidate of ['main', 'master']) {
+      try {
+        execSync(`git rev-parse --verify origin/${candidate}`, { cwd: worktreePath, encoding: 'utf8', stdio: 'pipe' });
+        baseBranch = candidate;
+        break;
+      } catch { /* try next */ }
+    }
+    // Check how far behind
+    try {
+      execSync('git fetch origin --quiet', { cwd: worktreePath, encoding: 'utf8', timeout: 10000 });
+      const count = execSync(
+        `git rev-list HEAD..origin/${baseBranch} --count`,
+        { cwd: worktreePath, encoding: 'utf8' },
+      ).trim();
+      behind = parseInt(count, 10) || 0;
+    } catch { /* fetch failed — offline, skip sync info */ }
+  } catch { /* not a valid git dir — let EnterWorktree handle the error */ }
+
+  const syncHint = behind > 0
+    ? `\n\nThe worktree is ${behind} commit(s) behind origin/${baseBranch}. To sync:\n  cd "${worktreePath}" && git rebase origin/${baseBranch}`
+    : '';
+
+  return {
+    decision: 'deny',
+    blockReason: [
+      `SLOPE: Worktree "${name}" already exists at ${worktreePath} (branch: ${branch}).`,
+      '',
+      `To reuse it, use Bash to change directory:`,
+      `  cd "${worktreePath}"`,
+      syncHint,
+      '',
+      `To create a fresh worktree, use a different name or remove the existing one:`,
+      `  git worktree remove "${worktreePath}"`,
+    ].join('\n'),
+  };
+}
+
+/** Resolve the project root (handles being inside a worktree) */
+function resolveProjectDir(cwd: string): string {
+  try {
+    const commonDir = execSync('git rev-parse --git-common-dir', { cwd, encoding: 'utf8' }).trim();
+    if (commonDir === '.git') return cwd;
+    // In a worktree — commonDir is like ../../.git, resolve to project root
+    const gitDir = join(cwd, commonDir);
+    // gitDir is the .git dir of the main repo — parent is the project root
+    return join(gitDir, '..');
+  } catch {
+    return cwd;
+  }
+}
+
+/** List existing persistent worktrees with status info */
+export function listWorktrees(cwd: string): Array<{ name: string; path: string; branch: string; behind: number }> {
+  const projectDir = resolveProjectDir(cwd);
+  const worktreeDir = join(projectDir, '.claude', 'worktrees');
+  if (!existsSync(worktreeDir)) return [];
+
+  const entries = readdirSync(worktreeDir).filter(name => {
+    const fullPath = join(worktreeDir, name);
+    return statSync(fullPath).isDirectory();
+  });
+
+  return entries.map(name => {
+    const fullPath = join(worktreeDir, name);
+    let branch = 'unknown';
+    let behind = 0;
+    try {
+      branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: fullPath, encoding: 'utf8' }).trim();
+      const count = execSync('git rev-list HEAD..origin/main --count 2>/dev/null', { cwd: fullPath, encoding: 'utf8' }).trim();
+      behind = parseInt(count, 10) || 0;
+    } catch { /* not a valid git worktree */ }
+    return { name, path: fullPath, branch, behind };
+  });
+}

--- a/src/core/adapters/cline.ts
+++ b/src/core/adapters/cline.ts
@@ -25,6 +25,7 @@ const CLINE_TOOLS: ToolNameMap = {
   execute_command: 'execute_command',
   create_subagent: 'use_mcp_tool',
   exit_plan: 'plan_mode_response',
+  enter_worktree: '',
 };
 
 /**

--- a/src/core/adapters/cursor.ts
+++ b/src/core/adapters/cursor.ts
@@ -16,6 +16,7 @@ const CURSOR_TOOLS: ToolNameMap = {
   execute_command: 'run_terminal_command',
   create_subagent: 'create_subagent',
   exit_plan: 'exit_plan',
+  enter_worktree: '',
 };
 
 /** Cursor hook entry in .cursor/hooks.json */

--- a/src/core/adapters/generic.ts
+++ b/src/core/adapters/generic.ts
@@ -16,6 +16,7 @@ const GENERIC_TOOLS: ToolNameMap = {
   execute_command: 'execute_command',
   create_subagent: 'create_subagent',
   exit_plan: 'exit_plan',
+  enter_worktree: '',
 };
 
 /** Guard manifest entry written to guards-manifest.json */

--- a/src/core/adapters/ob1.ts
+++ b/src/core/adapters/ob1.ts
@@ -30,7 +30,8 @@ const OB1_TOOLS: ToolNameMap = {
   search_content: 'grep_search',
   execute_command: 'run_shell_command',
   create_subagent: 'worker|general|explore|plan|codebase_investigator|browser|vision-analyzer|handoff_to_agent|web',
-  exit_plan: '',  // No OB1 equivalent for exit_plan
+  exit_plan: '',
+  enter_worktree: '',
 };
 
 /**

--- a/src/core/adapters/windsurf.ts
+++ b/src/core/adapters/windsurf.ts
@@ -20,6 +20,7 @@ const WINDSURF_TOOLS: ToolNameMap = {
   execute_command: 'run_command',
   create_subagent: 'create_subagent',
   exit_plan: 'exit_plan',
+  enter_worktree: '',
 };
 
 /** Windsurf hook entry in .windsurf/hooks.json */

--- a/src/core/guard.ts
+++ b/src/core/guard.ts
@@ -102,7 +102,8 @@ export type GuardName =
   | 'post-push'
   | 'phase-boundary'
   | 'claim-required'
-  | 'review-stale';
+  | 'review-stale'
+  | 'worktree-reuse';
 
 /** Guard registration entry */
 export interface GuardDefinition {
@@ -357,6 +358,14 @@ export const GUARD_DEFINITIONS: GuardDefinition[] = [
     name: 'review-stale',
     description: 'Warn about scored sprints with missing reviews at session end',
     hookEvent: 'Stop',
+    level: 'full',
+  },
+  {
+    name: 'worktree-reuse',
+    description: 'Guide agent to reuse existing worktrees instead of recreating',
+    hookEvent: 'PreToolUse',
+    toolCategories: ['enter_worktree'],
+    matcher: 'EnterWorktree',
     level: 'full',
   },
 ];

--- a/src/core/harness.ts
+++ b/src/core/harness.ts
@@ -17,7 +17,8 @@ export type ToolCategory =
   | 'search_content'
   | 'execute_command'
   | 'create_subagent'
-  | 'exit_plan';
+  | 'exit_plan'
+  | 'enter_worktree';
 
 /** All tool categories for iteration */
 export const TOOL_CATEGORIES: ToolCategory[] = [
@@ -28,6 +29,7 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
   'execute_command',
   'create_subagent',
   'exit_plan',
+  'enter_worktree',
 ];
 
 /** Maps tool categories to harness-specific tool name patterns */
@@ -72,6 +74,7 @@ export const CLAUDE_CODE_TOOLS: ToolNameMap = {
   execute_command: 'Bash',
   create_subagent: 'Agent',
   exit_plan: 'ExitPlanMode',
+  enter_worktree: 'EnterWorktree',
 };
 
 // --- Adapter Priority ---

--- a/tests/adapters.test.ts
+++ b/tests/adapters.test.ts
@@ -97,7 +97,7 @@ describe('adapters barrel export', () => {
     expect(ADAPTER_PRIORITY).toContain('claude-code');
     expect(ADAPTER_PRIORITY).toContain('cline');
     expect(ADAPTER_PRIORITY).toContain('generic');
-    expect(TOOL_CATEGORIES.length).toBe(7);
+    expect(TOOL_CATEGORIES.length).toBe(8);
     expect(CLAUDE_CODE_TOOLS.read_file).toBe('Read');
   });
 

--- a/tests/core/adapters/cline.test.ts
+++ b/tests/core/adapters/cline.test.ts
@@ -254,6 +254,9 @@ describe('ClineAdapter', () => {
       for (const g of GUARD_DEFINITIONS) {
         const resolved = resolveToolMatcher(adapter, g.toolCategories);
         if (g.toolCategories) {
+          // Skip guards whose categories don't map to any tool on this adapter
+          const hasMapping = g.toolCategories.some(c => (adapter.toolNames as Record<string, string>)[c]);
+          if (!hasMapping) continue;
           expect(resolved, `${g.name}: should resolve to non-empty string`).toBeTruthy();
           // Each resolved name should be a Cline tool name
           for (const name of resolved!.split('|')) {

--- a/tests/core/adapters/cursor.test.ts
+++ b/tests/core/adapters/cursor.test.ts
@@ -262,6 +262,9 @@ describe('CursorAdapter', () => {
       for (const g of GUARD_DEFINITIONS) {
         const resolved = resolveToolMatcher(adapter, g.toolCategories);
         if (g.toolCategories) {
+          // Skip guards whose categories don't map to any tool on this adapter
+          const hasMapping = g.toolCategories.some(c => (adapter.toolNames as Record<string, string>)[c]);
+          if (!hasMapping) continue;
           expect(resolved, `${g.name}: should resolve to non-empty string`).toBeTruthy();
           // Each resolved name should be a Cursor tool name
           for (const name of resolved!.split('|')) {

--- a/tests/core/adapters/windsurf.test.ts
+++ b/tests/core/adapters/windsurf.test.ts
@@ -264,6 +264,9 @@ describe('WindsurfAdapter', () => {
       for (const g of GUARD_DEFINITIONS) {
         const resolved = resolveToolMatcher(adapter, g.toolCategories);
         if (g.toolCategories) {
+          // Skip guards whose categories don't map to any tool on this adapter
+          const hasMapping = g.toolCategories.some(c => (adapter.toolNames as Record<string, string>)[c]);
+          if (!hasMapping) continue;
           expect(resolved, `${g.name}: should resolve to non-empty string`).toBeTruthy();
           for (const name of resolved!.split('|')) {
             const allWindsurfNames = Object.values(adapter.toolNames).flatMap(n => n.split('|'));

--- a/tests/core/guard.test.ts
+++ b/tests/core/guard.test.ts
@@ -11,8 +11,8 @@ import type { GuardResult } from '../../src/core/guard.js';
 import '../../src/core/adapters/claude-code.js';
 
 describe('GUARD_DEFINITIONS', () => {
-  it('has 27 guard definitions', () => {
-    expect(GUARD_DEFINITIONS).toHaveLength(27);
+  it('has 28 guard definitions', () => {
+    expect(GUARD_DEFINITIONS).toHaveLength(28);
   });
 
   it('all guards have required fields', () => {

--- a/tests/core/harness.test.ts
+++ b/tests/core/harness.test.ts
@@ -173,8 +173,8 @@ describe('CLAUDE_CODE_TOOLS', () => {
 });
 
 describe('TOOL_CATEGORIES', () => {
-  it('contains exactly 7 categories', () => {
-    expect(TOOL_CATEGORIES).toHaveLength(7);
+  it('contains exactly 8 categories', () => {
+    expect(TOOL_CATEGORIES).toHaveLength(8);
   });
 
   it('matches ToolNameMap keys', () => {


### PR DESCRIPTION
## Summary

New `worktree-reuse` guard that intercepts `EnterWorktree` when the named worktree already exists, guiding the agent to reuse it instead of failing.

Closes #185

## How it works

When `EnterWorktree(name="session-001")` is called and `.claude/worktrees/session-001/` exists:
1. Guard denies with helpful context containing:
   - Existing worktree path and current branch
   - `cd` command to enter the worktree
   - How many commits behind main + rebase command
   - Option to remove and recreate if desired
2. Agent can then `cd` into the existing worktree via Bash

## Changes

- New guard: `src/cli/guards/worktree-reuse.ts`
- New tool category: `enter_worktree` added to `ToolCategory`, `TOOL_CATEGORIES`, `CLAUDE_CODE_TOOLS`, and all adapter tool maps
- Settings.json: new `EnterWorktree` matcher entry
- Tests: updated guard count (27→28), category count (7→8), adapter drift tests skip guards with no mapping

## Test plan

- [x] Full test suite: 2731 passed, 154 files
- [x] Build + typecheck pass
- [ ] CI passes
- [ ] Manual: call `EnterWorktree` with existing worktree name → get reuse guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a worktree reuse guard that detects existing worktrees and guides users to reuse them instead of creating duplicates, improving project management efficiency.

* **Tests**
  * Updated test expectations to reflect the new guard and tool category additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->