### PR TITLE
fix: stale session blocks worktree sessions

### DIFF
--- a/src/cli/guards/stop-check.ts
+++ b/src/cli/guards/stop-check.ts
@@ -1,6 +1,8 @@
 import { execSync } from 'node:child_process';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { headIsOnMain, loadBaseline, removeBaseline } from './git-utils.js';
+import { resolveStore } from '../store.js';
+import { resetWorktreeCheckState } from './worktree-check.js';
 
 /**
  * Detect the effective git working directory for this session.
@@ -176,5 +178,20 @@ export async function stopCheckGuard(_input: HookInput, cwd: string): Promise<Gu
 
   // Clean session — remove baseline
   removeBaseline(_input.session_id, cwd);
+
+  // Clean up session from store and sentinel file
+  if (_input.session_id) {
+    try {
+      const store = await resolveStore(cwd);
+      try {
+        await store.removeSession(_input.session_id);
+      } finally {
+        try { store.close(); } catch { /* ignore */ }
+      }
+    } catch { /* store unavailable — session will expire via TTL */ }
+
+    resetWorktreeCheckState(_input.session_id);
+  }
+
   return {};
 }

--- a/src/cli/guards/transcript.ts
+++ b/src/cli/guards/transcript.ts
@@ -3,6 +3,7 @@ import type { HookInput, GuardResult } from '../../core/index.js';
 import { appendTurn } from '../../core/transcript.js';
 import type { ToolCallSummary, TranscriptLine } from '../../core/types.js';
 import { loadConfig } from '../config.js';
+import { resolveStore } from '../store.js';
 
 /**
  * Summarize tool_input params into a short string for the transcript.
@@ -77,6 +78,18 @@ export async function transcriptGuard(input: HookInput, cwd: string): Promise<Gu
     appendTurn(transcriptsDir, input.session_id, line);
   } catch {
     // Silent — transcript write failure should never block the agent
+  }
+
+  // Heartbeat: keep session alive in store (prevents stale cleanup with shorter TTL)
+  if (input.session_id) {
+    try {
+      const store = await resolveStore(cwd);
+      try {
+        await store.updateHeartbeat(input.session_id);
+      } finally {
+        try { store.close(); } catch { /* ignore */ }
+      }
+    } catch { /* heartbeat failure is non-fatal */ }
   }
 
   return {};

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -49,8 +49,8 @@ export const REVIEW_TYPE_HAZARD_MAP: Record<ReviewType, HazardType> = {
   ux: 'trees',
 };
 
-/** Stale session cleanup threshold (2 hours in ms) */
-export const STALE_SESSION_THRESHOLD_MS = 7_200_000;
+/** Stale session cleanup threshold (10 minutes in ms) */
+export const STALE_SESSION_THRESHOLD_MS = 600_000;
 
 /** Default nutrition items to assess per sprint */
 export const NUTRITION_CHECKLIST: NutritionCategory[] = [

--- a/tests/cli/guards/stop-check.test.ts
+++ b/tests/cli/guards/stop-check.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
@@ -92,6 +92,82 @@ describe('stop-check guard', () => {
       expect(result.blockReason).toBeUndefined();
 
       rmSync(bareDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('session cleanup on exit', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('calls removeSession on clean exit with correct sessionId', async () => {
+      const mockStore = {
+        removeSession: vi.fn().mockResolvedValue(true),
+        close: vi.fn(),
+      };
+      const resolveStoreMock = vi.fn().mockResolvedValue(mockStore);
+
+      vi.resetModules();
+      vi.doMock('../../../src/cli/store.js', () => ({
+        resolveStore: resolveStoreMock,
+      }));
+
+      const { stopCheckGuard: guardWithMock } = await import('../../../src/cli/guards/stop-check.js');
+
+      const result = await guardWithMock(makeStop(), tmpDir);
+      expect(result.blockReason).toBeUndefined();
+      expect(resolveStoreMock).toHaveBeenCalledWith(tmpDir);
+      expect(mockStore.removeSession).toHaveBeenCalledWith('test-session');
+      expect(mockStore.close).toHaveBeenCalled();
+    });
+
+    it('removeSession failure does not block stop', async () => {
+      vi.resetModules();
+      vi.doMock('../../../src/cli/store.js', () => ({
+        resolveStore: vi.fn().mockRejectedValue(new Error('store unavailable')),
+      }));
+
+      const { stopCheckGuard: guardWithMock } = await import('../../../src/cli/guards/stop-check.js');
+
+      // Should not throw
+      const result = await guardWithMock(makeStop(), tmpDir);
+      expect(result.blockReason).toBeUndefined();
+    });
+
+    it('sentinel file cleaned on exit', async () => {
+      // Create sentinel file
+      const sentinelDir = join(tmpdir(), 'slope-guards');
+      const sentinelFile = join(sentinelDir, 'worktree-check-test-session');
+      writeFileSync(sentinelFile, new Date().toISOString());
+      expect(existsSync(sentinelFile)).toBe(true);
+
+      vi.resetModules();
+      vi.doMock('../../../src/cli/store.js', () => ({
+        resolveStore: vi.fn().mockResolvedValue({
+          removeSession: vi.fn().mockResolvedValue(true),
+          close: vi.fn(),
+        }),
+      }));
+
+      const { stopCheckGuard: guardWithMock } = await import('../../../src/cli/guards/stop-check.js');
+      await guardWithMock(makeStop(), tmpDir);
+
+      expect(existsSync(sentinelFile)).toBe(false);
+    });
+
+    it('cleanup skipped when no session_id', async () => {
+      const resolveStoreMock = vi.fn();
+
+      vi.resetModules();
+      vi.doMock('../../../src/cli/store.js', () => ({
+        resolveStore: resolveStoreMock,
+      }));
+
+      const { stopCheckGuard: guardWithMock } = await import('../../../src/cli/guards/stop-check.js');
+      const input: HookInput = { session_id: '', cwd: tmpDir, hook_event_name: 'Stop' };
+      await guardWithMock(input, tmpDir);
+
+      expect(resolveStoreMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/cli/guards/transcript.test.ts
+++ b/tests/cli/guards/transcript.test.ts
@@ -184,4 +184,64 @@ describe('transcriptGuard', () => {
       expect(() => JSON.parse(l)).not.toThrow();
     }
   });
+
+  describe('heartbeat', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('calls updateHeartbeat after transcript append', async () => {
+      const mockStore = {
+        updateHeartbeat: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn(),
+      };
+
+      vi.resetModules();
+      vi.doMock('../../../src/cli/store.js', () => ({
+        resolveStore: vi.fn().mockResolvedValue(mockStore),
+      }));
+      vi.doMock('../../../src/cli/config.js', () => ({
+        loadConfig: () => ({ transcriptsPath: '.slope/transcripts' }),
+      }));
+
+      const { transcriptGuard: guardWithMock } = await import('../../../src/cli/guards/transcript.js');
+      await guardWithMock(makeInput(), TEST_DIR);
+
+      expect(mockStore.updateHeartbeat).toHaveBeenCalledWith('test-sess-1');
+      expect(mockStore.close).toHaveBeenCalled();
+    });
+
+    it('heartbeat failure does not block transcript', async () => {
+      vi.resetModules();
+      vi.doMock('../../../src/cli/store.js', () => ({
+        resolveStore: vi.fn().mockRejectedValue(new Error('store unavailable')),
+      }));
+      vi.doMock('../../../src/cli/config.js', () => ({
+        loadConfig: () => ({ transcriptsPath: '.slope/transcripts' }),
+      }));
+
+      const { transcriptGuard: guardWithMock } = await import('../../../src/cli/guards/transcript.js');
+      const result = await guardWithMock(makeInput(), TEST_DIR);
+
+      // Guard still returns empty (silent)
+      expect(result).toEqual({});
+    });
+
+    it('heartbeat skipped when no session_id', async () => {
+      const resolveStoreMock = vi.fn();
+
+      vi.resetModules();
+      vi.doMock('../../../src/cli/store.js', () => ({
+        resolveStore: resolveStoreMock,
+      }));
+      vi.doMock('../../../src/cli/config.js', () => ({
+        loadConfig: () => ({ transcriptsPath: '.slope/transcripts' }),
+      }));
+
+      const { transcriptGuard: guardWithMock } = await import('../../../src/cli/guards/transcript.js');
+      await guardWithMock(makeInput({ session_id: '' }), TEST_DIR);
+
+      expect(resolveStoreMock).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- **Stop hook cleanup** — `stopCheckGuard()` now calls `removeSession()` and cleans the sentinel file on exit, so sessions don't linger in the store after the process ends
- **Shorter TTL** — `STALE_SESSION_THRESHOLD_MS` reduced from 2 hours to 10 minutes, so orphaned sessions clear quickly
- **Heartbeat** — transcript guard calls `updateHeartbeat()` on every `PostToolUse`, keeping active sessions alive under the shorter TTL

Fixes #189

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 2738 passed, 0 failures
- [x] 4 new stop-check tests (removeSession called, failure non-fatal, sentinel cleaned, skipped without session_id)
- [x] 3 new transcript tests (updateHeartbeat called, failure non-fatal, skipped without session_id)
- [ ] Manual: open two sessions, close one, verify the other isn't blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session lifecycle management with proper cleanup on termination and heartbeat monitoring during active use to prevent premature timeout.
  * Reduced stale session detection timeout from 2 hours to 10 minutes.

* **Tests**
  * Added test coverage for session cleanup and heartbeat operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->