### PR TITLE
chore: bump version to 1.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump 1.32.0 to 1.33.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Release version 1.33.0

No specific features, bug fixes, or changes are documented in this release beyond the version number update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->