### PR TITLE
chore(roadmap): triage GH #290/#291 — S78 enforcement + new S80 hygiene sprint

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -26,9 +26,10 @@
       "sprints": [
         68,
         69,
-        77
+        78,
+        80
       ],
-      "note": "S69 diverged — patch kit ran instead of The Referee. The Referee rescheduled as S77."
+      "note": "S69 diverged — patch kit ran instead of The Referee. The Referee was rescheduled and now sits at S78 (renumbered after S73 Caddy's Notes was inserted). S80 added 2026-04-30 to address GH issues #290/#291 (sprint hygiene — read-side surfacing + post-hole command)."
     },
     {
       "name": "Phase 13 — Multi-Project & Teams",
@@ -716,11 +717,59 @@
           "title": "Guard enforcement report — slope doctor check for advisory vs mechanical guards",
           "club": "wedge",
           "complexity": "small"
+        },
+        {
+          "key": "S78-5",
+          "title": "Post-hole enforcement guard — stop hook fails session-end on roadmap/scorecard drift (GH #291)",
+          "club": "long_iron",
+          "complexity": "moderate"
+        },
+        {
+          "key": "S78-6",
+          "title": "Extend slope validate to detect scorecard↔roadmap drift (GH #291)",
+          "club": "short_iron",
+          "complexity": "standard"
         }
       ],
       "depends_on": [
         68
-      ]
+      ],
+      "note_addendum": "S78-5 and S78-6 added 2026-04-30 to address GH #291 — converts the advisory \"update roadmap\" rule in the Post-Hole Routine into a mechanical guard + validator. Fits S78's advisory-to-mechanical thesis."
+    },
+    {
+      "id": 80,
+      "theme": "The Course Marshal — Sprint Hygiene Surfacing",
+      "par": 4,
+      "slope": 1,
+      "type": "feature + dx",
+      "note": "Created 2026-04-30 to address GH #290 (briefing should surface next planned sprint) and GH #291 item 3 (slope post-hole command). Read-side counterpart to S78-5/S78-6's write-side enforcement.",
+      "tickets": [
+        {
+          "key": "S80-1",
+          "title": "slope briefing surfaces next planned sprint (dependency-resolved) — GH #290",
+          "club": "short_iron",
+          "complexity": "standard"
+        },
+        {
+          "key": "S80-2",
+          "title": "Fix slope status next-sprint heuristic — read next-planned from roadmap, not max(complete_id)+1 — GH #290",
+          "club": "wedge",
+          "complexity": "small"
+        },
+        {
+          "key": "S80-3",
+          "title": "slope post-hole command — flip latest scorecard to complete, scaffold next sprint, single commit — GH #291",
+          "club": "short_iron",
+          "complexity": "standard"
+        },
+        {
+          "key": "S80-4",
+          "title": "Test coverage — briefing next-sprint selection, status heuristic, post-hole command roundtrip",
+          "club": "wedge",
+          "complexity": "small"
+        }
+      ],
+      "depends_on": []
     },
     {
       "id": 79,
@@ -757,7 +806,8 @@
       ],
       "depends_on": [
         77,
-        78
+        78,
+        80
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Triages two related sprint-hygiene issues filed from a fathoms-game session and lands them on the (post-#293) roadmap.

After PR #293 merged S73 Caddy's Notes, sprint numbering shifted: The Referee is now S78 (was S77) and the 19th Hole capstone is S79 (was S78). This commit applies the original triage plan against the new layout.

- **GH #291 (write-side)** — adds \`S78-5\` (post-hole enforcement guard at session-end stop hook) and \`S78-6\` (extend \`slope validate\` to detect scorecard↔roadmap drift) to The Referee sprint. Fits S78's advisory-to-mechanical thesis.
- **GH #290 + GH #291 item 3 (read-side)** — new sprint **S80 The Course Marshal — Sprint Hygiene Surfacing** with 4 tickets:
  - S80-1: \`slope briefing\` surfaces next planned sprint (dependency-resolved)
  - S80-2: fix \`slope status\` next-sprint heuristic to read roadmap, not \`max(complete_id)+1\`
  - S80-3: \`slope post-hole\` command — flip latest scorecard, scaffold next sprint, single commit
  - S80-4: test coverage

S79 capstone \`depends_on\` updated to include 80; Phase 12 sprints list updated to [68, 69, 78, 80].

GH #292 (review amend crash) is **not** part of this triage — it's filed separately as a \`fix/\` branch.

## Test plan

- [x] \`slope roadmap validate\` passes (20 sprints, 85 tickets, 7 phases)
- [x] No code changes — roadmap.json edit only