### PR TITLE
chore: bump version to 1.39.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump 1.38.0 to 1.39.0