### PR TITLE
fix: README.md missing from npm package display

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "files": [
     "dist",
     "src/core/workflows",
-    "templates"
+    "templates",
+    "README.md"
   ],
   "scripts": {
     "prepare": "tsc",


### PR DESCRIPTION
README was in tarball but not in npm registry metadata. Added to files array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the published package configuration to include the README file in distributed artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->