### PR TITLE
fix(init): proper pi skill dirs + skip ext copy in slope repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ docs/issues/
 
 # SLOPE session hooks
 .claude/hooks/slope-session-*.sh
+.agents/

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -575,43 +575,63 @@ function installOpenCodeMcpConfig(cwd: string): void {
 }
 
 function installPiTemplates(cwd: string): void {
-  // Copy compiled extension to .pi/extensions/slope/
-  const extDir = join(cwd, '.pi', 'extensions', 'slope');
-  mkdirSync(extDir, { recursive: true });
+  // Skip extension copy if this IS the slope package itself (would conflict
+  // with pi.extensions resolution from package.json)
+  const isSlopePackage = (() => {
+    try {
+      const pkgJson = JSON.parse(readFileSync(join(cwd, 'package.json'), 'utf8'));
+      return pkgJson.name === '@slope-dev/slope';
+    } catch { return false; }
+  })();
 
-  const pkgRoot = getTemplatesRoot(); // <pkg_root>/templates
-  const srcDir = join(pkgRoot, '..', 'packages', 'pi-extension', 'dist');
-  const extFiles = ['index.js', 'index.d.ts'];
-  let extInstalled = 0;
-  for (const file of extFiles) {
-    const src = join(srcDir, file);
-    const dest = join(extDir, file);
-    if (existsSync(src)) {
-      cpSync(src, dest, { force: true });
-      console.log(`  Created/updated ${dest}`);
-      extInstalled++;
-    } else {
-      console.warn(`  Warning: extension source not found: ${src} (package may not be bundled correctly)`);
+  if (!isSlopePackage) {
+    // Copy compiled extension to .pi/extensions/slope/
+    const extDir = join(cwd, '.pi', 'extensions', 'slope');
+    mkdirSync(extDir, { recursive: true });
+
+    const pkgRoot = getTemplatesRoot(); // <pkg_root>/templates
+    const srcDir = join(pkgRoot, '..', 'packages', 'pi-extension', 'dist');
+    const extFiles = ['index.js', 'index.d.ts'];
+    let extInstalled = 0;
+    for (const file of extFiles) {
+      const src = join(srcDir, file);
+      const dest = join(extDir, file);
+      if (existsSync(src)) {
+        cpSync(src, dest, { force: true });
+        console.log(`  Created/updated ${dest}`);
+        extInstalled++;
+      } else {
+        console.warn(`  Warning: extension source not found: ${src} (package may not be bundled correctly)`);
+      }
     }
-  }
-  if (extInstalled === 0) {
-    console.warn('  Warning: no extension files copied. Pi will rely on global pi.extensions resolution.');
+    if (extInstalled === 0) {
+      console.warn('  Warning: no extension files copied. Pi will rely on global pi.extensions resolution.');
+    }
+  } else {
+    console.log('  Skipped extension copy (slope package loads via pi.extensions)');
   }
 
-  // Copy skill templates to .pi/skills/
+  // Copy skill templates to .pi/skills/<name>/SKILL.md
+  // Pi expects SKILL.md inside a named directory per the Agent Skills spec
   const skillsDir = join(cwd, '.pi', 'skills');
   mkdirSync(skillsDir, { recursive: true });
 
   const templatesRoot = join(getTemplatesRoot(), 'pi', 'skills');
-  const skillFiles = ['start-sprint.md', 'post-sprint.md', 'review-pr.md'];
+  const skillFiles: Record<string, string> = {
+    'start-sprint': 'start-sprint.md',
+    'post-sprint': 'post-sprint.md',
+    'review-pr': 'review-pr.md',
+  };
   let skillsInstalled = 0;
-  for (const file of skillFiles) {
+  for (const [skillName, file] of Object.entries(skillFiles)) {
     const src = join(templatesRoot, file);
-    const dest = join(skillsDir, file);
+    const skillDir = join(skillsDir, skillName);
+    const dest = join(skillDir, 'SKILL.md');
     if (!existsSync(src)) {
       console.warn(`  Warning: skill template not found: ${file} (templates may not be bundled)`);
       continue;
     }
+    mkdirSync(skillDir, { recursive: true });
     cpSync(src, dest, { force: true });
     console.log(`  Created/updated ${dest}`);
     skillsInstalled++;


### PR DESCRIPTION
## Problem

	slope init --pi

produced:
1. Skill warnings: name does not match parent directory 'skills'
2. Extension tool conflicts when run inside slope repo itself

## Changes

- Skills installed as  per Agent Skills spec
- Extension copy skipped inside @slope-dev/slope package (avoids conflict with pi.extensions)
- Added  to .gitignore (auto-generated skills)

## Testing

- Local test:   Detected stack: TypeScript, vitest, pnpm
  Recommended guards: typecheck, test, ci-check
  Run: slope hook add --guard=typecheck (or --level=recommended)
  Created /Users/sebastianbryers/Development/slope/.slope/config.json
  Created .slope/plugins/ directories
  Created .slope/hooks.json
  Skipped extension copy (slope package loads via pi.extensions)
  Created/updated /Users/sebastianbryers/Development/slope/.pi/skills/start-sprint/SKILL.md
  Created/updated /Users/sebastianbryers/Development/slope/.pi/skills/post-sprint/SKILL.md
  Created/updated /Users/sebastianbryers/Development/slope/.pi/skills/review-pr/SKILL.md

  Pi: Extension installed to .pi/extensions/slope/
  Pi: Skills copied to .pi/skills/
  Pi: Run /reload in pi to activate
Updating codebase map...

  Updated auto-generated sections
  602 lines, 25.5KB
  220 source files, 171 test files
  48 CLI commands, 29 guards

Map written to CODEBASE.md

  Generated CODEBASE.md

==================================================
  SLOPE initialized successfully
==================================================

Core files:
  .slope/config.json      — configuration
  .slope/slope.db         — SQLite store (sessions, claims, events)
  .slope/common-issues.json — recurring patterns
  .slope/hooks.json       — installed hook registry
  .slope/plugins/         — custom plugin directories
  docs/retros/            — sprint scorecards
  docs/backlog/roadmap.json — project roadmap

Platform: pi

Next steps:

Get started:
  slope briefing    — pre-sprint briefing with hazards and gotchas
  slope card        — view your handicap card
  slope validate    — validate a scorecard
  slope hook add --level=full — install all guidance hooks in slope repo
  - Skips extension copy ✓
  - Skills in proper subdirs ✓
  - No tool conflicts ✓