### PR TITLE
fix: stop hook non-blocking — don't interrupt background agents

### DIFF
--- a/src/cli/guards/next-action.ts
+++ b/src/cli/guards/next-action.ts
@@ -205,7 +205,7 @@ export function buildSuggestionObject(state: SprintState): Suggestion {
           { id: 'push-break', label: 'Push and take a break', description: 'Resume later' },
           { id: 'end', label: 'End session', description: 'Nothing more to do right now' },
         ],
-        requiresDecision: true,
+        requiresDecision: false,
         priority: 'normal',
       };
     }
@@ -221,7 +221,7 @@ export function buildSuggestionObject(state: SprintState): Suggestion {
           { id: 'distill', label: 'Distill learnings', command: 'slope distill --auto' },
           { id: 'end', label: 'End session', description: 'Nothing more to do right now' },
         ],
-        requiresDecision: true,
+        requiresDecision: false,
         priority: 'normal',
       };
 
@@ -235,7 +235,7 @@ export function buildSuggestionObject(state: SprintState): Suggestion {
           { id: 'distill', label: 'Distill learnings', command: 'slope distill --auto' },
           { id: 'end', label: 'End session', description: 'Nothing more to do right now' },
         ],
-        requiresDecision: true,
+        requiresDecision: false,
         priority: 'normal',
       };
 
@@ -249,7 +249,7 @@ export function buildSuggestionObject(state: SprintState): Suggestion {
           { id: 'list', label: 'View findings first', command: 'slope review findings list' },
           { id: 'end', label: 'End session', description: 'Nothing more to do right now' },
         ],
-        requiresDecision: true,
+        requiresDecision: false,
         priority: 'normal',
       };
 
@@ -263,7 +263,7 @@ export function buildSuggestionObject(state: SprintState): Suggestion {
           { id: 'end-testing', label: 'End testing session' },
           { id: 'end', label: 'End session', description: 'Nothing more to do right now' },
         ],
-        requiresDecision: true,
+        requiresDecision: false,
         priority: 'normal',
       };
 
@@ -281,7 +281,7 @@ export function buildSuggestionObject(state: SprintState): Suggestion {
           { id: 'briefing', label: 'Run briefing', command: 'slope briefing' },
           { id: 'end', label: 'End session', description: 'Nothing more to do right now' },
         ],
-        requiresDecision: true,
+        requiresDecision: false,
         priority: 'normal',
       };
     }

--- a/tests/cli/next-action.test.ts
+++ b/tests/cli/next-action.test.ts
@@ -172,7 +172,7 @@ describe('buildSuggestionObject', () => {
     expect(suggestion.id).toBe('next-action-mid-sprint');
     expect(suggestion.context).toContain('S26-1, S26-2');
     expect(suggestion.options.map(o => o.label)).toContain('Continue with the next ticket');
-    expect(suggestion.requiresDecision).toBe(true);
+    expect(suggestion.requiresDecision).toBe(false);
   });
 
   it('includes scoring options for sprint-complete', () => {


### PR DESCRIPTION
Stop hook suggestions changed from blocking (requiresDecision: true) to advisory (false). Prevents interrupting agents waiting for background subagents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decision requirement flags for action suggestions across all sprint and workflow states to accurately reflect current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->