### PR TITLE
feat: subagent-based PR reviews — slope review run

### DIFF
--- a/src/cli/commands/review-run.ts
+++ b/src/cli/commands/review-run.ts
@@ -1,0 +1,164 @@
+/**
+ * slope review run — Generate review prompts for subagent-based PR reviews.
+ *
+ * Prepares isolated review context (PR diff + changed files) and outputs
+ * structured prompts that can be used with Claude Code's Agent tool.
+ *
+ * Usage:
+ *   slope review run [--pr=N] [--type=architect|code|both] [--sprint=N] [--json]
+ */
+
+import { execSync } from 'node:child_process';
+import { loadConfig, detectLatestSprint } from '../../core/index.js';
+
+export interface ReviewPrompt {
+  type: 'architect' | 'code';
+  prompt: string;
+  context: {
+    pr_number?: number;
+    sprint?: number;
+    changed_files: string[];
+    diff_lines: number;
+  };
+}
+
+function getPrDiff(prNumber?: number): { diff: string; files: string[]; prNum: number } | null {
+  try {
+    const prArg = prNumber ? String(prNumber) : '';
+    const diff = execSync(`gh pr diff ${prArg}`, { encoding: 'utf8', timeout: 30000 }).trim();
+    const filesRaw = execSync(`gh pr diff ${prArg} --name-only`, { encoding: 'utf8', timeout: 10000 }).trim();
+    const files = filesRaw.split('\n').filter(Boolean);
+    const num = prNumber ?? parseInt(execSync(`gh pr view --json number -q .number`, { encoding: 'utf8', timeout: 10000 }).trim(), 10);
+    return { diff, files, prNum: num };
+  } catch {
+    return null;
+  }
+}
+
+function buildArchitectPrompt(diff: string, files: string[], sprint?: number): string {
+  return [
+    'You are performing an ARCHITECT REVIEW of a pull request.',
+    'You have a clean context — no prior implementation knowledge.',
+    '',
+    '## Review Criteria',
+    '1. Does the design match codebase patterns? Check for duplication of existing infrastructure.',
+    '2. Are dependencies correct and ordering optimal?',
+    '3. Are there scope gaps or underscoped complexity?',
+    '4. Does it introduce unnecessary complexity?',
+    '5. Are there security concerns (injection, auth bypass, data exposure)?',
+    '',
+    '## Changed Files',
+    files.map(f => `- ${f}`).join('\n'),
+    '',
+    '## Diff',
+    '```diff',
+    diff.length > 50000 ? diff.slice(0, 50000) + '\n... (truncated)' : diff,
+    '```',
+    '',
+    '## Output Format',
+    'For each finding, output:',
+    '```',
+    `slope review findings add --type=architect${sprint ? ` --sprint=${sprint}` : ''} --severity=<minor|moderate|major|critical> --description="<finding>"`,
+    '```',
+    'If no issues found, say "No architect findings."',
+  ].join('\n');
+}
+
+function buildCodePrompt(diff: string, files: string[], sprint?: number): string {
+  return [
+    'You are performing a CODE REVIEW of a pull request.',
+    'You have a clean context — no prior implementation knowledge.',
+    '',
+    '## Review Criteria',
+    '1. Correctness: Does the code do what it claims? Edge cases?',
+    '2. Error handling: Are errors caught and handled appropriately?',
+    '3. Test coverage: Are new paths tested? Any gaps?',
+    '4. Code quality: Naming, structure, consistency with existing patterns.',
+    '5. Performance: Any obvious bottlenecks or N+1 patterns?',
+    '',
+    '## Changed Files',
+    files.map(f => `- ${f}`).join('\n'),
+    '',
+    '## Diff',
+    '```diff',
+    diff.length > 50000 ? diff.slice(0, 50000) + '\n... (truncated)' : diff,
+    '```',
+    '',
+    '## Output Format',
+    'For each finding, output:',
+    '```',
+    `slope review findings add --type=code${sprint ? ` --sprint=${sprint}` : ''} --severity=<minor|moderate|major|critical> --description="<finding>"`,
+    '```',
+    'If no issues found, say "No code findings."',
+  ].join('\n');
+}
+
+export async function reviewRunCommand(args: string[]): Promise<void> {
+  const cwd = process.cwd();
+  const flags: Record<string, string> = {};
+  for (const arg of args) {
+    const match = arg.match(/^--(\w[\w-]*)(?:=(.+))?$/);
+    if (match) flags[match[1]] = match[2] ?? 'true';
+  }
+
+  const prNumber = flags.pr ? parseInt(flags.pr, 10) : undefined;
+  const reviewType = (flags.type ?? 'both') as 'architect' | 'code' | 'both';
+  const json = flags.json === 'true';
+
+  // Detect sprint
+  let sprint: number | undefined;
+  if (flags.sprint) {
+    sprint = parseInt(flags.sprint, 10);
+  } else {
+    try {
+      const config = loadConfig(cwd);
+      sprint = config.currentSprint ?? detectLatestSprint(config, cwd);
+    } catch { /* no config */ }
+  }
+
+  // Get PR diff
+  const pr = getPrDiff(prNumber);
+  if (!pr) {
+    console.error('Could not get PR diff. Ensure `gh` CLI is installed and a PR exists for the current branch.');
+    process.exit(1);
+  }
+
+  const diffLines = pr.diff.split('\n').length;
+  const prompts: ReviewPrompt[] = [];
+
+  if (reviewType === 'architect' || reviewType === 'both') {
+    prompts.push({
+      type: 'architect',
+      prompt: buildArchitectPrompt(pr.diff, pr.files, sprint),
+      context: { pr_number: pr.prNum, sprint, changed_files: pr.files, diff_lines: diffLines },
+    });
+  }
+
+  if (reviewType === 'code' || reviewType === 'both') {
+    prompts.push({
+      type: 'code',
+      prompt: buildCodePrompt(pr.diff, pr.files, sprint),
+      context: { pr_number: pr.prNum, sprint, changed_files: pr.files, diff_lines: diffLines },
+    });
+  }
+
+  if (json) {
+    console.log(JSON.stringify(prompts, null, 2));
+    return;
+  }
+
+  // Output prompts for agent consumption
+  console.log(`\n=== Review Prompts for PR #${pr.prNum} ===`);
+  console.log(`Sprint: ${sprint ?? '?'} | Files: ${pr.files.length} | Diff: ${diffLines} lines\n`);
+
+  for (const p of prompts) {
+    console.log(`--- ${p.type.toUpperCase()} REVIEW PROMPT ---`);
+    console.log('Use this with Claude Code\'s Agent tool (model: "haiku") for an isolated review:\n');
+    console.log(p.prompt);
+    console.log('');
+  }
+
+  console.log('To run both reviews as subagents, use:');
+  console.log('  slope review run --json | # pass to Agent tool prompts');
+  console.log('');
+}

--- a/src/cli/commands/review-state.ts
+++ b/src/cli/commands/review-state.ts
@@ -477,8 +477,13 @@ export async function reviewStateCommand(args: string[]): Promise<void> {
     case 'resolve':
       resolveCommand(args.slice(1), cwd);
       break;
+    case 'run': {
+      const { reviewRunCommand } = await import('./review-run.js');
+      await reviewRunCommand(args.slice(1));
+      break;
+    }
     default:
-      console.error(`Unknown review subcommand: ${sub}. Use start, round, status, reset, recommend, findings, amend, defer, deferred, resolve.`);
+      console.error(`Unknown review subcommand: ${sub}. Use start, round, status, reset, recommend, findings, amend, defer, deferred, resolve, run.`);
       process.exit(1);
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -117,7 +117,7 @@ switch (subcommand) {
   case 'review': {
     const reviewArgs = process.argv.slice(3);
     const reviewSub = reviewArgs[0];
-    if (['start', 'round', 'status', 'reset', 'recommend', 'findings', 'amend', 'defer', 'deferred', 'resolve'].includes(reviewSub)) {
+    if (['start', 'round', 'status', 'reset', 'recommend', 'findings', 'amend', 'defer', 'deferred', 'resolve', 'run'].includes(reviewSub)) {
       reviewStateCommand(reviewArgs).catch(err => {
         console.error('Error:', err.message);
         process.exit(1);

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -30,7 +30,7 @@ export interface CliCommandMeta {
 }
 
 /** Command files that are internal implementation modules, not user-invocable top-level commands. */
-export const CLI_INTERNAL_MODULES = ['phase', 'review-state'] as const;
+export const CLI_INTERNAL_MODULES = ['phase', 'review-state', 'review-run'] as const;
 
 export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
   // ── Lifecycle ──────────────────────────────────────────────────
@@ -150,6 +150,12 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
         { flag: 'clear', desc: 'Clear all findings' },
       ]},
       { name: 'amend', desc: 'Inject review findings as hazards into scorecard' },
+      { name: 'run', desc: 'Generate subagent review prompts from PR diff', flags: [
+        { flag: '--pr=<N>', desc: 'PR number (default: current branch)' },
+        { flag: '--type=<type>', desc: 'Review type: architect, code, or both (default: both)' },
+        { flag: '--sprint=<N>', desc: 'Sprint number for findings' },
+        { flag: '--json', desc: 'Output as JSON for programmatic use' },
+      ]},
     ],
     flags: [
       { flag: '--metaphor=<id>', desc: 'Display theme override' },


### PR DESCRIPTION
## Summary
New `slope review run` command generates isolated review prompts from PR diffs
for use with Claude Code's Agent tool. Each review subagent works from clean
context — just the diff and changed files, no implementation memory.

### Usage
```bash
slope review run                          # both architect + code for current branch PR
slope review run --pr=225 --type=code     # code review only for PR #225
slope review run --json                   # machine-readable for programmatic use
```

The prompts include `slope review findings add` commands so findings flow directly
into the scorecard amendment pipeline.

Addresses feature request in #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `slope review run` CLI command to generate structured PR review prompts
  * Supports configurable review types: architect, code, or both
  * Options: `--pr` (PR number), `--sprint` (sprint number), `--type`, and `--json` (JSON output format)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->