### PR TITLE
chore: bump version to 1.35.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump 1.34.0 to 1.35.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 1.35.0

---

**Note:** This is a maintenance release with no new features or bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->