### PR TITLE
fix: snapshot workflow definition at execution start (#235)

### DIFF
--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -10,6 +10,26 @@ import {
   type SprintPhase,
 } from '../sprint-state.js';
 import { WorkflowEngine, loadWorkflow, resolveVariables, validateWorkflow, loadConfig } from '../../core/index.js';
+import type { WorkflowDefinition, WorkflowExecution } from '../../core/index.js';
+import { createHash } from 'node:crypto';
+
+/** Get workflow definition from execution snapshot (preferred) or disk (fallback for old executions) */
+function getDefinition(exec: WorkflowExecution, cwd: string): { def: WorkflowDefinition; drifted: boolean } {
+  // Prefer snapshot from execution
+  if (exec.definition_json) {
+    const def = JSON.parse(exec.definition_json) as WorkflowDefinition;
+    // Check if current YAML has drifted
+    let drifted = false;
+    try {
+      const current = loadWorkflow(exec.workflow_name, cwd);
+      const currentHash = createHash('sha256').update(JSON.stringify(current)).digest('hex').slice(0, 16);
+      drifted = exec.definition_hash !== currentHash;
+    } catch { /* workflow file might be gone — that's fine, we have the snapshot */ }
+    return { def, drifted };
+  }
+  // Fallback for old executions without snapshot
+  return { def: loadWorkflow(exec.workflow_name, cwd), drifted: false };
+}
 import { createStore } from '../../store/index.js';
 
 const VALID_GATES: GateName[] = ['tests', 'code_review', 'architect_review', 'scorecard', 'review_md'];
@@ -225,7 +245,8 @@ async function resumeCommand(args: string[], cwd: string): Promise<void> {
       process.exit(1);
     }
 
-    const def = loadWorkflow(exec.workflow_name, cwd);
+    const { def, drifted } = getDefinition(exec, cwd);
+    if (drifted) console.log(`\x1b[33m⚠ Workflow definition has changed since this execution started. Using snapshot from start.\x1b[0m`);
     const resolved = resolveVariables(def, exec.variables);
     const engine = new WorkflowEngine();
 
@@ -275,7 +296,8 @@ async function skipCommand(args: string[], cwd: string): Promise<void> {
       process.exit(1);
     }
 
-    const def = loadWorkflow(exec.workflow_name, cwd);
+    const { def, drifted } = getDefinition(exec, cwd);
+    if (drifted) console.log(`\x1b[33m⚠ Workflow definition has changed since this execution started. Using snapshot from start.\x1b[0m`);
     const resolved = resolveVariables(def, exec.variables);
     const engine = new WorkflowEngine();
     const result = await engine.skip(exec.id, stepId, reason, resolved, store);

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -71,7 +71,7 @@ export interface SlopeStore extends SprintRegistry {
   getTestingFindings(sessionId: string): Promise<Array<{ id: string; description: string; severity: string; ticket?: string; created_at: string }>>;
 
   // Workflow executions
-  startExecution(params: { workflow_name: string; sprint_id?: string; variables?: Record<string, string>; session_id?: string }): Promise<WorkflowExecution>;
+  startExecution(params: { workflow_name: string; sprint_id?: string; variables?: Record<string, string>; session_id?: string; definition_json?: string; definition_hash?: string }): Promise<WorkflowExecution>;
   getExecution(executionId: string): Promise<WorkflowExecution | null>;
   getExecutionBySprint(sprintId: string): Promise<WorkflowExecution | null>;
   updateExecutionState(executionId: string, phase: string, step: string): Promise<void>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -456,6 +456,10 @@ export interface WorkflowExecution {
   started_at: string;
   updated_at: string;
   session_id?: string;
+  /** Snapshot of the workflow definition at execution start (prevents definition drift) */
+  definition_json?: string;
+  /** Hash of the definition at start — used to detect if YAML changed since execution began */
+  definition_hash?: string;
 }
 
 /** Result of a single workflow step execution */

--- a/src/core/workflow-engine.ts
+++ b/src/core/workflow-engine.ts
@@ -83,11 +83,18 @@ export class WorkflowEngine {
       throw new Error(`Phase "${firstPhase.id}" has no steps`);
     }
 
+    // Snapshot the definition at start to prevent definition drift
+    const definitionJson = JSON.stringify(def);
+    const { createHash } = await import('node:crypto');
+    const definitionHash = createHash('sha256').update(definitionJson).digest('hex').slice(0, 16);
+
     const execution = await store.startExecution({
       workflow_name: def.name,
       sprint_id: opts.sprint_id,
       variables: opts.variables,
       session_id: opts.session_id,
+      definition_json: definitionJson,
+      definition_hash: definitionHash,
     });
 
     // Position at first step

--- a/src/store-pg/index.ts
+++ b/src/store-pg/index.ts
@@ -639,7 +639,7 @@ export class PostgresSlopeStore implements SlopeStore {
 
   // --- Workflow Executions ---
 
-  async startExecution(params: { workflow_name: string; sprint_id?: string; variables?: Record<string, string>; session_id?: string }): Promise<WorkflowExecution> {
+  async startExecution(params: { workflow_name: string; sprint_id?: string; variables?: Record<string, string>; session_id?: string; definition_json?: string; definition_hash?: string }): Promise<WorkflowExecution> {
     const id = generateId('wf');
     const now = nowISO();
     const execution: WorkflowExecution = {
@@ -654,11 +654,13 @@ export class PostgresSlopeStore implements SlopeStore {
       started_at: now,
       updated_at: now,
       session_id: params.session_id,
+      definition_json: params.definition_json,
+      definition_hash: params.definition_hash,
     };
 
     await this.pool.query(`
-      INSERT INTO workflow_executions (id, project_id, workflow_name, sprint_id, current_phase, current_step, status, variables, completed_steps, started_at, updated_at, session_id)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      INSERT INTO workflow_executions (id, project_id, workflow_name, sprint_id, current_phase, current_step, status, variables, completed_steps, started_at, updated_at, session_id, definition_json, definition_hash)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
     `, [
       execution.id,
       this.projectId,
@@ -672,6 +674,8 @@ export class PostgresSlopeStore implements SlopeStore {
       execution.started_at,
       execution.updated_at,
       execution.session_id ?? null,
+      execution.definition_json ?? null,
+      execution.definition_hash ?? null,
     ]);
 
     return execution;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -181,6 +181,13 @@ const MIGRATIONS: Array<{ version: number; sql: string }> = [
       CREATE INDEX IF NOT EXISTS idx_wf_step_exec ON workflow_step_results(execution_id);
     `,
   },
+  {
+    version: 7,
+    sql: `
+      ALTER TABLE workflow_executions ADD COLUMN definition_json TEXT;
+      ALTER TABLE workflow_executions ADD COLUMN definition_hash TEXT;
+    `,
+  },
 ];
 
 /** Latest schema version — total number of migrations available. */
@@ -584,7 +591,7 @@ export class SqliteSlopeStore implements SlopeStore, EmbeddingStore {
 
   // --- Workflow Executions ---
 
-  async startExecution(params: { workflow_name: string; sprint_id?: string; variables?: Record<string, string>; session_id?: string }): Promise<WorkflowExecution> {
+  async startExecution(params: { workflow_name: string; sprint_id?: string; variables?: Record<string, string>; session_id?: string; definition_json?: string; definition_hash?: string }): Promise<WorkflowExecution> {
     const id = generateId('wf');
     const now = nowISO();
     const execution: WorkflowExecution = {
@@ -599,11 +606,13 @@ export class SqliteSlopeStore implements SlopeStore, EmbeddingStore {
       started_at: now,
       updated_at: now,
       session_id: params.session_id,
+      definition_json: params.definition_json,
+      definition_hash: params.definition_hash,
     };
 
     this.db.prepare(`
-      INSERT INTO workflow_executions (id, workflow_name, sprint_id, current_phase, current_step, status, variables, completed_steps, started_at, updated_at, session_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO workflow_executions (id, workflow_name, sprint_id, current_phase, current_step, status, variables, completed_steps, started_at, updated_at, session_id, definition_json, definition_hash)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       execution.id,
       execution.workflow_name,
@@ -616,6 +625,8 @@ export class SqliteSlopeStore implements SlopeStore, EmbeddingStore {
       execution.started_at,
       execution.updated_at,
       execution.session_id ?? null,
+      execution.definition_json ?? null,
+      execution.definition_hash ?? null,
     );
 
     return execution;
@@ -930,6 +941,8 @@ function rowToExecution(row: Record<string, unknown>): WorkflowExecution {
     started_at: row.started_at as string,
     updated_at: row.updated_at as string,
     session_id: (row.session_id as string | null) ?? undefined,
+    definition_json: (row.definition_json as string | null) ?? undefined,
+    definition_hash: (row.definition_hash as string | null) ?? undefined,
   };
 }
 

--- a/tests/cli/store.test.ts
+++ b/tests/cli/store.test.ts
@@ -108,7 +108,7 @@ describe('slope store status', () => {
 
     const parsed = JSON.parse(output);
     expect(parsed.type).toBe('sqlite');
-    expect(parsed.schemaVersion).toBe(6);
+    expect(parsed.schemaVersion).toBe(7);
     expect(typeof parsed.sessions).toBe('number');
     expect(typeof parsed.claims).toBe('number');
     expect(typeof parsed.scorecards).toBe('number');
@@ -117,7 +117,7 @@ describe('slope store status', () => {
 });
 
 describe('slope store migrate status', () => {
-  it('shows version 6 and up to date', async () => {
+  it('shows version 7 and up to date', async () => {
     const logs: string[] = [];
     const spy = vi.spyOn(console, 'log').mockImplementation((...args) => { logs.push(args.join(' ')); });
 
@@ -126,8 +126,8 @@ describe('slope store migrate status', () => {
     const output = logs.join('\n');
     spy.mockRestore();
 
-    expect(output).toContain('Current schema version: 6');
-    expect(output).toContain('Total migrations:       6');
+    expect(output).toContain('Current schema version: 7');
+    expect(output).toContain('Total migrations:       7');
     expect(output).toContain('up to date');
   });
 });

--- a/tests/core/store-health.test.ts
+++ b/tests/core/store-health.test.ts
@@ -23,7 +23,7 @@ describe('checkStoreHealth', () => {
     const result = await checkStoreHealth(store, 'sqlite');
     expect(result.healthy).toBe(true);
     expect(result.type).toBe('sqlite');
-    expect(result.schemaVersion).toBe(6);
+    expect(result.schemaVersion).toBe(7);
     expect(result.stats.sessions).toBe(0);
     expect(result.stats.claims).toBe(0);
     expect(result.stats.scorecards).toBe(0);


### PR DESCRIPTION
Prevents definition drift when YAML is modified mid-execution. Stores definition snapshot + hash at start, uses snapshot for all subsequent operations. Warns when YAML has changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflow definitions are now captured and snapshotted when executions begin
  * Detects and warns users when workflow definitions change during active executions
  * Uses captured definition snapshot instead of reloading modified definitions from disk

<!-- end of auto-generated comment: release notes by coderabbit.ai -->