### PR TITLE
fix: review amend exits cleanly when scorecard has no shots (closes #292)

### DIFF
--- a/src/cli/commands/review-state.ts
+++ b/src/cli/commands/review-state.ts
@@ -408,7 +408,14 @@ function amendCommand(args: string[], cwd: string): void {
   console.log(`Amending Sprint ${sprintNumber} scorecard with ${findingsData.findings.length} review finding${findingsData.findings.length !== 1 ? 's' : ''}...\n`);
 
   // Amend
-  const result = amendScorecardWithFindings(scorecard, findingsData.findings);
+  let result;
+  try {
+    result = amendScorecardWithFindings(scorecard, findingsData.findings);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${msg}`);
+    process.exit(1);
+  }
 
   if (result.amendments.length === 0) {
     console.log('No new amendments applied (findings already present or no matching tickets).');

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -136,6 +136,14 @@ export function amendScorecardWithFindings(
   scorecard: GolfScorecard,
   findings: ReviewFinding[],
 ): AmendResult {
+  if (!Array.isArray(scorecard.shots)) {
+    throw new Error(
+      `Scorecard for sprint ${scorecard.sprint_number} has no \`shots\` array — ` +
+        `likely a sub-sprint parent stub or malformed file. ` +
+        `Pass --sprint=<id> for the sub-sprint scorecard, or check the on-disk file.`,
+    );
+  }
+
   const scoreBefore = scorecard.score;
   const labelBefore = scorecard.score_label;
   const amendments: AmendResult['amendments'] = [];

--- a/tests/cli/review-amend.test.ts
+++ b/tests/cli/review-amend.test.ts
@@ -111,6 +111,31 @@ describe('review amend', () => {
     expect(logged).toContain('No review findings to amend');
   });
 
+  it('GH #292: errors clearly when scorecard has no shots array (sub-sprint parent stub)', async () => {
+    // Repro: parent scorecard sprint-180.json with no `shots` field.
+    // Was crashing as "Cannot read properties of undefined (reading 'map')".
+    // Should now exit cleanly with actionable error.
+    mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+    writeFileSync(join(tmpDir, '.slope/config.json'), JSON.stringify({ scorecardDir: 'docs/retros' }));
+    mkdirSync(join(tmpDir, 'docs/retros'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'docs/retros/sprint-180.json'),
+      JSON.stringify({ sprint_number: 180, theme: 'Parent', par: 5, slope: 2, date: '2026-04-30' }),
+    );
+    writeFileSync(join(tmpDir, '.slope/review-findings.json'), JSON.stringify({
+      sprint_number: 180,
+      findings: [{ review_type: 'architect', ticket_key: 'S180-1', severity: 'minor', description: 'test', resolved: true }],
+    }));
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await expect(runCommand(['amend', '--sprint=180'])).rejects.toThrow('process.exit(1)');
+    const errored = errSpy.mock.calls.map(c => c[0]).join('\n');
+    errSpy.mockRestore();
+
+    expect(errored).toContain('no `shots` array');
+    expect(errored).toContain('sub-sprint');
+  });
+
   it('errors when scorecard not found', async () => {
     mkdirSync(join(tmpDir, '.slope'), { recursive: true });
     writeFileSync(join(tmpDir, '.slope/config.json'), JSON.stringify({ scorecardDir: 'docs/retros' }));


### PR DESCRIPTION
## Summary

- \`slope review amend\` was crashing with \`Cannot read properties of undefined (reading 'map')\` when the loaded scorecard had no \`shots\` array
- Root cause: \`loader.ts:21\` regex \`^sprint-(\d+)\.json$\` filters out sub-sprint files (e.g. \`sprint-180-10.json\`), so \`detectLatestSprint\` lands on the parent stub \`sprint-180.json\` which has no \`shots\`
- Adds a defensive guard in \`amendScorecardWithFindings\` that throws an actionable error naming the sub-sprint diagnosis, and surfaces it cleanly from the CLI (exit 1 instead of unhandled stack trace)

The deeper fix — extending the loader regex to recognise \`sprint-{major}-{minor}.json\` files — is intentionally **not** in this patch. It's a larger change with knock-on effects on \`detectLatestSprint\`/\`loadScorecards\` ordering and would need its own design pass. This patch unblocks the immediate workflow with a clear pointer to the right next step.

Closes #292.

## Test plan

- [x] New regression test reproduces the parent-stub scenario and asserts the new error message
- [x] All 78 existing review tests pass
- [x] \`pnpm typecheck\` clean

## Follow-up

- Sub-sprint loader regex extension — separate ticket. Would need to consider how to derive sprint ordering from filename vs in-file \`sprint_number\` field, and how to dedupe parent + sub-sprint scorecards.