### PR TITLE
chore: reconcile roadmap statuses + gitignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 .pi/
 *.tsbuildinfo
+.DS_Store
 .slope/
 .env
 .aider*

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -66,12 +66,39 @@
       "note": "S77/S79 plan-and-review work; S81-S84 expanded Phase 16 into harness universality (Codex/OpenCode/Pi adapters + testing polish)."
     },
     {
-      "name": "Phase 17 \u2014 TBD",
+      "name": "Phase 17 \u2014 TBD (S85 placeholder)",
       "sprints": [
         85
       ],
       "status": "planned",
-      "note": "S85 placeholder \u2014 theme TBD"
+      "note": "S85 theme TBD \u2014 current sprint per slope status."
+    },
+    {
+      "name": "Phase 18 \u2014 Drift Detection & Bug Clearing",
+      "sprints": [
+        86,
+        87
+      ],
+      "status": "planned",
+      "note": "Builds the drift-detection scaffolding (S86) the project lacked during S70-S84, and clears accumulated CLI bugs from external users (S87, supersedes S75.5)."
+    },
+    {
+      "name": "Phase 19 \u2014 Agent Developer Experience",
+      "sprints": [
+        88,
+        89
+      ],
+      "status": "planned",
+      "note": "Machine-readable state + bundled workflow commands. Foundation for agent-driven SLOPE usage filed as #309-316."
+    },
+    {
+      "name": "Phase 20 \u2014 Architecture & Automation",
+      "sprints": [
+        90,
+        91
+      ],
+      "status": "planned",
+      "note": "Memory\u2194store reunification (architectural debt from PR #293) + automation hooks for PR/issue/branch hygiene."
     }
   ],
   "sprints": [
@@ -646,7 +673,7 @@
       "par": 3,
       "slope": 1,
       "type": "bug fix",
-      "note": "Created 2026-05-02 to clear 4 accumulated CLI bugs from external repos. GH #297, #298, #299, #300.",
+      "note": "Superseded by S87 (The Bug Clearing v2). #297/#299 already shipped via 14d01862; remaining bugs refreshed in S87.",
       "tickets": [
         {
           "key": "S75.5-1",
@@ -674,7 +701,7 @@
         }
       ],
       "depends_on": [],
-      "status": "planned"
+      "status": "superseded"
     },
     {
       "id": 76,
@@ -920,6 +947,275 @@
       "type": "tbd",
       "status": "planned",
       "tickets": []
+    },
+    {
+      "id": 86,
+      "theme": "The Marshal \u2014 Drift Detection",
+      "par": 5,
+      "slope": 2,
+      "type": "feature + guard",
+      "status": "planned",
+      "depends_on": [
+        85
+      ],
+      "note": "Drift catches up. Builds the audit infrastructure that would have caught the S70-S84 status drift fixed in PR #317.",
+      "tickets": [
+        {
+          "key": "S86-1",
+          "title": "slope roadmap validate \u2014 detect status drift against git log (#319)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 319
+        },
+        {
+          "key": "S86-2",
+          "title": "Guard: block edits to sprints with status:complete (#320)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 320
+        },
+        {
+          "key": "S86-3",
+          "title": "Post-hole enforcement hook \u2014 fail session-end on roadmap/scorecard drift (#291)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 291,
+          "depends_on": [
+            "S86-1"
+          ]
+        },
+        {
+          "key": "S86-4",
+          "title": "Backfill missing scorecards for S70, S74-S83 (#318)",
+          "club": "long_iron",
+          "complexity": "multi_package",
+          "github_issue": 318
+        },
+        {
+          "key": "S86-5",
+          "title": "Briefing surfaces next sprint + fix title/theme schema drift (#290, #324)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": [
+            290,
+            324
+          ]
+        }
+      ]
+    },
+    {
+      "id": 87,
+      "theme": "The Bug Clearing v2 \u2014 CLI fixes for external repos",
+      "par": 4,
+      "slope": 1,
+      "type": "bug fix",
+      "status": "planned",
+      "depends_on": [],
+      "note": "Supersedes S75.5. Highest-impact CLI bugs from external SLOPE users.",
+      "tickets": [
+        {
+          "key": "S87-1",
+          "title": "slope version returns 'vunknown' \u2014 read from installed package, not cwd (#300)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 300
+        },
+        {
+          "key": "S87-2",
+          "title": "slope review formatted output shows 'Tickets Delivered: 0' despite tickets array (#298)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 298
+        },
+        {
+          "key": "S87-3",
+          "title": "roadmap generate --dry-run should not write roadmap.json (#304)",
+          "club": "putter",
+          "complexity": "trivial",
+          "github_issue": 304
+        },
+        {
+          "key": "S87-4",
+          "title": "init should not create a completed example retrospective by default (#306)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 306
+        }
+      ]
+    },
+    {
+      "id": 88,
+      "theme": "The Compass \u2014 Agent State & Status",
+      "par": 4,
+      "slope": 1,
+      "type": "feature + dx",
+      "status": "planned",
+      "depends_on": [],
+      "note": "Foundation primitives for the agent-DX batch (#309-316). #310 is the keystone \u2014 once status is machine-readable, downstream commands compose.",
+      "tickets": [
+        {
+          "key": "S88-1",
+          "title": "slope agent status \u2014 machine-readable next-step output (#310)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 310
+        },
+        {
+          "key": "S88-2",
+          "title": "Generate AGENT_NEXT.md with current recommended action (#315)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 315,
+          "depends_on": [
+            "S88-1"
+          ]
+        },
+        {
+          "key": "S88-3",
+          "title": "slope sprint begin \u2014 bundle start, claim, briefing, and prep (#311)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 311
+        },
+        {
+          "key": "S88-4",
+          "title": "slope ticket done \u2014 close claim and update sprint state (#316)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 316
+        }
+      ]
+    },
+    {
+      "id": 89,
+      "theme": "The Toolkit \u2014 Agent Workflow Commands",
+      "par": 4,
+      "slope": 1,
+      "type": "feature + dx",
+      "status": "planned",
+      "depends_on": [
+        88
+      ],
+      "note": "Builds on S88 status primitive. Adds Codex profile and the bundled commands agents reach for most.",
+      "tickets": [
+        {
+          "key": "S89-1",
+          "title": "slope sprint plan \u2014 generate implementation plan file (#312)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 312
+        },
+        {
+          "key": "S89-2",
+          "title": "Simpler gate commands for agent workflows (#313)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 313
+        },
+        {
+          "key": "S89-3",
+          "title": "slope commit-ready \u2014 pre-commit agent checks (#314)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 314
+        },
+        {
+          "key": "S89-4",
+          "title": "First-class Codex initialization/profile (#309)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 309
+        }
+      ]
+    },
+    {
+      "id": 90,
+      "theme": "The Vault \u2014 Memory \u2194 Store Reunification",
+      "par": 4,
+      "slope": 2,
+      "type": "refactor + architecture",
+      "status": "planned",
+      "depends_on": [],
+      "note": "Address PR #293 architect finding A1: memory system bypasses store abstraction. Requires extending store interface and migrating memory module across both store backends.",
+      "tickets": [
+        {
+          "key": "S90-1",
+          "title": "Extend store interface with memory operations (#294)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 294
+        },
+        {
+          "key": "S90-2",
+          "title": "Implement memory ops in store-sqlite + store-pg",
+          "club": "long_iron",
+          "complexity": "multi_package",
+          "github_issue": 294,
+          "depends_on": [
+            "S90-1"
+          ]
+        },
+        {
+          "key": "S90-3",
+          "title": "Migrate memory module to use store interface",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 294,
+          "depends_on": [
+            "S90-2"
+          ]
+        },
+        {
+          "key": "S90-4",
+          "title": "Migration script + tests + cleanup of legacy memory paths",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 294,
+          "depends_on": [
+            "S90-3"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 91,
+      "theme": "The Pit Crew \u2014 Automation Hooks",
+      "par": 4,
+      "slope": 1,
+      "type": "feature + automation",
+      "status": "planned",
+      "depends_on": [],
+      "note": "Hook-based automation: PR review prompts, issue auto-close, branch hygiene. Pairs nicely with S86 drift detection but doesn't depend on it.",
+      "tickets": [
+        {
+          "key": "S91-1",
+          "title": "PostPRCreate hook \u2014 auto-trigger review-loop recommendation (#302)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 302
+        },
+        {
+          "key": "S91-2",
+          "title": "Auto-close GH issues from fix commits \u2014 convention or hook (#321)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 321
+        },
+        {
+          "key": "S91-3",
+          "title": "Branch hygiene automation in slope doctor (#322)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 322
+        },
+        {
+          "key": "S91-4",
+          "title": "vision create \u2014 tracked Markdown output (#305)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 305
+        }
+      ]
     }
   ]
 }

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -1,9 +1,9 @@
 {
   "name": "SLOPE Development Roadmap",
-  "description": "Forward-looking roadmap from S61+. Phases 1-9 (S1-S47) are complete. S48-S60 were hardening, guard enforcement, and process sprints. This roadmap covers adoption, observability, guard maturity, multi-project, and loop evolution. S61-S64 reflect what actually shipped (themes diverged from original plan). Note: the actual S69 diverged from the planned Referee sprint — a carryover patch kit ran instead. The Referee work was rescheduled as S78. S75.5 (The Bug Clearing) added 2026-05-02 to clear accumulated CLI bugs from external repos.",
+  "description": "Forward-looking roadmap from S61+. Phases 1-9 (S1-S47) are complete. S48-S60 were hardening, guard enforcement, and process sprints. This roadmap covers adoption, observability, guard maturity, multi-project, and loop evolution. S61-S64 reflect what actually shipped (themes diverged from original plan). Note: the actual S69 diverged from the planned Referee sprint \u2014 a carryover patch kit ran instead. The Referee work was rescheduled as S78. S75.5 (The Bug Clearing) added 2026-05-02 to clear accumulated CLI bugs from external repos.",
   "phases": [
     {
-      "name": "Phase 10 — Adoption & Onboarding",
+      "name": "Phase 10 \u2014 Adoption & Onboarding",
       "sprints": [
         61,
         62,
@@ -13,7 +13,7 @@
       "status": "complete"
     },
     {
-      "name": "Phase 11 — Repair & Observability",
+      "name": "Phase 11 \u2014 Repair & Observability",
       "sprints": [
         65,
         66,
@@ -22,30 +22,30 @@
       "status": "complete"
     },
     {
-      "name": "Phase 12 — Guard Maturity",
+      "name": "Phase 12 \u2014 Guard Maturity",
       "sprints": [
         68,
         69,
         78,
         80
       ],
-      "note": "S69 diverged — patch kit ran instead of The Referee. The Referee was rescheduled and now sits at S78 (renumbered after S73 Caddy's Notes was inserted). S80 added 2026-04-30 to address GH issues #290/#291 (sprint hygiene — read-side surfacing + post-hole command)."
+      "note": "S69 diverged \u2014 patch kit ran instead of The Referee. The Referee was rescheduled and now sits at S78 (renumbered after S73 Caddy's Notes was inserted). S80 added 2026-04-30 to address GH issues #290/#291 (sprint hygiene \u2014 read-side surfacing + post-hole command)."
     },
     {
-      "name": "Phase 13 — Multi-Project & Teams",
+      "name": "Phase 13 \u2014 Multi-Project & Teams",
       "sprints": [
         70,
         72
       ]
     },
     {
-      "name": "Phase 14 — Agent Memory & Context",
+      "name": "Phase 14 \u2014 Agent Memory & Context",
       "sprints": [
         73
       ]
     },
     {
-      "name": "Phase 15 — Loop Evolution",
+      "name": "Phase 15 \u2014 Loop Evolution",
       "sprints": [
         74,
         75,
@@ -54,16 +54,30 @@
       ]
     },
     {
-      "name": "Phase 16 — Assessment & Wrap-up",
+      "name": "Phase 16 \u2014 Assessment & Wrap-up",
       "sprints": [
-        79
-      ]
+        77,
+        79,
+        81,
+        82,
+        83,
+        84
+      ],
+      "note": "S77/S79 plan-and-review work; S81-S84 expanded Phase 16 into harness universality (Codex/OpenCode/Pi adapters + testing polish)."
+    },
+    {
+      "name": "Phase 17 \u2014 TBD",
+      "sprints": [
+        85
+      ],
+      "status": "planned",
+      "note": "S85 placeholder \u2014 theme TBD"
     }
   ],
   "sprints": [
     {
       "id": 61,
-      "theme": "The Terminal Caddy — OB1 Adapter",
+      "theme": "The Terminal Caddy \u2014 OB1 Adapter",
       "par": 3,
       "slope": 1,
       "type": "feature",
@@ -93,7 +107,7 @@
     },
     {
       "id": 62,
-      "theme": "The Welcome Mat v2 + Templates — Streamlined First-Run Experience",
+      "theme": "The Welcome Mat v2 + Templates \u2014 Streamlined First-Run Experience",
       "par": 5,
       "slope": 1,
       "type": "dx",
@@ -103,7 +117,7 @@
       "tickets": [
         {
           "key": "S62-0",
-          "title": "Sprint & ticket templates — standard templates for sprint plans and tickets",
+          "title": "Sprint & ticket templates \u2014 standard templates for sprint plans and tickets",
           "club": "short_iron",
           "complexity": "standard"
         },
@@ -121,13 +135,13 @@
         },
         {
           "key": "S62-3",
-          "title": "slope init --migrate — upgrade config from older SLOPE versions",
+          "title": "slope init --migrate \u2014 upgrade config from older SLOPE versions",
           "club": "wedge",
           "complexity": "small"
         },
         {
           "key": "S62-4",
-          "title": "Post-init validation — run doctor checks after init to confirm setup",
+          "title": "Post-init validation \u2014 run doctor checks after init to confirm setup",
           "club": "putter",
           "complexity": "trivial"
         }
@@ -135,7 +149,7 @@
     },
     {
       "id": 63,
-      "theme": "The Handbook + Template Integration — CLI Help & Documentation Polish",
+      "theme": "The Handbook + Template Integration \u2014 CLI Help & Documentation Polish",
       "par": 5,
       "slope": 1,
       "type": "docs + dx",
@@ -145,19 +159,19 @@
       "tickets": [
         {
           "key": "S63-1",
-          "title": "slope help <command> — detailed usage, examples, and flags for each command",
+          "title": "slope help <command> \u2014 detailed usage, examples, and flags for each command",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S63-2",
-          "title": "slope quickstart — interactive tutorial for new users",
+          "title": "slope quickstart \u2014 interactive tutorial for new users",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S63-3",
-          "title": "Guard documentation — explain each guard's purpose, triggers, and config",
+          "title": "Guard documentation \u2014 explain each guard's purpose, triggers, and config",
           "club": "wedge",
           "complexity": "small"
         },
@@ -175,7 +189,7 @@
         },
         {
           "key": "S63-6",
-          "title": "slope plan --sprint=N — show full ticket specs from roadmap",
+          "title": "slope plan --sprint=N \u2014 show full ticket specs from roadmap",
           "club": "short_iron",
           "complexity": "standard"
         }
@@ -211,7 +225,7 @@
         },
         {
           "key": "S64-4",
-          "title": "slope prep --lite — hazards + similar tickets without embedding index",
+          "title": "slope prep --lite \u2014 hazards + similar tickets without embedding index",
           "club": "wedge",
           "complexity": "small"
         },
@@ -225,7 +239,7 @@
     },
     {
       "id": 65,
-      "theme": "The Doctor — Repo Health Checks & Repair",
+      "theme": "The Doctor \u2014 Repo Health Checks & Repair",
       "par": 4,
       "slope": 1,
       "type": "feature + dx",
@@ -235,25 +249,25 @@
       "tickets": [
         {
           "key": "S65-1",
-          "title": "slope doctor command — check .gitignore, config, hooks, guards",
+          "title": "slope doctor command \u2014 check .gitignore, config, hooks, guards",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S65-2",
-          "title": "slope init --repair — fix missing/outdated config in existing repos",
+          "title": "slope init --repair \u2014 fix missing/outdated config in existing repos",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S65-3",
-          "title": "slope doctor --fix — auto-repair common issues (gitignore, hooks, guards)",
+          "title": "slope doctor --fix \u2014 auto-repair common issues (gitignore, hooks, guards)",
           "club": "wedge",
           "complexity": "small"
         },
         {
           "key": "S65-4",
-          "title": "Guard installation audit — detect missing guards and suggest additions",
+          "title": "Guard installation audit \u2014 detect missing guards and suggest additions",
           "club": "wedge",
           "complexity": "small"
         }
@@ -261,7 +275,7 @@
     },
     {
       "id": 66,
-      "theme": "The Scorekeeper — Sprint Analytics Dashboard",
+      "theme": "The Scorekeeper \u2014 Sprint Analytics Dashboard",
       "par": 4,
       "slope": 2,
       "type": "feature",
@@ -271,25 +285,25 @@
       "tickets": [
         {
           "key": "S66-1",
-          "title": "Handicap trend API — time-series data for handicap, GIR, fairway hit",
+          "title": "Handicap trend API \u2014 time-series data for handicap, GIR, fairway hit",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S66-2",
-          "title": "Guard effectiveness metrics — track block/allow ratios per guard",
+          "title": "Guard effectiveness metrics \u2014 track block/allow ratios per guard",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S66-3",
-          "title": "Sprint velocity tracking — tickets/sprint, score trends, par accuracy",
+          "title": "Sprint velocity tracking \u2014 tickets/sprint, score trends, par accuracy",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S66-4",
-          "title": "Dashboard widgets for new metrics — guard stats, velocity, trend charts",
+          "title": "Dashboard widgets for new metrics \u2014 guard stats, velocity, trend charts",
           "club": "long_iron",
           "complexity": "moderate"
         }
@@ -300,7 +314,7 @@
     },
     {
       "id": 67,
-      "theme": "The Auditor — Cost & Token Tracking",
+      "theme": "The Auditor \u2014 Cost & Token Tracking",
       "par": 3,
       "slope": 2,
       "type": "feature",
@@ -310,19 +324,19 @@
       "tickets": [
         {
           "key": "S67-1",
-          "title": "Token usage tracking per sprint — estimate from transcript data",
+          "title": "Token usage tracking per sprint \u2014 estimate from transcript data",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S67-2",
-          "title": "Cost estimation — model-aware pricing for tracked token usage",
+          "title": "Cost estimation \u2014 model-aware pricing for tracked token usage",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S67-3",
-          "title": "slope cost — CLI report of token/cost trends across sprints",
+          "title": "slope cost \u2014 CLI report of token/cost trends across sprints",
           "club": "wedge",
           "complexity": "small"
         }
@@ -330,7 +344,7 @@
     },
     {
       "id": 68,
-      "theme": "The Fence — Guard Testing Framework",
+      "theme": "The Fence \u2014 Guard Testing Framework",
       "par": 4,
       "slope": 2,
       "type": "infrastructure",
@@ -340,25 +354,25 @@
       "tickets": [
         {
           "key": "S68-1",
-          "title": "Guard test harness — simulate PreToolUse/PostToolUse/Stop with fixtures",
+          "title": "Guard test harness \u2014 simulate PreToolUse/PostToolUse/Stop with fixtures",
           "club": "long_iron",
           "complexity": "moderate"
         },
         {
           "key": "S68-2",
-          "title": "Guard snapshot testing — verify guard output stability across changes",
+          "title": "Guard snapshot testing \u2014 verify guard output stability across changes",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S68-3",
-          "title": "Custom guard validation — check custom guards for common errors",
+          "title": "Custom guard validation \u2014 check custom guards for common errors",
           "club": "wedge",
           "complexity": "small"
         },
         {
           "key": "S68-4",
-          "title": "Guard dry-run mode — show what guards would fire without blocking",
+          "title": "Guard dry-run mode \u2014 show what guards would fire without blocking",
           "club": "wedge",
           "complexity": "small"
         }
@@ -366,7 +380,7 @@
     },
     {
       "id": 69,
-      "theme": "The Patch Kit — S68 Carryover Fixes",
+      "theme": "The Patch Kit \u2014 S68 Carryover Fixes",
       "par": 3,
       "slope": 2,
       "type": "bug fix + hardening",
@@ -377,7 +391,7 @@
       "tickets": [
         {
           "key": "S69-1",
-          "title": "Fix review amend crash — hole_stats → stats normalization",
+          "title": "Fix review amend crash \u2014 hole_stats \u2192 stats normalization",
           "club": "wedge",
           "complexity": "small"
         },
@@ -403,50 +417,51 @@
     },
     {
       "id": 70,
-      "theme": "The Replay — Session Insights & Debugging",
+      "theme": "The Replay \u2014 Session Insights & Debugging",
       "par": 4,
       "slope": 2,
       "type": "feature",
       "tickets": [
         {
           "key": "S70-1",
-          "title": "Enhanced transcript viewer — filter by tool, show timing, highlight errors",
+          "title": "Enhanced transcript viewer \u2014 filter by tool, show timing, highlight errors",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S70-2",
-          "title": "Session replay summary — auto-generate narrative of what happened",
+          "title": "Session replay summary \u2014 auto-generate narrative of what happened",
           "club": "long_iron",
           "complexity": "moderate"
         },
         {
           "key": "S70-3",
-          "title": "Compaction event tracking — log what was lost and recovered",
+          "title": "Compaction event tracking \u2014 log what was lost and recovered",
           "club": "wedge",
           "complexity": "small"
         },
         {
           "key": "S70-4",
-          "title": "Guard fire log — persistent record of every guard decision per session",
+          "title": "Guard fire log \u2014 persistent record of every guard decision per session",
           "club": "wedge",
           "complexity": "small"
         }
       ],
       "depends_on": [
         66
-      ]
+      ],
+      "status": "complete"
     },
     {
       "id": 71,
-      "theme": "The Intake Desk — Agent-Native Project Interview",
+      "theme": "The Intake Desk \u2014 Agent-Native Project Interview",
       "par": 5,
       "slope": 2,
       "type": "feature + dx",
       "tickets": [
         {
           "key": "S71-1",
-          "title": "Interview state machine refactor — extract UI-agnostic state machine from interview-steps.ts",
+          "title": "Interview state machine refactor \u2014 extract UI-agnostic state machine from interview-steps.ts",
           "club": "long_iron",
           "complexity": "moderate"
         },
@@ -464,73 +479,75 @@
         },
         {
           "key": "S71-4",
-          "title": "Auto-transition fresh → active after interview completion",
+          "title": "Auto-transition fresh \u2192 active after interview completion",
           "club": "wedge",
           "complexity": "small"
         },
         {
           "key": "S71-5",
-          "title": "Test coverage for state machine, CLI JSON mode, Pi tool, and fresh→active flow",
+          "title": "Test coverage for state machine, CLI JSON mode, Pi tool, and fresh\u2192active flow",
           "club": "wedge",
           "complexity": "small"
         }
-      ]
+      ],
+      "status": "complete"
     },
     {
       "id": 72,
-      "theme": "The Clubhouse Network — Multi-Repo Aggregation",
+      "theme": "The Clubhouse Network \u2014 Multi-Repo Aggregation",
       "par": 4,
       "slope": 3,
       "type": "architecture",
       "tickets": [
         {
           "key": "S72-1",
-          "title": "Cross-repo scorecard collection — aggregate from multiple .slope/ directories",
+          "title": "Cross-repo scorecard collection \u2014 aggregate from multiple .slope/ directories",
           "club": "long_iron",
           "complexity": "moderate"
         },
         {
           "key": "S72-2",
-          "title": "Org-level handicap card — compute combined stats across repos",
+          "title": "Org-level handicap card \u2014 compute combined stats across repos",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S72-3",
-          "title": "slope org status — show all repos, their handicaps, and active sprints",
+          "title": "slope org status \u2014 show all repos, their handicaps, and active sprints",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S72-4",
-          "title": "Cross-repo common-issues — promote patterns that appear in multiple repos",
+          "title": "Cross-repo common-issues \u2014 promote patterns that appear in multiple repos",
           "club": "wedge",
           "complexity": "small"
         }
-      ]
+      ],
+      "status": "complete"
     },
     {
       "id": 73,
-      "theme": "The Caddy's Notes — Cross-Session Memory System",
+      "theme": "The Caddy's Notes \u2014 Cross-Session Memory System",
       "par": 5,
       "slope": 2,
       "type": "feature",
       "tickets": [
         {
           "key": "S73-1",
-          "title": "Memory storage core — .slope/memories.json schema, CRUD, search API",
+          "title": "Memory storage core \u2014 .slope/memories.json schema, CRUD, search API",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S73-2",
-          "title": "Memory CLI — slope memory add/list/remove/edit/search/import/export",
+          "title": "Memory CLI \u2014 slope memory add/list/remove/edit/search/import/export",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S73-3",
-          "title": "Pi extension memory integration — session-start load, briefing injection, /slope-memory command",
+          "title": "Pi extension memory integration \u2014 session-start load, briefing injection, /slope-memory command",
           "club": "short_iron",
           "complexity": "standard"
         },
@@ -542,87 +559,90 @@
         },
         {
           "key": "S73-5",
-          "title": "Test coverage — unit, CLI, Pi extension, auto-memory tests",
+          "title": "Test coverage \u2014 unit, CLI, Pi extension, auto-memory tests",
           "club": "wedge",
           "complexity": "small"
         }
-      ]
+      ],
+      "status": "complete"
     },
     {
       "id": 74,
-      "theme": "The Foursome v2 — Multi-Agent Session Coordination",
+      "theme": "The Foursome v2 \u2014 Multi-Agent Session Coordination",
       "par": 4,
       "slope": 3,
       "type": "feature",
       "tickets": [
         {
           "key": "S74-1",
-          "title": "Session conflict detection across worktrees — real-time claim overlap alerts",
+          "title": "Session conflict detection across worktrees \u2014 real-time claim overlap alerts",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S74-2",
-          "title": "Agent handoff protocol — structured session transfer between agents",
+          "title": "Agent handoff protocol \u2014 structured session transfer between agents",
           "club": "long_iron",
           "complexity": "moderate"
         },
         {
           "key": "S74-3",
-          "title": "Parallel sprint orchestration — coordinate multiple agents on independent tickets",
+          "title": "Parallel sprint orchestration \u2014 coordinate multiple agents on independent tickets",
           "club": "long_iron",
           "complexity": "moderate"
         },
         {
           "key": "S74-4",
-          "title": "Agent session dashboard — live view of all active agent sessions",
+          "title": "Agent session dashboard \u2014 live view of all active agent sessions",
           "club": "short_iron",
           "complexity": "standard"
         }
       ],
       "depends_on": [
         72
-      ]
+      ],
+      "status": "complete"
     },
     {
       "id": 75,
-      "theme": "The Autopilot v2 — Smart Model Routing",
+      "theme": "The Autopilot v2 \u2014 Smart Model Routing",
       "par": 4,
       "slope": 2,
       "type": "feature",
       "tickets": [
         {
           "key": "S75-1",
-          "title": "Model success rate tracking — per-club, per-ticket-type success data",
+          "title": "Model success rate tracking \u2014 per-club, per-ticket-type success data",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S75-2",
-          "title": "Adaptive model selection — use historical data to pick optimal model per ticket",
+          "title": "Adaptive model selection \u2014 use historical data to pick optimal model per ticket",
           "club": "long_iron",
           "complexity": "moderate"
         },
         {
           "key": "S75-3",
-          "title": "Model cost-performance tradeoff — factor cost into routing decisions",
+          "title": "Model cost-performance tradeoff \u2014 factor cost into routing decisions",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S75-4",
-          "title": "slope loop config recommend — suggest optimal model config from data",
+          "title": "slope loop config recommend \u2014 suggest optimal model config from data",
           "club": "wedge",
           "complexity": "small"
         }
       ],
       "depends_on": [
         67
-      ]
+      ],
+      "status": "complete"
     },
     {
       "id": 75.5,
-      "theme": "The Bug Clearing — CLI Bug Fixes",
+      "theme": "The Bug Clearing \u2014 CLI Bug Fixes",
       "par": 3,
       "slope": 1,
       "type": "bug fix",
@@ -636,13 +656,13 @@
         },
         {
           "key": "S75.5-2",
-          "title": "Fix review findings stale state — namespace by sprint (GH #297)",
+          "title": "Fix review findings stale state \u2014 namespace by sprint (GH #297)",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S75.5-3",
-          "title": "Fix review tickets display — schema field mismatch (GH #298)",
+          "title": "Fix review tickets display \u2014 schema field mismatch (GH #298)",
           "club": "short_iron",
           "complexity": "standard"
         },
@@ -653,54 +673,56 @@
           "complexity": "small"
         }
       ],
-      "depends_on": []
+      "depends_on": [],
+      "status": "planned"
     },
     {
       "id": 76,
-      "theme": "The Assembly Line — Batch Sprint Execution",
+      "theme": "The Assembly Line \u2014 Batch Sprint Execution",
       "par": 4,
       "slope": 3,
       "type": "feature",
       "tickets": [
         {
           "key": "S76-1",
-          "title": "Dependency-aware sprint scheduling — respect depends_on in continuous mode",
+          "title": "Dependency-aware sprint scheduling \u2014 respect depends_on in continuous mode",
           "club": "long_iron",
           "complexity": "moderate"
         },
         {
           "key": "S76-2",
-          "title": "Parallel worktree management — auto-create/cleanup worktrees for parallel sprints",
+          "title": "Parallel worktree management \u2014 auto-create/cleanup worktrees for parallel sprints",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S76-3",
-          "title": "Sprint failure recovery — auto-retry with different strategy on failure",
+          "title": "Sprint failure recovery \u2014 auto-retry with different strategy on failure",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S76-4",
-          "title": "Batch execution report — summary of all sprints run in a batch",
+          "title": "Batch execution report \u2014 summary of all sprints run in a batch",
           "club": "wedge",
           "complexity": "small"
         }
       ],
       "depends_on": [
         75
-      ]
+      ],
+      "status": "complete"
     },
     {
       "id": 77,
-      "theme": "The Convergence — Loop Self-Improvement",
+      "theme": "The Convergence \u2014 Loop Self-Improvement",
       "par": 3,
       "slope": 3,
       "type": "architecture",
       "tickets": [
         {
           "key": "S77-1",
-          "title": "Backlog quality scoring — rate backlog tickets by likelihood of clean execution",
+          "title": "Backlog quality scoring \u2014 rate backlog tickets by likelihood of clean execution",
           "club": "short_iron",
           "complexity": "standard"
         },
@@ -712,7 +734,7 @@
         },
         {
           "key": "S77-3",
-          "title": "Convergence metrics — track handicap improvement rate, predict plateau",
+          "title": "Convergence metrics \u2014 track handicap improvement rate, predict plateau",
           "club": "short_iron",
           "complexity": "standard"
         }
@@ -720,11 +742,12 @@
       "depends_on": [
         75,
         76
-      ]
+      ],
+      "status": "complete"
     },
     {
       "id": 78,
-      "theme": "The Referee — Advisory-to-Mechanical Guard Conversion",
+      "theme": "The Referee \u2014 Advisory-to-Mechanical Guard Conversion",
       "par": 4,
       "slope": 2,
       "type": "hardening",
@@ -732,7 +755,7 @@
       "tickets": [
         {
           "key": "S78-1",
-          "title": "Audit all advisory guards — identify which return context-only with no disk state",
+          "title": "Audit all advisory guards \u2014 identify which return context-only with no disk state",
           "club": "wedge",
           "complexity": "small"
         },
@@ -750,19 +773,19 @@
         },
         {
           "key": "S78-4",
-          "title": "Guard enforcement report — slope doctor check for advisory vs mechanical guards",
+          "title": "Guard enforcement report \u2014 slope doctor check for advisory vs mechanical guards",
           "club": "wedge",
           "complexity": "small"
         },
         {
           "key": "S78-5",
-          "title": "Post-hole enforcement guard — stop hook fails session-end on roadmap/scorecard drift (GH #291)",
+          "title": "Post-hole enforcement guard \u2014 stop hook fails session-end on roadmap/scorecard drift (GH #291)",
           "club": "long_iron",
           "complexity": "moderate"
         },
         {
           "key": "S78-6",
-          "title": "Extend slope validate to detect scorecard↔roadmap drift (GH #291)",
+          "title": "Extend slope validate to detect scorecard\u2194roadmap drift (GH #291)",
           "club": "short_iron",
           "complexity": "standard"
         }
@@ -770,46 +793,12 @@
       "depends_on": [
         68
       ],
-      "note_addendum": "S78-5 and S78-6 added 2026-04-30 to address GH #291 — converts the advisory \"update roadmap\" rule in the Post-Hole Routine into a mechanical guard + validator. Fits S78's advisory-to-mechanical thesis."
-    },
-    {
-      "id": 80,
-      "theme": "The Course Marshal — Sprint Hygiene Surfacing",
-      "par": 4,
-      "slope": 1,
-      "type": "feature + dx",
-      "note": "Created 2026-04-30 to address GH #290 (briefing should surface next planned sprint) and GH #291 item 3 (slope post-hole command). Read-side counterpart to S78-5/S78-6's write-side enforcement.",
-      "tickets": [
-        {
-          "key": "S80-1",
-          "title": "slope briefing surfaces next planned sprint (dependency-resolved) — GH #290",
-          "club": "short_iron",
-          "complexity": "standard"
-        },
-        {
-          "key": "S80-2",
-          "title": "Fix slope status next-sprint heuristic — read next-planned from roadmap, not max(complete_id)+1 — GH #290",
-          "club": "wedge",
-          "complexity": "small"
-        },
-        {
-          "key": "S80-3",
-          "title": "slope post-hole command — flip latest scorecard to complete, scaffold next sprint, single commit — GH #291",
-          "club": "short_iron",
-          "complexity": "standard"
-        },
-        {
-          "key": "S80-4",
-          "title": "Test coverage — briefing next-sprint selection, status heuristic, post-hole command roundtrip",
-          "club": "wedge",
-          "complexity": "small"
-        }
-      ],
-      "depends_on": []
+      "note_addendum": "S78-5 and S78-6 added 2026-04-30 to address GH #291 \u2014 converts the advisory \"update roadmap\" rule in the Post-Hole Routine into a mechanical guard + validator. Fits S78's advisory-to-mechanical thesis.",
+      "status": "complete"
     },
     {
       "id": 79,
-      "theme": "The 19th Hole — Workflow Engine Assessment & Phase Wrap-up",
+      "theme": "The 19th Hole \u2014 Workflow Engine Assessment & Phase Wrap-up",
       "par": 4,
       "slope": 2,
       "type": "assessment + hardening",
@@ -817,25 +806,25 @@
       "tickets": [
         {
           "key": "S79-1",
-          "title": "Workflow engine test coverage audit — identify gaps vs S67/S68 test suite",
+          "title": "Workflow engine test coverage audit \u2014 identify gaps vs S67/S68 test suite",
           "club": "wedge",
           "complexity": "small"
         },
         {
           "key": "S79-2",
-          "title": "Workflow engine E2E smoke test — full sprint lifecycle via CLI against real store",
+          "title": "Workflow engine E2E smoke test \u2014 full sprint lifecycle via CLI against real store",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S79-3",
-          "title": "Phase retrospective — assess shipped state vs original vision, document gaps for next roadmap",
+          "title": "Phase retrospective \u2014 assess shipped state vs original vision, document gaps for next roadmap",
           "club": "short_iron",
           "complexity": "standard"
         },
         {
           "key": "S79-4",
-          "title": "CODEBASE.md and docs alignment check — ensure map reflects all shipped features",
+          "title": "CODEBASE.md and docs alignment check \u2014 ensure map reflects all shipped features",
           "club": "wedge",
           "complexity": "small"
         }
@@ -844,7 +833,93 @@
         77,
         78,
         80
-      ]
+      ],
+      "status": "complete"
+    },
+    {
+      "id": 80,
+      "theme": "The Course Marshal \u2014 Sprint Hygiene Surfacing",
+      "par": 4,
+      "slope": 1,
+      "type": "feature + dx",
+      "note": "Created 2026-04-30 to address GH #290 (briefing should surface next planned sprint) and GH #291 item 3 (slope post-hole command). Read-side counterpart to S78-5/S78-6's write-side enforcement.",
+      "tickets": [
+        {
+          "key": "S80-1",
+          "title": "slope briefing surfaces next planned sprint (dependency-resolved) \u2014 GH #290",
+          "club": "short_iron",
+          "complexity": "standard"
+        },
+        {
+          "key": "S80-2",
+          "title": "Fix slope status next-sprint heuristic \u2014 read next-planned from roadmap, not max(complete_id)+1 \u2014 GH #290",
+          "club": "wedge",
+          "complexity": "small"
+        },
+        {
+          "key": "S80-3",
+          "title": "slope post-hole command \u2014 flip latest scorecard to complete, scaffold next sprint, single commit \u2014 GH #291",
+          "club": "short_iron",
+          "complexity": "standard"
+        },
+        {
+          "key": "S80-4",
+          "title": "Test coverage \u2014 briefing next-sprint selection, status heuristic, post-hole command roundtrip",
+          "club": "wedge",
+          "complexity": "small"
+        }
+      ],
+      "depends_on": [],
+      "status": "complete"
+    },
+    {
+      "id": 81,
+      "theme": "Universal Adapter \u2014 Codex CLI, OpenCode, cross-agent support",
+      "par": 4,
+      "slope": 1,
+      "type": "feature",
+      "status": "complete",
+      "note": "stub added during roadmap reconcile \u2014 sprint shipped without an in-roadmap plan entry",
+      "tickets": []
+    },
+    {
+      "id": 82,
+      "theme": "Testing Polish \u2014 Pi/OpenCode integration tests + essential guard tier",
+      "par": 4,
+      "slope": 1,
+      "type": "test + dx",
+      "status": "complete",
+      "note": "stub added during roadmap reconcile \u2014 sprint shipped without an in-roadmap plan entry",
+      "tickets": []
+    },
+    {
+      "id": 83,
+      "theme": "Native Pi Adapter \u2014 HarnessAdapter + init + tests",
+      "par": 4,
+      "slope": 1,
+      "type": "feature",
+      "status": "complete",
+      "note": "stub added during roadmap reconcile \u2014 sprint shipped without an in-roadmap plan entry",
+      "tickets": []
+    },
+    {
+      "id": 84,
+      "theme": "Pi Extension \u2014 local planner+executor harness",
+      "par": 4,
+      "slope": 1,
+      "type": "feature",
+      "status": "complete",
+      "note": "stub added during roadmap reconcile \u2014 sprint shipped without an in-roadmap plan entry",
+      "tickets": []
+    },
+    {
+      "id": 85,
+      "theme": "TBD \u2014 current sprint",
+      "par": 4,
+      "slope": 1,
+      "type": "tbd",
+      "status": "planned",
+      "tickets": []
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two-part roadmap update:

**Part 1 — Reconcile (commit dd66a25)**: Bring `roadmap.json` in sync with what actually shipped on main.
- Mark S70–S84 status=complete based on commit-log evidence (11 sprints had `status:null` despite shipping)
- Add stub entries for S81–S84 (shipped without in-roadmap plans)
- Add S85 + Phase 17 placeholders, mark S75.5 as `planned`

**Part 2 — Plan forward (commit aa795ea)**: Cluster the 25 open GH issues into 6 sprints across 3 new phases.

| Sprint | Theme | Tickets | Issues addressed |
|---|---|---|---|
| S86 | The Marshal — Drift Detection | 5 | #319, #320, #291, #318, #290+#324 |
| S87 | The Bug Clearing v2 | 4 | #300, #298, #304, #306 (supersedes S75.5) |
| S88 | The Compass — Agent State | 4 | #310, #315, #311, #316 |
| S89 | The Toolkit — Agent Workflow | 4 | #312, #313, #314, #309 |
| S90 | The Vault — Memory↔Store | 4 | #294 (split into 4 ordered tickets) |
| S91 | The Pit Crew — Automation | 4 | #302, #321, #322, #305 |

**21 of 25 open issues** scheduled. Backlog (unscheduled): #307 (hook count), #323 (gitignore audit) — small enough to slot opportunistically.

## Why both parts in one PR

Reconcile and plan-forward are the same surface (`roadmap.json`); separating them would create a rebase chore. The reconcile commit is the audit; the plan commit is the response.

## Out of scope

- Persistent S75 → S75.5 → S76 numbering gap (preserved deliberately — subsprint concept intact)
- Oversized historical sprint warnings (S62, S63, S64, S71, S73, S78 — won't rewrite shipped sprints)
- Empty-ticket warnings on S81–S85 stubs

## Companion work in this session

- Closed #297, #299 (fixed in `14d01862` but missing auto-close keywords)
- Labeled remaining 18 issues + 7 newly-filed meta-issues (bug / enhancement / agent-dx / architecture)
- Filed #318–#324 covering systemic drift patterns surfaced during the cleanup

## Test plan

- [x] `npx slope roadmap validate` — only pre-existing numbering gap and stub-related warnings remain (plus explicit 5-ticket S86)
- [ ] Reviewer sanity-check of S81–S84 stub themes vs. merge commit subjects
- [ ] Reviewer sanity-check of S86–S91 sprint clustering and ticket sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)