### PR TITLE
fix: stop-check guard — worktree merge ancestors + untracked files (#255)

### DIFF
--- a/src/cli/guards/stop-check.ts
+++ b/src/cli/guards/stop-check.ts
@@ -116,9 +116,8 @@ export async function stopCheckGuard(_input: HookInput, cwd: string): Promise<Gu
       if (sessionModified.length > 0) {
         warningIssues.push(`${sessionModified.length} uncommitted change${sessionModified.length === 1 ? '' : 's'}`);
       }
-      if (sessionUntracked.length > 0) {
-        warningIssues.push(`${sessionUntracked.length} untracked file${sessionUntracked.length === 1 ? '' : 's'}`);
-      }
+      // Untracked files are informational only — don't block session end
+      // (agents frequently create temp files, .slope state files, etc.)
       if (preExistingCount > 0) {
         warningIssues.push(`${preExistingCount} pre-existing dirty file${preExistingCount === 1 ? '' : 's'} (not from this session)`);
       }
@@ -126,15 +125,19 @@ export async function stopCheckGuard(_input: HookInput, cwd: string): Promise<Gu
   } catch { /* not a git repo */ }
 
   // Check for unpushed commits
-  // Skip if HEAD is already on origin/main (e.g., after squash merge + reset)
-  // The tracking branch (@{u}) may be stale after squash merges, causing false positives
+  // Use origin/<branch> explicitly + --first-parent to avoid counting merge ancestors
+  // in worktrees (#255: git log @{u}..HEAD traverses merged branch history)
   if (!headIsOnMain(gitDir)) {
     try {
-      const unpushed = execSync('git log @{u}..HEAD --oneline 2>/dev/null', { cwd: gitDir, encoding: 'utf8' }).trim();
-      if (unpushed) {
-        const lines = unpushed.split('\n').filter(Boolean);
-        if (lines.length > 0) {
-          blockingIssues.push(`${lines.length} unpushed commit${lines.length === 1 ? '' : 's'}`);
+      const branch = execSync('git rev-parse --abbrev-ref HEAD 2>/dev/null', { cwd: gitDir, encoding: 'utf8' }).trim();
+      const remoteRef = `origin/${branch}`;
+      // Verify remote ref exists before comparing
+      const hasRemote = (() => { try { execSync(`git rev-parse --verify ${remoteRef} 2>/dev/null`, { cwd: gitDir, encoding: 'utf8' }); return true; } catch { return false; } })();
+      if (hasRemote) {
+        const unpushed = execSync(`git rev-list ${remoteRef}..HEAD --first-parent --count 2>/dev/null`, { cwd: gitDir, encoding: 'utf8' }).trim();
+        const count = parseInt(unpushed, 10) || 0;
+        if (count > 0) {
+          blockingIssues.push(`${count} unpushed commit${count === 1 ? '' : 's'}`);
         }
       }
     } catch { /* no upstream */ }
@@ -172,7 +175,7 @@ export async function stopCheckGuard(_input: HookInput, cwd: string): Promise<Gu
   if (warningIssues.length > 0) {
     removeBaseline(_input.session_id, cwd);
     return {
-      context: `SLOPE: ${warningIssues.join(' and ')} detected. Consider committing or cleaning up untracked files.`,
+      context: `SLOPE: ${warningIssues.join(' and ')} detected. Consider committing before stopping.`,
     };
   }
 

--- a/tests/cli/guards.test.ts
+++ b/tests/cli/guards.test.ts
@@ -476,15 +476,14 @@ describe('stopCheckGuard', () => {
     expect(result).toEqual({});
   });
 
-  it('warns but does not block for untracked-only files', async () => {
+  it('ignores untracked-only files (no warning)', async () => {
     const { execSync } = await import('node:child_process');
     execSync('git init && git config user.email "test@test.com" && git config user.name "Test" && git commit -m "init" --allow-empty', { cwd: tmpDir, stdio: 'ignore' });
     writeFileSync(join(tmpDir, 'orphan.txt'), 'untracked');
 
     const result = await stopCheckGuard(makeInput(), tmpDir);
     expect(result.blockReason).toBeUndefined();
-    expect(result.context).toContain('untracked');
-    expect(result.context).toContain('SLOPE');
+    expect(result.context).toBeUndefined();
   });
 
   it('warns but does not block when modified (staged/unstaged) changes exist', async () => {
@@ -499,7 +498,7 @@ describe('stopCheckGuard', () => {
     expect(result.context).toContain('uncommitted');
   });
 
-  it('warns with both uncommitted and untracked when both exist', async () => {
+  it('warns on uncommitted changes but ignores untracked when both exist', async () => {
     const { execSync } = await import('node:child_process');
     execSync('git init && git config user.email "test@test.com" && git config user.name "Test"', { cwd: tmpDir, stdio: 'ignore' });
     writeFileSync(join(tmpDir, 'tracked.txt'), 'original');
@@ -510,7 +509,7 @@ describe('stopCheckGuard', () => {
     const result = await stopCheckGuard(makeInput(), tmpDir);
     expect(result.blockReason).toBeUndefined();
     expect(result.context).toContain('uncommitted');
-    expect(result.context).toContain('untracked');
+    expect(result.context).not.toContain('untracked');
   });
 });
 

--- a/tests/cli/guards/stop-check.test.ts
+++ b/tests/cli/guards/stop-check.test.ts
@@ -51,12 +51,12 @@ describe('stop-check guard', () => {
     expect(result.context).toContain('uncommitted');
   });
 
-  it('warns on untracked files only', async () => {
+  it('ignores untracked files (no warning)', async () => {
     writeFileSync(join(tmpDir, 'new-file.txt'), 'new');
 
     const result = await stopCheckGuard(makeStop(), tmpDir);
     expect(result.blockReason).toBeUndefined();
-    expect(result.context).toContain('untracked');
+    expect(result.context).toBeUndefined();
   });
 
   describe('post-squash-merge scenario', () => {


### PR DESCRIPTION
Prevents stop hook loops in worktrees. Uses origin/<branch>..HEAD --first-parent instead of @{u}..HEAD. Ignores untracked files.