### PR TITLE
fix: scaffold workflows on init + per-push next-action (#228, #238)

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -858,6 +858,22 @@ export async function initCommand(args: string[]): Promise<void> {
 
   const configPath = createConfig(cwd);
 
+  // Scaffold .slope/workflows/ with built-in workflow stubs
+  const workflowsDir = join(cwd, '.slope', 'workflows');
+  mkdirSync(workflowsDir, { recursive: true });
+  const builtinDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'core', 'workflows');
+  if (existsSync(builtinDir)) {
+    const yamlFiles = ['sprint-standard.yaml', 'sprint-autonomous.yaml', 'sprint-lightweight.yaml'];
+    for (const file of yamlFiles) {
+      const src = join(builtinDir, file);
+      const dest = join(workflowsDir, file);
+      if (existsSync(src) && !existsSync(dest)) {
+        cpSync(src, dest);
+        console.log(`  Created ${dest}`);
+      }
+    }
+  }
+
   // Apply metaphor and team config
   const configData = JSON.parse(readFileSync(configPath, 'utf8'));
   configData.metaphor = metaphor.id;

--- a/src/cli/guards/post-push.ts
+++ b/src/cli/guards/post-push.ts
@@ -20,15 +20,20 @@ export async function postPushGuard(input: HookInput, cwd: string): Promise<Guar
   const exitCode = response.exit_code ?? response.exitCode;
   if (exitCode !== 0 && exitCode !== '0' && exitCode !== undefined) return {};
 
-  // Session dedup: fire once per session
+  // Dedup: fire once per push (track push count, not session boolean)
   const sessionId = input.session_id;
   if (!sessionId) return {};
 
   const sessionState = loadSessionState(cwd);
-  if (sessionState.push_prompted_session_id === sessionId) return {};
+  const pushCount = parseInt(sessionState.push_count ?? '0', 10) || 0;
+  const lastPushCmd = sessionState.last_push_command as string | undefined;
 
-  // Mark as prompted
-  updateSessionState(cwd, 'push_prompted_session_id', sessionId);
+  // Skip if this is the same push command repeated (e.g., retry)
+  if (lastPushCmd === command) return {};
+
+  // Track the push
+  updateSessionState(cwd, 'push_count', String(pushCount + 1));
+  updateSessionState(cwd, 'last_push_command', command);
 
   // Determine workflow context
   const sprintState = loadSprintState(cwd);

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -9,8 +9,12 @@ export type SessionMode = 'sprint' | 'adhoc';
 interface SessionState {
   /** Session ID for the briefing guard */
   briefing_session_id?: string;
-  /** Session ID for the post-push guard */
+  /** Session ID for the post-push guard (legacy — kept for backward compat) */
   push_prompted_session_id?: string;
+  /** Number of pushes in current session (stored as string) */
+  push_count?: string;
+  /** Last push command string (dedup repeated retries) */
+  last_push_command?: string;
   /** Session ID for the claim-required guard */
   claim_warned_session_id?: string;
   /** Session ID for handoff read in explore guard */


### PR DESCRIPTION
Two fixes: slope init now scaffolds .slope/workflows/ with built-in stubs, and post-push guard fires per push instead of once per session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Built-in workflow templates (sprint-standard, sprint-autonomous, sprint-lightweight) are now automatically scaffolded during workspace initialization.

* **Bug Fixes**
  * Improved push command retry handling to more accurately detect and prevent duplicate prompts when the same command is retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->