### PR TITLE
fix: route guard audit/recommend to management command

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -224,7 +224,7 @@ switch (subcommand) {
   case 'guard': {
     const guardArgs = process.argv.slice(3);
     const guardSub = guardArgs[0];
-    if (guardSub === 'list' || guardSub === 'status' || guardSub === 'enable' || guardSub === 'disable' || guardSub === 'docs') {
+    if (guardSub === 'list' || guardSub === 'status' || guardSub === 'enable' || guardSub === 'disable' || guardSub === 'docs' || guardSub === 'audit' || guardSub === 'recommend') {
       guardManageCommand(guardArgs).catch(err => {
         console.error('Error:', err.message);
         process.exit(1);


### PR DESCRIPTION
Smoke testing found that `slope guard audit` and `slope guard recommend` fell through to the guard runner. Added both to the CLI router dispatch.