### PR TITLE
feat(S79): add plan review phase to workflow definitions

### DIFF
--- a/docs/backlog/sprint-79-plan.md
+++ b/docs/backlog/sprint-79-plan.md
@@ -1,0 +1,52 @@
+# Sprint 79 Plan — The Playbook (Workflow Plan Review Phase)
+
+**Par:** 3 (3 tickets)
+**Slope:** 1 (modifying YAML workflow definitions + test updates)
+**Theme:** Add explicit plan review phase to workflow definitions so the review loop is enforced by the engine, not just by guards
+
+## Problem
+
+sprint-standard workflow goes: briefing → verify → per_ticket (implement). No plan review step exists. The review-tier/workflow-gate guards handle plan review via plan mode, but:
+- If the agent doesn't enter plan mode, reviews are silently skipped
+- The workflow engine doesn't enforce plan creation before implementation
+- S78 demonstrated this: we jumped straight from verify to implementation
+
+## Tickets
+
+### T1: Add plan_review phase to sprint-standard.yaml
+**Club:** short_iron
+**Files:** `src/core/workflows/sprint-standard.yaml`, `tests/core/workflow-builtins.test.ts`
+
+Add between `pre_hole` and `per_ticket`:
+```yaml
+- id: plan_review
+  steps:
+    - id: write_plan
+      type: agent_work
+      prompt: "Write the sprint plan as a file in docs/backlog/"
+      rules:
+        - "Use EnterPlanMode before writing"
+        - "Include ticket list, clubs, approach, hazard watch"
+      blocks_next: true
+    - id: review_plan
+      type: agent_input
+      prompt: "Review the plan — tier determined by review-tier guard"
+      required_fields:
+        - review_tier
+        - review_complete
+    - id: revise_plan
+      type: agent_work
+      prompt: "Address review findings if any"
+```
+
+### T2: Add plan_review phase to sprint-autonomous.yaml
+**Club:** wedge
+**Files:** `src/core/workflows/sprint-autonomous.yaml`, `tests/core/workflow-builtins.test.ts`
+
+Same structure but with `on_timeout: skip` so autonomous agents don't block on review input.
+
+### T3: Document sprint-lightweight as explicitly review-free
+**Club:** putter
+**Files:** `src/core/workflows/sprint-lightweight.yaml`
+
+Add a comment making it explicit that lightweight intentionally skips plan review. No code change, just documentation.

--- a/src/core/workflows/sprint-autonomous.yaml
+++ b/src/core/workflows/sprint-autonomous.yaml
@@ -25,6 +25,17 @@ phases:
         command: slope briefing --sprint=${sprint_id}
         checkpoint: exit_code_0
 
+  # --- Plan: Generate execution plan (no review gate for autonomous) ---
+  - id: plan
+    steps:
+      - id: generate_plan
+        type: agent_work
+        prompt: "Generate an execution plan for each ticket. Identify files, approach, and risks. No review gate — autonomous agents proceed directly."
+        rules:
+          - "Plan is for agent self-orientation, not human review"
+          - "Identify primary files and test files for each ticket"
+        blocks_next: true
+
   # --- Per-Ticket: Execute each ticket ---
   - id: per_ticket
     repeat_for: tickets

--- a/src/core/workflows/sprint-lightweight.yaml
+++ b/src/core/workflows/sprint-lightweight.yaml
@@ -1,6 +1,10 @@
 # SLOPE Sprint Lightweight Workflow
 # Minimal gates: implement → validate → done.
 # Use for quick fixes, docs-only sprints, or when full ceremony isn't needed.
+#
+# NOTE: This workflow INTENTIONALLY skips plan review.
+# Use sprint-standard if plan review is needed.
+# Choosing lightweight is an explicit decision to trade ceremony for speed.
 name: sprint-lightweight
 version: "1"
 description: Minimal workflow — implement, validate, done

--- a/src/core/workflows/sprint-standard.yaml
+++ b/src/core/workflows/sprint-standard.yaml
@@ -1,8 +1,8 @@
 # SLOPE Sprint Standard Workflow
-# Full lifecycle: briefing → tickets → scorecard → review
+# Full lifecycle: briefing → plan review → tickets → scorecard → review
 name: sprint-standard
 version: "1"
-description: Standard sprint lifecycle with pre-hole, per-ticket, and post-hole phases
+description: Standard sprint lifecycle with pre-hole, plan review, per-ticket, and post-hole phases
 
 variables:
   sprint_id:
@@ -28,6 +28,28 @@ phases:
         prompt: Verify previous sprint scorecard exists
         conditions:
           - previous_scorecard_exists
+
+  # --- Plan Review: Write and review the sprint plan ---
+  - id: plan_review
+    steps:
+      - id: write_plan
+        type: agent_work
+        prompt: "Write the sprint plan as a file in docs/backlog/. Use EnterPlanMode before writing. Include ticket list, clubs, approach, and hazard watch for each ticket."
+        rules:
+          - "Enter plan mode before writing the plan file"
+          - "Plan file triggers review-tier guard which determines review tier"
+        blocks_next: true
+
+      - id: review_plan
+        type: agent_input
+        prompt: "Review the plan. The review-tier guard determines the tier (skip/light/standard/deep). Complete required review rounds before proceeding."
+        required_fields:
+          - review_tier
+          - review_complete
+
+      - id: revise_plan
+        type: agent_work
+        prompt: "Address review findings if any. Skip if no findings or review tier was skip."
 
   # --- Per-Ticket: Execute each ticket ---
   - id: per_ticket

--- a/tests/core/workflow-builtins.test.ts
+++ b/tests/core/workflow-builtins.test.ts
@@ -15,12 +15,13 @@ describe('Built-in workflows', () => {
     it('has required structure', () => {
       const def = loadWorkflow('sprint-standard', cwd);
 
-      // Should have 3 phases
-      expect(def.phases).toHaveLength(3);
+      // Should have 4 phases (pre_hole, plan_review, per_ticket, post_hole)
+      expect(def.phases).toHaveLength(4);
 
       // Phase IDs
       const phaseIds = def.phases.map(p => p.id);
       expect(phaseIds).toContain('pre_hole');
+      expect(phaseIds).toContain('plan_review');
       expect(phaseIds).toContain('per_ticket');
       expect(phaseIds).toContain('post_hole');
 
@@ -67,8 +68,12 @@ describe('Built-in workflows', () => {
       expect(result.errors).toHaveLength(0);
     });
 
-    it('has per_ticket phase with repeat_for and timeout', () => {
+    it('has plan and per_ticket phases', () => {
       const def = loadWorkflow('sprint-autonomous', cwd);
+      const phaseIds = def.phases.map(p => p.id);
+      expect(phaseIds).toContain('plan');
+      expect(phaseIds).toContain('per_ticket');
+
       const perTicket = def.phases.find(p => p.id === 'per_ticket')!;
       expect(perTicket.repeat_for).toBe('tickets');
       expect(perTicket.on_timeout).toBe('log_blocker_and_skip');

--- a/tests/core/workflow-integration.test.ts
+++ b/tests/core/workflow-integration.test.ts
@@ -39,7 +39,15 @@ describe('Full workflow execution E2E', () => {
     expect(next.step!.id).toBe('verify_previous');
     await engine.complete(exec.id, 'verify_previous', {}, resolved, store);
 
-    // Phase 2: per_ticket — T1
+    // Phase 2: plan_review
+    next = await engine.next(exec.id, resolved, store);
+    expect(next.phase).toBe('plan_review');
+    expect(next.step!.id).toBe('write_plan');
+    await engine.complete(exec.id, 'write_plan', {}, resolved, store);
+    await engine.complete(exec.id, 'review_plan', { output: { review_tier: 'skip', review_complete: true } }, resolved, store);
+    await engine.complete(exec.id, 'revise_plan', {}, resolved, store);
+
+    // Phase 3: per_ticket — T1
     next = await engine.next(exec.id, resolved, store);
     expect(next.phase).toBe('per_ticket');
     expect(next.current_item).toBe('T1');
@@ -69,7 +77,7 @@ describe('Full workflow execution E2E', () => {
     // Verify final state
     const final = await store.getExecution(exec.id);
     expect(final!.status).toBe('completed');
-    expect(final!.completed_steps.length).toBe(11); // 2 + 3*2 + 3
+    expect(final!.completed_steps.length).toBe(14); // 2 + 3 (plan_review) + 3*2 + 3
   });
 });
 
@@ -216,7 +224,13 @@ describe('Full workflow execution E2E — sprint-autonomous', () => {
     expect(next.step!.command).toContain('slope briefing');
     await engine.complete(exec.id, 'briefing', { exit_code: 0 }, resolved, store);
 
-    // Phase 2: per_ticket — T1
+    // Phase 2: plan — generate execution plan
+    next = await engine.next(exec.id, resolved, store);
+    expect(next.phase).toBe('plan');
+    expect(next.step!.id).toBe('generate_plan');
+    await engine.complete(exec.id, 'generate_plan', {}, resolved, store);
+
+    // Phase 3: per_ticket — T1
     next = await engine.next(exec.id, resolved, store);
     expect(next.phase).toBe('per_ticket');
     expect(next.current_item).toBe('T1');
@@ -227,7 +241,7 @@ describe('Full workflow execution E2E — sprint-autonomous', () => {
     expect(next.step!.id).toBe('verify');
     await engine.complete(exec.id, 'verify', { exit_code: 0 }, resolved, store);
 
-    // Phase 2: per_ticket — T2
+    // Phase 3: per_ticket — T2
     next = await engine.next(exec.id, resolved, store);
     expect(next.current_item).toBe('T2');
     expect(next.step!.id).toBe('implement');
@@ -249,7 +263,7 @@ describe('Full workflow execution E2E — sprint-autonomous', () => {
     // Verify final state
     const final = await store.getExecution(exec.id);
     expect(final!.status).toBe('completed');
-    expect(final!.completed_steps.length).toBe(7); // 1 + 2*2 + 2
+    expect(final!.completed_steps.length).toBe(8); // 1 + 1 (plan) + 2*2 + 2
   });
 
   it('uses default model variable when not provided', async () => {


### PR DESCRIPTION
## Summary

Adds explicit plan review phase to sprint workflows so the review loop is enforced
by the engine, not just by guards.

- **sprint-standard**: New `plan_review` phase (write_plan → review_plan → revise_plan)
  between pre_hole and per_ticket
- **sprint-autonomous**: New `plan` phase (generate_plan) for self-orientation
- **sprint-lightweight**: Documented as intentionally review-free

Addresses the gap found in S78: workflow jumped straight from verify to implementation
with no plan review enforced.

## Test plan
- [x] 18 workflow tests updated and passing (builtins + integration)
- [x] Full suite: 2932 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added plan review phase to standard sprint workflow with write, review, and revise steps
  * Added plan generation phase to autonomous sprint workflow with timeout handling
  * Updated lightweight workflow documentation to clarify review-free execution approach

* **Tests**
  * Updated workflow integration tests to reflect new planning phases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->