### PR TITLE
feat: make workflow engine the default sprint path

### DIFF
--- a/src/cli/guards/session-briefing.ts
+++ b/src/cli/guards/session-briefing.ts
@@ -35,10 +35,25 @@ export async function sessionBriefingGuard(input: HookInput, cwd: string): Promi
       .map(([name, done]) => `${done ? '[x]' : '[ ]'} ${name}`)
       .join('  ');
     lines.push(`Sprint: S${sprintState.sprint}  Phase: ${sprintState.phase}  Gates: ${gateStatus}`);
+
+    // Nudge if no workflow execution is active
+    try {
+      const { SqliteSlopeStore } = await import('../../store/index.js');
+      const storePath = join(cwd, '.slope/slope.db');
+      if (existsSync(storePath)) {
+        const store = new SqliteSlopeStore(storePath);
+        const executions = await store.listExecutions({ status: 'running' });
+        store.close();
+        if (executions.length === 0) {
+          lines.push('No workflow execution active. Consider: slope sprint run --workflow=sprint-standard --var sprint_id=S' + sprintState.sprint);
+        }
+      }
+    } catch { /* store unavailable */ }
   } else if (isPlanning) {
     setSessionMode(cwd, sessionId, 'sprint');
     lines.push(`Sprint: S${sprintState!.sprint}  Phase: planning`);
-    lines.push('Reminder: Use EnterPlanMode and write the sprint plan as a file. The review-tier and workflow-gate guards only fire in plan mode — describing the plan in prose skips the review loop.');
+    lines.push('Start with: slope sprint run --workflow=sprint-standard --var sprint_id=S' + sprintState!.sprint);
+    lines.push('Then enter plan mode to write the sprint plan — review guards require plan mode to fire.');
   } else {
     setSessionMode(cwd, sessionId, 'adhoc');
     lines.push('No active sprint. Session mode: adhoc (sprint-workflow guards silenced).');

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -77,6 +77,8 @@ export interface SlopeConfig {
     runtime?: string;
   };
   slopeVersion?: string;
+  /** Default workflow for sprint execution (e.g., 'sprint-standard', 'sprint-lightweight') */
+  defaultWorkflow?: string;
 }
 
 const DEFAULT_CONFIG: SlopeConfig = {
@@ -94,6 +96,7 @@ const DEFAULT_CONFIG: SlopeConfig = {
   repoProfilePath: '.slope/repo-profile.json',
   transcriptsPath: '.slope/transcripts',
   metaphor: 'golf',
+  defaultWorkflow: 'sprint-standard',
 };
 
 const CONFIG_DIR = '.slope';

--- a/templates/claude-code/commands/start-sprint.md
+++ b/templates/claude-code/commands/start-sprint.md
@@ -39,9 +39,17 @@ If you know the sprint's work area, add filters:
 slope briefing --categories=<area> --keywords=<topic>
 ```
 
-### 5. Initialize sprint state
+### 5. Start sprint with workflow engine
 
-Run `slope sprint start --number={N}` to create the sprint state file with gate tracking.
+Run `slope sprint run --workflow=sprint-standard --var sprint_id=S{N}` to start a workflow-controlled sprint.
+
+This activates the workflow engine which:
+- Controls step ordering (plan → review → implement → validate → score)
+- The `workflow-step-gate` guard blocks file edits outside of `agent_work` steps
+- State persists in the store — resume with `slope sprint resume` if interrupted
+- Skip steps with `slope sprint skip` if not applicable
+
+If no workflow is needed (simple fix or chore), use `slope sprint run --workflow=sprint-lightweight`.
 
 ### 6. Write sprint plan in plan mode
 


### PR DESCRIPTION
## Problem
Projects with SLOPE installed still use legacy guard-only approach. The workflow
engine (S67) is opt-in and never activated by default.

## Fix
- `defaultWorkflow: 'sprint-standard'` in SlopeConfig defaults
- `/start-sprint` template now uses `slope sprint run --workflow=sprint-standard`
- Session-briefing guard nudges when active sprint has no workflow execution
- Planning phase shows the workflow run command

Existing projects keep working (config field is optional). New installs and
updated templates guide toward workflow-controlled execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)