### PR TITLE
fix(init): make slope init --pi actually copy extension and skills

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -574,6 +574,53 @@ function installOpenCodeMcpConfig(cwd: string): void {
   writeFileSync(mcpPath, JSON.stringify(config, null, 2) + '\n');
 }
 
+function installPiTemplates(cwd: string): void {
+  // Copy compiled extension to .pi/extensions/slope/
+  const extDir = join(cwd, '.pi', 'extensions', 'slope');
+  mkdirSync(extDir, { recursive: true });
+
+  const pkgRoot = getTemplatesRoot(); // <pkg_root>/templates
+  const srcDir = join(pkgRoot, '..', 'packages', 'pi-extension', 'dist');
+  const extFiles = ['index.js', 'index.d.ts'];
+  let extInstalled = 0;
+  for (const file of extFiles) {
+    const src = join(srcDir, file);
+    const dest = join(extDir, file);
+    if (existsSync(src)) {
+      cpSync(src, dest, { force: true });
+      console.log(`  Created/updated ${dest}`);
+      extInstalled++;
+    } else {
+      console.warn(`  Warning: extension source not found: ${src} (package may not be bundled correctly)`);
+    }
+  }
+  if (extInstalled === 0) {
+    console.warn('  Warning: no extension files copied. Pi will rely on global pi.extensions resolution.');
+  }
+
+  // Copy skill templates to .pi/skills/
+  const skillsDir = join(cwd, '.pi', 'skills');
+  mkdirSync(skillsDir, { recursive: true });
+
+  const templatesRoot = join(getTemplatesRoot(), 'pi', 'skills');
+  const skillFiles = ['start-sprint.md', 'post-sprint.md', 'review-pr.md'];
+  let skillsInstalled = 0;
+  for (const file of skillFiles) {
+    const src = join(templatesRoot, file);
+    const dest = join(skillsDir, file);
+    if (!existsSync(src)) {
+      console.warn(`  Warning: skill template not found: ${file} (templates may not be bundled)`);
+      continue;
+    }
+    cpSync(src, dest, { force: true });
+    console.log(`  Created/updated ${dest}`);
+    skillsInstalled++;
+  }
+  if (skillsInstalled === 0) {
+    console.warn('  Warning: no skill templates copied.');
+  }
+}
+
 function installDefaultHooks(cwd: string, provider: InitProvider): void {
   // Import hook templates inline to avoid circular deps
   const SESSION_HOOKS: Record<string, string[]> = {
@@ -664,8 +711,7 @@ function installForProvider(cwd: string, provider: InitProvider, metaphor: Metap
       console.log('    args = ["mcp"]');
       break;
     case 'pi':
-      // Pi adapter registered via side-effect import — use installDefaultHooks
-      installDefaultHooks(cwd, 'pi');
+      installPiTemplates(cwd);
       console.log('\n  Pi: Extension installed to .pi/extensions/slope/');
       console.log('  Pi: Skills copied to .pi/skills/');
       console.log('  Pi: Run /reload in pi to activate');

--- a/templates/pi/skills/post-sprint.md
+++ b/templates/pi/skills/post-sprint.md
@@ -1,0 +1,72 @@
+---
+name: post-sprint
+description: Post-sprint routine. Creates scorecard, validates it, generates review, distills learnings, and prompts for PR.
+---
+
+# Post Sprint
+
+Run the complete post-sprint routine. This automates scorecard creation, validation, review generation, and common-issues distillation.
+
+## Steps
+
+### 1. Determine sprint number and gather context
+
+- Run `slope next` to get the current sprint number, or check for an active sprint with `slope sprint status`
+- Run `git log --oneline` to see all commits in the current sprint (since branching from main)
+- Read the sprint plan if one exists in `docs/backlog/`
+
+### 2. Build the scorecard
+
+For each ticket/commit in this sprint, classify the shot:
+
+- **Ticket key**: Extract from commit messages (e.g., `S21-1`)
+- **Title**: Brief description of what was done
+- **Club**: `driver` (risky/new), `long_iron` (multi-package), `short_iron` (standard), `wedge` (small), `putter` (trivial)
+- **Result**: `fairway`, `green`, `in_the_hole`, or miss direction (`long`/`short`/`left`/`right`)
+- **Hazards**: Any gotchas encountered (check commit messages and PR comments for clues)
+- **Notes**: Key implementation details
+
+Use the SLOPE MCP `execute` tool to build the scorecard programmatically:
+
+```javascript
+const scorecard = buildScorecard({
+  sprint_number: N,
+  theme: "Sprint theme from plan",
+  par: computePar(ticketCount),
+  slope: computeSlope(slopeFactors),
+  date: new Date().toISOString().split('T')[0],
+  shots: [/* classified shots */]
+});
+return JSON.stringify(scorecard, null, 2);
+```
+
+Write the scorecard to `docs/retros/sprint-N.json`.
+
+### 3. Validate
+
+Run `slope validate` to check the scorecard for errors and warnings. Fix any issues.
+
+### 4. Generate review
+
+Run `slope review` to generate the sprint review markdown. Share the output with the user.
+
+### 5. Distill learnings
+
+If any new recurring patterns were encountered during this sprint:
+- Check `.slope/common-issues.json` for existing patterns
+- Add new patterns or update `sprints_hit` arrays for existing ones
+
+### 6. Roadmap status (auto-updated)
+
+Roadmap sprint status is automatically updated to `"complete"` when `slope validate` succeeds (step 3). Verify with `slope roadmap show` if needed.
+
+### 7. Prompt for PR
+
+Ask the user if they'd like to create a PR. If yes, create one with the sprint review as the PR body.
+
+## Important
+
+- Always run `slope validate` after creating the scorecard — never skip this
+- The scorecard must match the actual work done (commits), not the plan
+- Record hazards honestly — they feed the handicap system and improve future guidance
+- If the sprint had review findings, run `slope review amend` after adding findings

--- a/templates/pi/skills/review-pr.md
+++ b/templates/pi/skills/review-pr.md
@@ -1,0 +1,81 @@
+---
+name: review-pr
+description: Structured implementation review with finding tracking and scorecard amendment.
+---
+
+# Review PR
+
+Run a structured implementation review with finding tracking and scorecard amendment.
+
+## Arguments
+
+- First argument — optional PR number, file path, or review tier override (light/standard/deep)
+
+## Steps
+
+### 1. Determine review scope
+
+- If a PR number was provided, use `gh pr view <number>` to get the diff
+- Otherwise, use `git diff main...HEAD` to see all changes on the current branch
+- Count tickets, packages touched, and complexity factors
+
+### 2. Get review recommendations
+
+Run `slope review recommend` to see which review types are suggested based on the sprint characteristics. The output will suggest review types like:
+- `architect` — module boundaries, data model, coupling, integration points
+- `code` — correctness, edge cases, bugs, unused code, runtime safety
+- `security` — auth, injection, secrets, OWASP top 10
+- `ux` — user experience, accessibility, flow coherence
+
+### 3. Start review tracking
+
+Run `slope review start` to initialize review state. This auto-detects the tier from the plan, or you can override with `--tier=<tier>`.
+
+### 4. Run reviews
+
+Launch review agents in parallel based on the recommendations. For each review type:
+
+1. **Code Quality Review** (always): Staff engineer perspective — correctness, edge cases, bugs, unused code, runtime safety, error handling
+2. **Architecture Review** (if recommended): Staff architect perspective — module boundaries, data model extensibility, coupling, constants management, integration points, testing strategy
+3. **Specialist Reviews** (if recommended): Domain-specific reviews based on the sprint's work area
+
+Each review agent should:
+- Read all changed files
+- Analyze against its specialty area
+- Produce findings with: review_type, ticket_key, severity (minor/moderate/major/critical), description
+
+### 5. Record findings
+
+For each finding from the reviews, run:
+
+```
+slope review findings add --type=<type> --ticket=<key> --severity=<sev> --description="<desc>"
+```
+
+### 6. Complete review round
+
+Run `slope review round` to mark the review round complete.
+
+### 7. Amend scorecard
+
+If findings were recorded, run `slope review amend` to inject them as hazards into the scorecard. This may adjust the sprint score.
+
+### 8. Present consolidated results
+
+Present all findings to the user in a table:
+
+| # | Type | Ticket | Severity | Description | Action |
+|---|------|--------|----------|-------------|--------|
+
+For each finding, recommend one of:
+- **Fix now** — fix in the current sprint before merge
+- **Defer** — track with `slope review defer --from=<current> --to=<target> --severity=<sev> --description="<desc>"` for a future sprint
+- **Accept** — acknowledged risk, no action needed
+
+All findings must be explicitly addressed — no unacknowledged findings.
+
+## Important
+
+- Save individual review agent outputs to `docs/reviews/` before consolidating
+- Never skip the `slope review findings add` step — findings feed the handicap system
+- All findings must be addressed (fix, defer, or accept) before the PR can merge

--- a/templates/pi/skills/start-sprint.md
+++ b/templates/pi/skills/start-sprint.md
@@ -1,0 +1,98 @@
+---
+name: start-sprint
+description: Pre-sprint setup and briefing. Verifies prior sprint hygiene, creates branch, runs briefing, and initializes sprint state.
+---
+
+# Start Sprint
+
+Run the complete pre-sprint routine: verify prior sprint hygiene, get briefing, create branch, and initialize sprint state.
+
+## Arguments
+
+- First argument — optional sprint number (auto-detected if omitted)
+
+## Steps
+
+### 1. Determine sprint number
+
+- If a number was provided as an argument, use it
+- Otherwise, run `slope next` to auto-detect the next sprint number
+
+### 2. Verify prior sprint scorecard
+
+Check that the previous sprint's scorecard exists at `docs/retros/sprint-{N-1}.json`:
+- If missing, **stop and create it first** using `/skill:post-sprint`
+- If it exists, continue
+- Note: the sprint-completion guard also enforces this — PR creation is blocked without a scorecard
+
+### 3. Branch hygiene
+
+- Run `git branch` to check for stale branches from prior sprints
+- If stale branches exist, warn the user
+- Create a new feature branch: `feat/sprint-{N}-<theme-slug>`
+
+### 4. Run briefing
+
+Run `slope briefing` to get:
+- Handicap snapshot (rolling performance stats)
+- Hazard index (recent gotchas by area)
+- Filtered common issues relevant to this sprint's work area
+- Session continuity (any handoffs from prior sessions)
+
+If you know the sprint's work area, add filters:
+```
+slope briefing --categories=<area> --keywords=<topic>
+```
+
+### 5. Start sprint with workflow engine
+
+Run `slope sprint run --workflow=sprint-standard --var sprint_id=S{N}` to start a workflow-controlled sprint.
+
+This activates the workflow engine which:
+- Controls step ordering (plan → review → implement → validate → score)
+- The `workflow-step-gate` guard blocks file edits outside of `agent_work` steps
+- State persists in the store — resume with `slope sprint resume` if interrupted
+- Skip steps with `slope sprint skip` if not applicable
+
+If no workflow is needed (simple fix or chore), use `slope sprint run --workflow=sprint-lightweight`.
+
+### 6. Write sprint plan
+
+Write the sprint plan as a markdown file (e.g., `docs/backlog/sprint-{N}-plan.md`).
+
+The `review-tier` guard fires on plan file writes and determines the review tier. Complete the required review rounds before proceeding to implementation.
+
+### 7. Set par and slope
+
+Based on the sprint plan:
+- **Par**: 1-2 tickets = 3, 3-4 tickets = 4, 5+ tickets = 5
+- **Slope**: Count complexity factors:
+  - New infrastructure or architecture (+1)
+  - Multi-package changes (+1)
+  - Schema or API changes (+1)
+  - External API integration (+1)
+  - Learning curve / unfamiliar territory (+1)
+
+### 8. Prior art research
+
+Before implementation begins, search for existing solutions:
+- How have other projects solved this problem?
+- Are there standard algorithms or approaches?
+- Any relevant GDC talks, blog posts, or papers?
+
+Save findings to `docs/` for reference during implementation.
+
+### 9. Present sprint summary
+
+Show the user:
+- Sprint number and theme
+- Par and slope
+- Ticket list with planned clubs
+- Key hazards to watch for (from briefing)
+- Deferred findings targeting this sprint: `slope review deferred --sprint={N}`
+
+## Important
+
+- Never skip the prior scorecard verification — this prevents the "batch without reflection" problem
+- The briefing output contains critical context; read it carefully before starting
+- If the codebase map is stale, run `slope map` to refresh it


### PR DESCRIPTION
## Problem

	slope init --pi

was essentially a no-op. It printed "Extension installed" and "Skills copied" but:
- Never copied the compiled extension to .pi/extensions/slope/
- Never copied skill templates to .pi/skills/
- Called installDefaultHooks(cwd, 'pi') which immediately returned (pi uses extensions, not hooks)

## Changes

- Added installPiTemplates() that copies compiled extension from packages/pi-extension/dist/ to .pi/extensions/slope/
- Added installPiTemplates() that copies skill templates from templates/pi/skills/ to .pi/skills/
- Created three pi skill templates (start-sprint, post-sprint, review-pr) converted from Claude Code slash commands
- Removed no-op installDefaultHooks call from case 'pi'

## Testing

- pnpm build: clean
- pnpm test: 2986 passed