### PR TITLE
feat(S86): The Marshal — drift detection scaffolding

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"027cf01e-bc2d-42af-9189-68d16403a486","pid":37176,"procStart":"Thu May  7 17:52:58 2026","acquiredAt":1778201820882}

--- a/docs/retros/sprint-70.json
+++ b/docs/retros/sprint-70.json
@@ -1,0 +1,56 @@
+{
+  "sprint_number": 70,
+  "theme": "The Replay \u2014 Session Insights & Debugging",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-03-25",
+  "shots": [
+    {
+      "ticket_key": "S70-1",
+      "title": "feat(S77): The 19th Hole \u2014 workflow engine assessment & phase wrap-up (#208)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit 4f539ef2 on main. Original CI/PR signals not preserved."
+    },
+    {
+      "ticket_key": "S70-2",
+      "title": "feat(S70+S71): Session Insights + Multi-Repo Aggregation (#209)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit e09adcd3 on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 2,
+    "fairways_total": 2,
+    "greens_in_regulation": 2,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 2 commit(s) on main matching feat(S70)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/docs/retros/sprint-74.json
+++ b/docs/retros/sprint-74.json
@@ -1,0 +1,48 @@
+{
+  "sprint_number": 74,
+  "theme": "The Foursome v2 \u2014 Multi-Agent Session Coordination",
+  "par": 4,
+  "slope": 3,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-03-24",
+  "shots": [
+    {
+      "ticket_key": "S74-1",
+      "title": "feat(S74): The Assembly Line \u2014 batch sprint execution (#206)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit 5dc302ee on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 1 commit(s) on main matching feat(S74)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/docs/retros/sprint-75.json
+++ b/docs/retros/sprint-75.json
@@ -1,0 +1,48 @@
+{
+  "sprint_number": 75,
+  "theme": "The Autopilot v2 \u2014 Smart Model Routing",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-03-24",
+  "shots": [
+    {
+      "ticket_key": "S75-1",
+      "title": "feat(S75): The Convergence \u2014 loop self-improvement (#207)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit 3d046105 on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 1 commit(s) on main matching feat(S75)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/docs/retros/sprint-76.json
+++ b/docs/retros/sprint-76.json
@@ -1,0 +1,48 @@
+{
+  "sprint_number": 76,
+  "theme": "The Assembly Line \u2014 Batch Sprint Execution",
+  "par": 4,
+  "slope": 3,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-03-24",
+  "shots": [
+    {
+      "ticket_key": "S76-1",
+      "title": "feat(S76): The Referee \u2014 advisory-to-mechanical guard conversion (#204)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit 99026f3f on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 1 commit(s) on main matching feat(S76)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/docs/retros/sprint-77.json
+++ b/docs/retros/sprint-77.json
@@ -1,0 +1,48 @@
+{
+  "sprint_number": 77,
+  "theme": "The Convergence \u2014 Loop Self-Improvement",
+  "par": 3,
+  "slope": 3,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-03-25",
+  "shots": [
+    {
+      "ticket_key": "S77-1",
+      "title": "feat(S77): The 19th Hole \u2014 workflow engine assessment & phase wrap-up (#208)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit 4f539ef2 on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 1 commit(s) on main matching feat(S77)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/docs/retros/sprint-78.json
+++ b/docs/retros/sprint-78.json
@@ -1,0 +1,48 @@
+{
+  "sprint_number": 78,
+  "theme": "The Referee \u2014 Advisory-to-Mechanical Guard Conversion",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-03-26",
+  "shots": [
+    {
+      "ticket_key": "S78-1",
+      "title": "feat(S78): The Wiring \u2014 fix gaps (forceApi, pause/resume, guard metrics, CODEBASE.md) (#231)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit ca264415 on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 1 commit(s) on main matching feat(S78)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/docs/retros/sprint-79.json
+++ b/docs/retros/sprint-79.json
@@ -1,0 +1,48 @@
+{
+  "sprint_number": 79,
+  "theme": "The 19th Hole \u2014 Workflow Engine Assessment & Phase Wrap-up",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-03-26",
+  "shots": [
+    {
+      "ticket_key": "S79-1",
+      "title": "feat(S79): add plan review phase to workflow definitions (#233)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit 781abe5a on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 1 commit(s) on main matching feat(S79)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/docs/retros/sprint-80.json
+++ b/docs/retros/sprint-80.json
@@ -1,0 +1,48 @@
+{
+  "sprint_number": 80,
+  "theme": "The Course Marshal \u2014 Sprint Hygiene Surfacing",
+  "par": 4,
+  "slope": 1,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-03-29",
+  "shots": [
+    {
+      "ticket_key": "S80-1",
+      "title": "feat(S80): The Watchtower \u2014 worktree-aware guards (#249, #250, #251, #252) (#253)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit 32acc5bb on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 1 commit(s) on main matching feat(S80)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/docs/retros/sprint-81.json
+++ b/docs/retros/sprint-81.json
@@ -1,0 +1,48 @@
+{
+  "sprint_number": 81,
+  "theme": "Universal Adapter \u2014 Codex CLI, OpenCode, cross-agent support",
+  "par": 4,
+  "slope": 1,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-04-04",
+  "shots": [
+    {
+      "ticket_key": "S81-1",
+      "title": "feat(S81): universal adapter \u2014 Codex CLI, OpenCode, cross-agent support (#267)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit eced2494 on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 1 commit(s) on main matching feat(S81)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/docs/retros/sprint-82.json
+++ b/docs/retros/sprint-82.json
@@ -1,0 +1,48 @@
+{
+  "sprint_number": 82,
+  "theme": "Testing Polish \u2014 Pi/OpenCode integration tests + essential guard tier",
+  "par": 4,
+  "slope": 1,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-04-04",
+  "shots": [
+    {
+      "ticket_key": "S82-1",
+      "title": "feat(S82): testing polish \u2014 Pi/OpenCode integration tests + essential guard tier (#272)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit 0b7107bd on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 1 commit(s) on main matching feat(S82)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/docs/retros/sprint-83.json
+++ b/docs/retros/sprint-83.json
@@ -1,0 +1,48 @@
+{
+  "sprint_number": 83,
+  "theme": "Native Pi Adapter \u2014 HarnessAdapter + init + tests",
+  "par": 4,
+  "slope": 1,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-04-10",
+  "shots": [
+    {
+      "ticket_key": "S83-1",
+      "title": "feat(S83): native Pi adapter \u2014 HarnessAdapter + init + tests (#280) (#281)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Backfilled from commit 92f659f4 on main. Original CI/PR signals not preserved."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Backfilled retroactively on 2026-05-07",
+    "Source: 1 commit(s) on main matching feat(S83)",
+    "Original CI/PR/test data not recoverable"
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "This scorecard was backfilled by the S86-4 audit; treat scores as placeholder par."
+  ],
+  "_backfilled": true,
+  "_backfill_source": "main commit log; sub-ticket detail not preserved",
+  "_auto_generated": true
+}

--- a/src/cli/commands/briefing.ts
+++ b/src/cli/commands/briefing.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { formatBriefing, parseRoadmap, getRole, hasRole, loadCustomRoles, filterScorecardsByPlayer, filterHazardsByVisibility, formatDeferredForBriefing, loadDeferred, computeHandicapCard, formatStrategicContext } from '../../core/index.js';
+import { formatBriefing, parseRoadmap, castRoadmapStructure, getRole, hasRole, loadCustomRoles, filterScorecardsByPlayer, filterHazardsByVisibility, formatDeferredForBriefing, loadDeferred, computeHandicapCard, formatStrategicContext } from '../../core/index.js';
 import type { CommonIssuesFile, SessionEntry, SprintClaim, RoadmapDefinition, SlopeEvent, RoleDefinition } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { loadScorecards } from '../loader.js';
@@ -107,7 +107,10 @@ export async function briefingCommand(args: string[]): Promise<void> {
     if (existsSync(resolvedRoadmapPath)) {
       const raw = JSON.parse(readFileSync(resolvedRoadmapPath, 'utf8'));
       const parsed = parseRoadmap(raw);
-      if (parsed.roadmap) roadmap = parsed.roadmap;
+      // Fall back to permissive structural cast when parseRoadmap rejects due
+      // to validation errors (numbering gaps, ticket-count budget, etc.) —
+      // briefing should still surface strategic context when shape is right.
+      roadmap = parsed.roadmap ?? castRoadmapStructure(raw) ?? undefined;
     }
   } catch { /* skip — roadmap is optional */ }
 

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -30,6 +30,7 @@ import { claimRequiredGuard } from '../guards/claim-required.js';
 import { reviewStaleGuard } from '../guards/review-stale.js';
 import { workflowStepGateGuard } from '../guards/workflow-step-gate.js';
 import { roadmapEditShippedGuard } from '../guards/roadmap-edit-shipped.js';
+import { postHoleEnforcementGuard } from '../guards/post-hole-enforcement.js';
 import { formatGuardDocs } from '../guards/docs.js';
 import { recordBaseline } from '../guards/git-utils.js';
 import { execSync } from 'node:child_process';
@@ -104,6 +105,7 @@ const handlers: Partial<Record<GuardName, GuardHandler>> = {
   'worktree-reuse': worktreeReuseGuard,
   'workflow-step-gate': workflowStepGateGuard,
   'roadmap-edit-shipped': roadmapEditShippedGuard,
+  'post-hole-enforcement': postHoleEnforcementGuard,
 };
 
 /** Register a guard handler */

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -29,6 +29,7 @@ import { phaseBoundaryGuard } from '../guards/phase-boundary.js';
 import { claimRequiredGuard } from '../guards/claim-required.js';
 import { reviewStaleGuard } from '../guards/review-stale.js';
 import { workflowStepGateGuard } from '../guards/workflow-step-gate.js';
+import { roadmapEditShippedGuard } from '../guards/roadmap-edit-shipped.js';
 import { formatGuardDocs } from '../guards/docs.js';
 import { recordBaseline } from '../guards/git-utils.js';
 import { execSync } from 'node:child_process';
@@ -102,6 +103,7 @@ const handlers: Partial<Record<GuardName, GuardHandler>> = {
   'review-stale': reviewStaleGuard,
   'worktree-reuse': worktreeReuseGuard,
   'workflow-step-gate': workflowStepGateGuard,
+  'roadmap-edit-shipped': roadmapEditShippedGuard,
 };
 
 /** Register a guard handler */

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 import {
   parseRoadmap,
   validateRoadmap,
+  castRoadmapStructure,
+  findShippedSprintsOnMain,
   computeCriticalPath,
   findParallelOpportunities,
   formatRoadmapSummary,
@@ -98,8 +100,21 @@ function validateSubcommand(flags: Record<string, string>, cwd: string): void {
   const loaded = loadRawRoadmap(flags, cwd);
   if (!loaded) process.exit(1);
 
-  const { path, raw } = loaded;
-  const { roadmap, validation } = parseRoadmap(raw);
+  const { path, raw } = loaded!;
+  const parsed = parseRoadmap(raw);
+  let { validation } = parsed;
+
+  // Re-cast structurally even if parseRoadmap returned null due to validation
+  // failure — drift checks should still fire on roadmaps that have ticket/
+  // numbering issues. Only skip if the JSON has no name/sprints/phases at all.
+  const roadmap = parsed.roadmap ?? castRoadmapStructure(raw);
+
+  if (roadmap) {
+    const config = loadConfig(cwd);
+    const scorecards = loadScorecards(config, cwd).map(s => ({ sprint_number: s.sprint_number }));
+    const shippedSprintIds = findShippedSprintsOnMain(cwd);
+    validation = validateRoadmap(roadmap, scorecards, shippedSprintIds);
+  }
 
   console.log(`\nRoadmap: ${path}`);
   console.log('\u2550'.repeat(40));

--- a/src/cli/guards/post-hole-enforcement.ts
+++ b/src/cli/guards/post-hole-enforcement.ts
@@ -1,0 +1,104 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { HookInput, GuardResult } from '../../core/index.js';
+import { findShippedSprintsOnMain } from '../../core/index.js';
+import { loadConfig } from '../config.js';
+
+/**
+ * Post-hole enforcement guard: fires on Stop.
+ *
+ * Detects "silent roadmap drift" — sprints with shipped commits on main
+ * that haven't been properly closed out per the post-hole routine. A
+ * sprint is considered drifting if either:
+ *   • roadmap.json status is not "complete", OR
+ *   • no scorecard exists at docs/retros/sprint-N.json
+ *
+ * Advisory by default — surfaces the drift list with fix commands. Set
+ * SLOPE_POST_HOLE_BLOCK=1 to upgrade to a mechanical block on session end.
+ *
+ * Tied to GH #291. Builds on the validator drift detector from S86-1
+ * (findShippedSprintsOnMain in src/core/analyzers/git.ts).
+ */
+export async function postHoleEnforcementGuard(_input: HookInput, cwd: string): Promise<GuardResult> {
+  let roadmapAbs: string;
+  let scorecardDirAbs: string;
+  let scorecardPattern: string;
+
+  try {
+    const config = loadConfig(cwd);
+    roadmapAbs = join(cwd, config.roadmapPath);
+    scorecardDirAbs = join(cwd, config.scorecardDir);
+    scorecardPattern = config.scorecardPattern;
+  } catch {
+    return {};
+  }
+
+  if (!existsSync(roadmapAbs)) return {};
+
+  // Loose JSON parse — only need .sprints[]; phases and other fields are
+  // out of scope for this guard.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(roadmapAbs, 'utf8'));
+  } catch {
+    return {};
+  }
+  const sprints = (parsed as { sprints?: unknown[] })?.sprints;
+  if (!Array.isArray(sprints)) return {};
+
+  const statusById = new Map<number, string | null>();
+  for (const s of sprints) {
+    const id = (s as { id?: unknown })?.id;
+    const status = (s as { status?: unknown })?.status;
+    if (typeof id === 'number') {
+      statusById.set(id, typeof status === 'string' ? status : null);
+    }
+  }
+
+  const shipped = findShippedSprintsOnMain(cwd);
+  if (shipped.size === 0) return {};
+
+  type Drift = { sprint: number; issues: string[] };
+  const drifts: Drift[] = [];
+  for (const id of [...shipped].sort((a, b) => b - a)) {
+    const status = statusById.get(id);
+    const scorecardFile = join(scorecardDirAbs, scorecardPattern.replace('*', String(id)));
+    const hasScorecard = existsSync(scorecardFile);
+
+    const issues: string[] = [];
+    if (status !== 'complete') issues.push(`status="${status ?? 'unset'}"`);
+    if (!hasScorecard) issues.push('no scorecard');
+
+    if (issues.length > 0) drifts.push({ sprint: id, issues });
+  }
+
+  if (drifts.length === 0) return {};
+
+  const shown = drifts.slice(0, 5);
+  const remainder = drifts.length - shown.length;
+
+  const lines = [
+    `SLOPE post-hole enforcement: ${drifts.length} shipped sprint${drifts.length === 1 ? '' : 's'} with incomplete close-out:`,
+    '',
+    ...shown.map(d => `  • S${d.sprint}: ${d.issues.join(', ')}`),
+  ];
+  if (remainder > 0) lines.push(`  …and ${remainder} more`);
+  lines.push(
+    '',
+    'Per the post-hole routine, each shipped sprint needs:',
+    '  • status:complete in roadmap.json',
+    '  • scorecard at docs/retros/sprint-N.json',
+    '',
+    'Fix commands:',
+    '  - Build scorecard: slope auto-card --sprint=<N>',
+    '  - Validate scorecard: slope validate',
+    '  - Roadmap status: edit docs/backlog/roadmap.json (or slope sprint complete)',
+  );
+
+  const message = lines.join('\n');
+
+  if (process.env.SLOPE_POST_HOLE_BLOCK === '1') {
+    return { decision: 'deny', blockReason: message };
+  }
+  return { context: message };
+}

--- a/src/cli/guards/post-hole-enforcement.ts
+++ b/src/cli/guards/post-hole-enforcement.ts
@@ -33,6 +33,15 @@ export async function postHoleEnforcementGuard(_input: HookInput, cwd: string): 
     return {};
   }
 
+  // Pattern must contain a '*' wildcard so each sprint's scorecard resolves
+  // to a unique filename. Misconfigured patterns (e.g. 'sprint.json') would
+  // collide every sprint to the same path, making this check meaningless.
+  if (!scorecardPattern.includes('*')) {
+    return {
+      context: `SLOPE post-hole enforcement: scorecardPattern "${scorecardPattern}" has no '*' wildcard — drift detection skipped. Update .slope/config.json to e.g. "sprint-*.json".`,
+    };
+  }
+
   if (!existsSync(roadmapAbs)) return {};
 
   // Loose JSON parse — only need .sprints[]; phases and other fields are

--- a/src/cli/guards/post-hole-enforcement.ts
+++ b/src/cli/guards/post-hole-enforcement.ts
@@ -62,7 +62,10 @@ export async function postHoleEnforcementGuard(_input: HookInput, cwd: string): 
   const drifts: Drift[] = [];
   for (const id of [...shipped].sort((a, b) => b - a)) {
     const status = statusById.get(id);
-    const scorecardFile = join(scorecardDirAbs, scorecardPattern.replace('*', String(id)));
+    // Replace EVERY '*' so patterns with multiple wildcards are sanitized
+    // (CodeQL js/incomplete-sanitization): single .replace() leaves later
+    // occurrences as literal '*' which won't match real filenames.
+    const scorecardFile = join(scorecardDirAbs, scorecardPattern.replaceAll('*', String(id)));
     const hasScorecard = existsSync(scorecardFile);
 
     const issues: string[] = [];

--- a/src/cli/guards/roadmap-edit-shipped.ts
+++ b/src/cli/guards/roadmap-edit-shipped.ts
@@ -103,6 +103,14 @@ export async function roadmapEditShippedGuard(input: HookInput, cwd: string): Pr
   };
 }
 
+/** Detect built-in object types that need special equality handling.
+ *  Plain objects fall through to recursive key comparison. */
+function isNonPlainObject(v: unknown): boolean {
+  if (v === null || typeof v !== 'object') return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto !== Object.prototype && proto !== null && !Array.isArray(v);
+}
+
 function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (typeof a !== typeof b) return false;
@@ -116,6 +124,18 @@ function deepEqual(a: unknown, b: unknown): boolean {
       if (!deepEqual(a[i], b[i])) return false;
     }
     return true;
+  }
+
+  // Non-plain objects (Date, RegExp, Map, Set, etc.) — compare via JSON
+  // serialization as a conservative fallback. roadmap.json never contains
+  // these in practice, but guarding here prevents future schema additions
+  // from triggering infinite recursion or incorrect equality.
+  if (isNonPlainObject(a) || isNonPlainObject(b)) {
+    try {
+      return JSON.stringify(a) === JSON.stringify(b);
+    } catch {
+      return false; // circular references → conservatively flag as unequal
+    }
   }
 
   const ka = Object.keys(a as Record<string, unknown>).sort();

--- a/src/cli/guards/roadmap-edit-shipped.ts
+++ b/src/cli/guards/roadmap-edit-shipped.ts
@@ -1,0 +1,129 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { HookInput, GuardResult } from '../../core/index.js';
+import { loadConfig } from '../../core/index.js';
+
+const DEFAULT_ROADMAP_PATH = 'docs/backlog/roadmap.json';
+
+/**
+ * roadmap-edit-shipped guard: PreToolUse on Edit|Write.
+ * Blocks edits to roadmap.json that modify any sprint with status:"complete".
+ * Shipped sprints are historical record — adding tickets, changing fields,
+ * or removing entries retroactively creates "paper-tickets" against frozen
+ * sprints (see GH #320 / commit 9255ee8).
+ *
+ * Override: set SLOPE_ALLOW_SHIPPED_EDIT=1 in the shell to bypass.
+ */
+export async function roadmapEditShippedGuard(input: HookInput, cwd: string): Promise<GuardResult> {
+  if (process.env.SLOPE_ALLOW_SHIPPED_EDIT === '1') return {};
+
+  const filePath = input.tool_input?.file_path as string | undefined;
+  if (!filePath) return {};
+
+  let roadmapAbs: string;
+  try {
+    const config = loadConfig(cwd);
+    roadmapAbs = resolve(cwd, config.roadmapPath ?? DEFAULT_ROADMAP_PATH);
+  } catch {
+    roadmapAbs = resolve(cwd, DEFAULT_ROADMAP_PATH);
+  }
+
+  if (resolve(filePath) !== roadmapAbs) return {};
+
+  let currentContent: string;
+  try {
+    currentContent = readFileSync(roadmapAbs, 'utf8');
+  } catch {
+    return {}; // file doesn't exist yet — nothing to protect
+  }
+
+  const newString = input.tool_input?.new_string as string | undefined;
+  const oldString = input.tool_input?.old_string as string | undefined;
+  if (newString === undefined) return {};
+
+  let wouldBeContent: string;
+  if (oldString !== undefined) {
+    if (!currentContent.includes(oldString)) return {}; // Edit will fail with its own error
+    wouldBeContent = currentContent.replace(oldString, newString);
+  } else {
+    wouldBeContent = newString;
+  }
+
+  let current: { sprints?: unknown[] };
+  let next: { sprints?: unknown[] };
+  try {
+    current = JSON.parse(currentContent);
+    next = JSON.parse(wouldBeContent);
+  } catch {
+    return {}; // malformed JSON on either side — let other tools surface that
+  }
+
+  if (!Array.isArray(current.sprints) || !Array.isArray(next.sprints)) return {};
+
+  const nextById = new Map<number, unknown>();
+  for (const s of next.sprints) {
+    const id = (s as { id?: unknown })?.id;
+    if (typeof id === 'number') nextById.set(id, s);
+  }
+
+  const violations: string[] = [];
+  for (const cur of current.sprints) {
+    const c = cur as { id?: unknown; status?: unknown };
+    if (c?.status !== 'complete') continue;
+    const id = c.id;
+    if (typeof id !== 'number') continue;
+
+    const nxt = nextById.get(id);
+    if (nxt === undefined) {
+      violations.push(`S${id}: removed (was status:complete)`);
+      continue;
+    }
+    if (!deepEqual(cur, nxt)) {
+      violations.push(`S${id}: shipped sprint fields modified`);
+    }
+  }
+
+  if (violations.length === 0) return {};
+
+  return {
+    decision: 'deny',
+    blockReason: [
+      'SLOPE: Cannot edit shipped sprints (status:complete).',
+      '',
+      'Violations:',
+      ...violations.map(v => `  • ${v}`),
+      '',
+      'Shipped sprints are historical record. Modifying their tickets, status,',
+      'or theme creates "paper-tickets" against frozen sprints (GH #320).',
+      'File the work as a NEW sprint instead.',
+      '',
+      'Override: set SLOPE_ALLOW_SHIPPED_EDIT=1 if you genuinely need to',
+      'correct shipped-sprint history.',
+    ].join('\n'),
+  };
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== 'object') return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  const ka = Object.keys(a as Record<string, unknown>).sort();
+  const kb = Object.keys(b as Record<string, unknown>).sort();
+  if (ka.length !== kb.length) return false;
+  for (let i = 0; i < ka.length; i++) {
+    if (ka[i] !== kb[i]) return false;
+    if (!deepEqual((a as Record<string, unknown>)[ka[i]], (b as Record<string, unknown>)[kb[i]])) return false;
+  }
+  return true;
+}

--- a/src/core/analyzers/git.ts
+++ b/src/core/analyzers/git.ts
@@ -27,9 +27,20 @@ export function extractSprintReferences(commitSubjects: string[]): Set<number> {
   return result;
 }
 
+/**
+ * Allowed characters in git refs (branch / tag / abbreviated SHA). Permissive
+ * enough for the names users actually pick (alphanumerics, slash, dot, dash,
+ * underscore, plus) — strict enough to forbid shell metacharacters that would
+ * make this function a shell-injection sink (CodeQL js/shell-command-...).
+ */
+const SAFE_REF_RE = /^[A-Za-z0-9/_.+-]+$/;
+
 /** Detect sprint IDs with shipped commits on the given ref (default: main).
  *  Falls back to `master` then `HEAD` if main is unavailable. Returns an empty
  *  set on any git failure so callers can run validation without a working repo.
+ *  Refs are validated against SAFE_REF_RE before being interpolated into the
+ *  shell command — refs containing whitespace, semicolons, backticks, etc.
+ *  short-circuit to an empty set rather than risk a shell injection.
  */
 export function findShippedSprintsOnMain(cwd: string, ref?: string): Set<number> {
   const isGit = git('rev-parse --is-inside-work-tree', cwd);
@@ -37,6 +48,7 @@ export function findShippedSprintsOnMain(cwd: string, ref?: string): Set<number>
 
   const candidates = ref ? [ref] : ['main', 'master', 'HEAD'];
   for (const r of candidates) {
+    if (!SAFE_REF_RE.test(r)) continue; // skip unsafe refs silently
     const log = git(`log ${r} --oneline --no-decorate -n 5000`, cwd);
     if (log) return extractSprintReferences(log.split('\n'));
   }

--- a/src/core/analyzers/git.ts
+++ b/src/core/analyzers/git.ts
@@ -49,7 +49,10 @@ export function findShippedSprintsOnMain(cwd: string, ref?: string): Set<number>
   const candidates = ref ? [ref] : ['main', 'master', 'HEAD'];
   for (const r of candidates) {
     if (!SAFE_REF_RE.test(r)) continue; // skip unsafe refs silently
-    const log = git(`log ${r} --oneline --no-decorate -n 5000`, cwd);
+    // Cap at 1000 commits — plenty for sprint references (a project would
+    // need to ship hundreds of sprints to exhaust this) and avoids slowing
+    // session-end Stop hooks on deep-history repos.
+    const log = git(`log ${r} --oneline --no-decorate -n 1000`, cwd);
     if (log) return extractSprintReferences(log.split('\n'));
   }
   return new Set();

--- a/src/core/analyzers/git.ts
+++ b/src/core/analyzers/git.ts
@@ -10,6 +10,39 @@ function git(cmd: string, cwd: string): string {
   }
 }
 
+/** Extract sprint IDs referenced in commit subjects.
+ *  Matches `S\d+` not followed by another digit or a dot — so `S75.5` does
+ *  NOT count as a reference to S75, and `S70+S71` correctly yields {70, 71}.
+ *  Pure function — separated from git I/O for testability.
+ */
+export function extractSprintReferences(commitSubjects: string[]): Set<number> {
+  const result = new Set<number>();
+  const re = /\bS(\d+)(?![\d.])/g;
+  for (const line of commitSubjects) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(line)) !== null) {
+      result.add(parseInt(m[1], 10));
+    }
+  }
+  return result;
+}
+
+/** Detect sprint IDs with shipped commits on the given ref (default: main).
+ *  Falls back to `master` then `HEAD` if main is unavailable. Returns an empty
+ *  set on any git failure so callers can run validation without a working repo.
+ */
+export function findShippedSprintsOnMain(cwd: string, ref?: string): Set<number> {
+  const isGit = git('rev-parse --is-inside-work-tree', cwd);
+  if (isGit !== 'true') return new Set();
+
+  const candidates = ref ? [ref] : ['main', 'master', 'HEAD'];
+  for (const r of candidates) {
+    const log = git(`log ${r} --oneline --no-decorate -n 5000`, cwd);
+    if (log) return extractSprintReferences(log.split('\n'));
+  }
+  return new Set();
+}
+
 function parseContributors(output: string): Array<{ name: string; email: string; commits: number }> {
   if (!output) return [];
   const contributors: Array<{ name: string; email: string; commits: number }> = [];

--- a/src/core/guard.ts
+++ b/src/core/guard.ts
@@ -105,7 +105,8 @@ export type GuardName =
   | 'review-stale'
   | 'worktree-reuse'
   | 'workflow-step-gate'
-  | 'roadmap-edit-shipped';
+  | 'roadmap-edit-shipped'
+  | 'post-hole-enforcement';
 
 /** Guard registration entry */
 export interface GuardDefinition {
@@ -417,6 +418,13 @@ export const GUARD_DEFINITIONS: GuardDefinition[] = [
     matcher: 'Edit|Write',
     level: 'full',
     guardType: 'mechanical',
+  },
+  {
+    name: 'post-hole-enforcement',
+    description: 'Surface shipped sprints missing scorecards or roadmap status:complete at session end',
+    hookEvent: 'Stop',
+    level: 'full',
+    guardType: 'advisory',
   },
 ];
 

--- a/src/core/guard.ts
+++ b/src/core/guard.ts
@@ -104,7 +104,8 @@ export type GuardName =
   | 'claim-required'
   | 'review-stale'
   | 'worktree-reuse'
-  | 'workflow-step-gate';
+  | 'workflow-step-gate'
+  | 'roadmap-edit-shipped';
 
 /** Guard registration entry */
 export interface GuardDefinition {
@@ -407,6 +408,15 @@ export const GUARD_DEFINITIONS: GuardDefinition[] = [
     matcher: 'EnterWorktree',
     level: 'full',
     guardType: 'advisory',
+  },
+  {
+    name: 'roadmap-edit-shipped',
+    description: 'Block edits to roadmap.json that modify sprints with status:complete (paper-tickets)',
+    hookEvent: 'PreToolUse',
+    toolCategories: ['write_file'],
+    matcher: 'Edit|Write',
+    level: 'full',
+    guardType: 'mechanical',
   },
 ];
 

--- a/src/core/guard.ts
+++ b/src/core/guard.ts
@@ -421,7 +421,7 @@ export const GUARD_DEFINITIONS: GuardDefinition[] = [
   },
   {
     name: 'post-hole-enforcement',
-    description: 'Surface shipped sprints missing scorecards or roadmap status:complete at session end',
+    description: 'Surface shipped sprints missing scorecards or roadmap status:complete at session end (advisory; set SLOPE_POST_HOLE_BLOCK=1 to block instead)',
     hookEvent: 'Stop',
     level: 'full',
     guardType: 'advisory',

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -166,9 +166,11 @@ export {
   computeCriticalPath,
   findParallelOpportunities,
   parseRoadmap,
+  castRoadmapStructure,
   formatRoadmapSummary,
   formatStrategicContext,
 } from './roadmap.js';
+export { extractSprintReferences, findShippedSprintsOnMain } from './analyzers/git.js';
 export type {
   RoadmapDefinition,
   RoadmapSprint,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -169,6 +169,7 @@ export {
   castRoadmapStructure,
   formatRoadmapSummary,
   formatStrategicContext,
+  findNextPlannedSprint,
 } from './roadmap.js';
 export { extractSprintReferences, findShippedSprintsOnMain } from './analyzers/git.js';
 export type {

--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -571,5 +571,48 @@ export function formatStrategicContext(
     lines.push(`Feeds into: ${dependents.join(', ')}`);
   }
 
+  // Next planned sprint (dependency-resolved) — see GH #290
+  const next = findNextPlannedSprint(roadmap, currentSprint);
+  if (next) {
+    const blockers = (next.depends_on ?? [])
+      .filter(d => {
+        const dep = roadmap.sprints.find(s => s.id === d);
+        return !dep || (dep as RoadmapSprint & { status?: string }).status !== 'complete';
+      });
+    const status = blockers.length === 0
+      ? 'ready'
+      : `blocked by ${blockers.map(b => `S${b}`).join(', ')}`;
+    lines.push(`Next: S${next.id}: ${next.theme} (${status})`);
+  }
+
   return lines.join('\n');
+}
+
+/** Find the next planned sprint after currentSprint.
+ *  Prefers a sprint with all dependencies satisfied (status:complete);
+ *  falls back to the lowest-id non-complete sprint when nothing is unblocked.
+ *  Returns null if no candidate found.
+ */
+export function findNextPlannedSprint(
+  roadmap: RoadmapDefinition,
+  currentSprint: number,
+): RoadmapSprint | null {
+  const candidates = roadmap.sprints
+    .filter(s => {
+      const status = (s as RoadmapSprint & { status?: string }).status;
+      return status !== 'complete' && s.id > currentSprint;
+    })
+    .sort((a, b) => a.id - b.id);
+
+  if (candidates.length === 0) return null;
+
+  const completedIds = new Set(
+    roadmap.sprints
+      .filter(s => (s as RoadmapSprint & { status?: string }).status === 'complete')
+      .map(s => s.id),
+  );
+
+  // Prefer the lowest-id candidate whose dependencies are all complete
+  const ready = candidates.find(s => (s.depends_on ?? []).every(d => completedIds.has(d)));
+  return ready ?? candidates[0];
 }

--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -63,11 +63,14 @@ export interface RoadmapValidationResult {
 }
 
 /** Validate a roadmap definition for structural correctness.
- *  Optionally cross-check sprint status against scorecards when provided.
+ *  Optionally cross-check sprint status against scorecards and/or shipped
+ *  sprint commits on main when provided. Caller is responsible for collecting
+ *  scorecards (via loadScorecards) and shipped IDs (via findShippedSprintsOnMain).
  */
 export function validateRoadmap(
   roadmap: RoadmapDefinition,
   scorecards?: { sprint_number: number }[],
+  shippedSprintIds?: Set<number>,
 ): RoadmapValidationResult {
   const errors: RoadmapValidationError[] = [];
   const warnings: RoadmapValidationWarning[] = [];
@@ -205,6 +208,30 @@ export function validateRoadmap(
           type: 'warning',
           sprint: sprint.id,
           message: `S${sprint.id} is marked "complete" in roadmap but no scorecard exists (phantom sprint)`,
+        });
+      }
+    }
+  }
+
+  // Cross-validate sprint status against shipped commits on main when provided
+  if (shippedSprintIds) {
+    for (const sprint of roadmap.sprints) {
+      const status = (sprint as RoadmapSprint & { status?: string }).status;
+      const isShipped = shippedSprintIds.has(sprint.id);
+
+      if (isShipped && status !== 'complete') {
+        errors.push({
+          type: 'error',
+          sprint: sprint.id,
+          message: `S${sprint.id} has shipped commits on main but status is "${status ?? 'planned'}" — expected "complete"`,
+        });
+      }
+
+      if (!isShipped && status === 'complete') {
+        warnings.push({
+          type: 'warning',
+          sprint: sprint.id,
+          message: `S${sprint.id} is marked "complete" but no shipped commits found on main`,
         });
       }
     }
@@ -404,59 +431,51 @@ function computeDepthMap(sprints: RoadmapSprint[]): Map<number, number> {
 
 // --- Parse ---
 
+/** Cast a raw JSON object to RoadmapDefinition if minimally structurally valid.
+ *  Unlike parseRoadmap, this does not run full validation — useful when callers
+ *  want to flag validation issues against a structurally-cast roadmap (e.g.
+ *  drift detection should still run when ticket counts or numbering are off).
+ */
+export function castRoadmapStructure(json: unknown): RoadmapDefinition | null {
+  if (!json || typeof json !== 'object') return null;
+  const obj = json as Record<string, unknown>;
+  if (typeof obj.name !== 'string') return null;
+  if (!Array.isArray(obj.sprints)) return null;
+  if (!Array.isArray(obj.phases)) return null;
+  return obj as unknown as RoadmapDefinition;
+}
+
 /** Parse and validate a roadmap from a JSON object */
 export function parseRoadmap(json: unknown): { roadmap: RoadmapDefinition | null; validation: RoadmapValidationResult } {
-  // Type guard: check minimal structure
+  // Type guard: check minimal structure with explicit per-field error messages
   if (!json || typeof json !== 'object') {
     return {
       roadmap: null,
-      validation: {
-        valid: false,
-        errors: [{ type: 'error', message: 'Input is not an object' }],
-        warnings: [],
-      },
+      validation: { valid: false, errors: [{ type: 'error', message: 'Input is not an object' }], warnings: [] },
     };
   }
-
   const obj = json as Record<string, unknown>;
-
   if (typeof obj.name !== 'string') {
     return {
       roadmap: null,
-      validation: {
-        valid: false,
-        errors: [{ type: 'error', message: 'Missing required field: name' }],
-        warnings: [],
-      },
+      validation: { valid: false, errors: [{ type: 'error', message: 'Missing required field: name' }], warnings: [] },
     };
   }
-
   if (!Array.isArray(obj.sprints)) {
     return {
       roadmap: null,
-      validation: {
-        valid: false,
-        errors: [{ type: 'error', message: 'Missing required field: sprints (must be an array)' }],
-        warnings: [],
-      },
+      validation: { valid: false, errors: [{ type: 'error', message: 'Missing required field: sprints (must be an array)' }], warnings: [] },
     };
   }
-
   if (!Array.isArray(obj.phases)) {
     return {
       roadmap: null,
-      validation: {
-        valid: false,
-        errors: [{ type: 'error', message: 'Missing required field: phases (must be an array)' }],
-        warnings: [],
-      },
+      validation: { valid: false, errors: [{ type: 'error', message: 'Missing required field: phases (must be an array)' }], warnings: [] },
     };
   }
 
-  // Cast — validateRoadmap will catch structural issues in sprint/ticket fields
   const roadmap = obj as unknown as RoadmapDefinition;
   const validation = validateRoadmap(roadmap);
-
   return { roadmap: validation.valid ? roadmap : null, validation };
 }
 

--- a/tests/cli/guards/post-hole-enforcement.test.ts
+++ b/tests/cli/guards/post-hole-enforcement.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+import { postHoleEnforcementGuard } from '../../../src/cli/guards/post-hole-enforcement.js';
+import type { HookInput } from '../../../src/core/index.js';
+
+function makeTmpRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'slope-posthole-'));
+  mkdirSync(join(dir, 'docs', 'backlog'), { recursive: true });
+  mkdirSync(join(dir, 'docs', 'retros'), { recursive: true });
+  mkdirSync(join(dir, '.slope'), { recursive: true });
+  writeFileSync(join(dir, '.slope', 'config.json'), JSON.stringify({
+    roadmapPath: 'docs/backlog/roadmap.json',
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+  }));
+  // Initialize git so findShippedSprintsOnMain has a repo to query
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email test@test', { cwd: dir });
+  execSync('git config user.name test', { cwd: dir });
+  return dir;
+}
+
+function commit(cwd: string, message: string) {
+  writeFileSync(join(cwd, `f-${Date.now()}-${Math.random()}.txt`), message);
+  execSync('git add -A', { cwd });
+  execSync(`git commit -q --allow-empty -m "${message}"`, { cwd });
+}
+
+function writeRoadmap(cwd: string, sprints: object[]) {
+  writeFileSync(
+    join(cwd, 'docs', 'backlog', 'roadmap.json'),
+    JSON.stringify({ name: 'Test', phases: [], sprints }, null, 2),
+  );
+}
+
+function writeScorecard(cwd: string, sprintId: number) {
+  writeFileSync(
+    join(cwd, 'docs', 'retros', `sprint-${sprintId}.json`),
+    JSON.stringify({ sprint_number: sprintId }),
+  );
+}
+
+const stopInput: HookInput = {
+  session_id: 'test',
+  cwd: '/will-be-overridden',
+  hook_event_name: 'Stop',
+  tool_response: {},
+};
+
+describe('postHoleEnforcementGuard', () => {
+  let cwd: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    cwd = makeTmpRepo();
+    originalEnv = process.env.SLOPE_POST_HOLE_BLOCK;
+    delete process.env.SLOPE_POST_HOLE_BLOCK;
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+    if (originalEnv !== undefined) process.env.SLOPE_POST_HOLE_BLOCK = originalEnv;
+    else delete process.env.SLOPE_POST_HOLE_BLOCK;
+  });
+
+  it('returns empty when no roadmap exists', async () => {
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result).toEqual({});
+  });
+
+  it('returns empty when no shipped sprints found', async () => {
+    writeRoadmap(cwd, [{ id: 1, status: 'planned' }]);
+    commit(cwd, 'chore: bump version'); // no S\d+ refs
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result).toEqual({});
+  });
+
+  it('returns empty when shipped sprint is fully closed out', async () => {
+    writeRoadmap(cwd, [{ id: 7, status: 'complete' }]);
+    writeScorecard(cwd, 7);
+    commit(cwd, 'feat(S7): closed out');
+
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result).toEqual({});
+  });
+
+  it('warns when shipped sprint has no scorecard', async () => {
+    writeRoadmap(cwd, [{ id: 7, status: 'complete' }]);
+    commit(cwd, 'feat(S7): shipped without scorecard');
+
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result.context).toBeDefined();
+    expect(result.context).toContain('S7');
+    expect(result.context).toContain('no scorecard');
+    expect(result.decision).toBeUndefined();
+  });
+
+  it('warns when shipped sprint has wrong status', async () => {
+    writeRoadmap(cwd, [{ id: 7, status: 'planned' }]);
+    writeScorecard(cwd, 7);
+    commit(cwd, 'feat(S7): shipped but status not updated');
+
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result.context).toContain('S7');
+    expect(result.context).toContain('status="planned"');
+  });
+
+  it('lists multiple drifting sprints sorted newest-first', async () => {
+    writeRoadmap(cwd, [
+      { id: 5, status: 'planned' },
+      { id: 6, status: 'complete' },
+      { id: 7, status: 'planned' },
+    ]);
+    writeScorecard(cwd, 6);
+    commit(cwd, 'feat(S5+S6+S7): all shipped, S5/S7 drift');
+
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result.context).toContain('S7');
+    expect(result.context).toContain('S5');
+    // Newest first: S7 line should appear before S5 line
+    const idxS7 = result.context!.indexOf('S7');
+    const idxS5 = result.context!.indexOf('S5');
+    expect(idxS7).toBeLessThan(idxS5);
+  });
+
+  it('caps the list and shows remainder count beyond 5', async () => {
+    const sprints: object[] = [];
+    for (let i = 1; i <= 7; i++) {
+      sprints.push({ id: i, status: 'planned' });
+    }
+    writeRoadmap(cwd, sprints);
+    commit(cwd, 'feat(S1+S2+S3+S4+S5+S6+S7): seven drifting sprints');
+
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result.context).toContain('and 2 more');
+  });
+
+  it('blocks instead of warns when SLOPE_POST_HOLE_BLOCK=1', async () => {
+    writeRoadmap(cwd, [{ id: 7, status: 'planned' }]);
+    commit(cwd, 'feat(S7): shipped');
+    process.env.SLOPE_POST_HOLE_BLOCK = '1';
+
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result.decision).toBe('deny');
+    expect(result.blockReason).toContain('S7');
+  });
+
+  it('handles malformed roadmap JSON gracefully', async () => {
+    writeFileSync(join(cwd, 'docs', 'backlog', 'roadmap.json'), '{ malformed');
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result).toEqual({});
+  });
+});

--- a/tests/cli/guards/roadmap-edit-shipped.test.ts
+++ b/tests/cli/guards/roadmap-edit-shipped.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { roadmapEditShippedGuard } from '../../../src/cli/guards/roadmap-edit-shipped.js';
+import type { HookInput } from '../../../src/core/index.js';
+
+function makeTmpRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'slope-guard-'));
+  mkdirSync(join(dir, 'docs', 'backlog'), { recursive: true });
+  return dir;
+}
+
+function writeRoadmap(cwd: string, content: object): string {
+  const path = join(cwd, 'docs', 'backlog', 'roadmap.json');
+  writeFileSync(path, JSON.stringify(content, null, 2));
+  return path;
+}
+
+function baseRoadmap() {
+  return {
+    name: 'Test',
+    description: 'test',
+    phases: [{ name: 'P1', sprints: [1, 2] }],
+    sprints: [
+      {
+        id: 1,
+        theme: 'Shipped sprint',
+        par: 4,
+        slope: 1,
+        type: 'feature',
+        status: 'complete',
+        tickets: [
+          { key: 'S1-1', title: 'Original', club: 'short_iron', complexity: 'standard' },
+        ],
+      },
+      {
+        id: 2,
+        theme: 'Planned sprint',
+        par: 4,
+        slope: 1,
+        type: 'feature',
+        status: 'planned',
+        tickets: [
+          { key: 'S2-1', title: 'Future', club: 'short_iron', complexity: 'standard' },
+        ],
+      },
+    ],
+  };
+}
+
+function writeInput(filePath: string, newContent: string): HookInput {
+  return {
+    session_id: 'test',
+    cwd: '/tmp',
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Write',
+    tool_input: { file_path: filePath, new_string: newContent },
+    tool_response: {},
+  };
+}
+
+function editInput(filePath: string, oldString: string, newString: string): HookInput {
+  return {
+    session_id: 'test',
+    cwd: '/tmp',
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Edit',
+    tool_input: { file_path: filePath, old_string: oldString, new_string: newString },
+    tool_response: {},
+  };
+}
+
+describe('roadmapEditShippedGuard', () => {
+  let cwd: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    cwd = makeTmpRepo();
+    originalEnv = process.env.SLOPE_ALLOW_SHIPPED_EDIT;
+    delete process.env.SLOPE_ALLOW_SHIPPED_EDIT;
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+    if (originalEnv !== undefined) process.env.SLOPE_ALLOW_SHIPPED_EDIT = originalEnv;
+    else delete process.env.SLOPE_ALLOW_SHIPPED_EDIT;
+  });
+
+  it('allows edits to non-roadmap files', async () => {
+    const result = await roadmapEditShippedGuard(
+      writeInput(join(cwd, 'src/main.ts'), 'console.log()'),
+      cwd,
+    );
+    expect(result).toEqual({});
+  });
+
+  it('allows roadmap edits when no sprint is complete', async () => {
+    const roadmap = baseRoadmap();
+    roadmap.sprints[0].status = 'planned';
+    const path = writeRoadmap(cwd, roadmap);
+
+    const next = JSON.parse(JSON.stringify(roadmap));
+    next.sprints[0].theme = 'Updated theme';
+    const result = await roadmapEditShippedGuard(writeInput(path, JSON.stringify(next, null, 2)), cwd);
+    expect(result).toEqual({});
+  });
+
+  it('allows edits that only touch planned sprints', async () => {
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const next = baseRoadmap();
+    next.sprints[1].theme = 'New planned theme'; // S2 is planned
+    const result = await roadmapEditShippedGuard(writeInput(path, JSON.stringify(next, null, 2)), cwd);
+    expect(result).toEqual({});
+  });
+
+  it('blocks adding a ticket to a shipped sprint', async () => {
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const next = baseRoadmap();
+    next.sprints[0].tickets.push({
+      key: 'S1-2',
+      title: 'New paper-ticket',
+      club: 'short_iron',
+      complexity: 'standard',
+    });
+    const result = await roadmapEditShippedGuard(writeInput(path, JSON.stringify(next, null, 2)), cwd);
+    expect(result.decision).toBe('deny');
+    expect(result.blockReason).toContain('S1');
+    expect(result.blockReason).toContain('shipped sprint fields modified');
+  });
+
+  it('blocks changing the theme of a shipped sprint', async () => {
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const next = baseRoadmap();
+    next.sprints[0].theme = 'Rewritten history';
+    const result = await roadmapEditShippedGuard(writeInput(path, JSON.stringify(next, null, 2)), cwd);
+    expect(result.decision).toBe('deny');
+  });
+
+  it('blocks reverting status from complete to planned', async () => {
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const next = baseRoadmap();
+    next.sprints[0].status = 'planned';
+    const result = await roadmapEditShippedGuard(writeInput(path, JSON.stringify(next, null, 2)), cwd);
+    expect(result.decision).toBe('deny');
+  });
+
+  it('blocks removing a shipped sprint entirely', async () => {
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const next = baseRoadmap();
+    next.sprints = [next.sprints[1]]; // drop S1
+    const result = await roadmapEditShippedGuard(writeInput(path, JSON.stringify(next, null, 2)), cwd);
+    expect(result.decision).toBe('deny');
+    expect(result.blockReason).toContain('removed');
+  });
+
+  it('handles Edit tool input via old_string/new_string delta', async () => {
+    const roadmap = baseRoadmap();
+    const path = writeRoadmap(cwd, roadmap);
+    const oldString = '"title": "Original"';
+    const newString = '"title": "Hijacked"';
+    const result = await roadmapEditShippedGuard(editInput(path, oldString, newString), cwd);
+    expect(result.decision).toBe('deny');
+  });
+
+  it('allows Edit when old_string does not match current content', async () => {
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const result = await roadmapEditShippedGuard(
+      editInput(path, 'nonexistent string', 'replacement'),
+      cwd,
+    );
+    expect(result).toEqual({});
+  });
+
+  it('allows edits when JSON is malformed', async () => {
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const result = await roadmapEditShippedGuard(writeInput(path, '{ broken json'), cwd);
+    expect(result).toEqual({});
+  });
+
+  it('respects SLOPE_ALLOW_SHIPPED_EDIT=1 override', async () => {
+    process.env.SLOPE_ALLOW_SHIPPED_EDIT = '1';
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const next = baseRoadmap();
+    next.sprints[0].theme = 'Override allowed';
+    const result = await roadmapEditShippedGuard(writeInput(path, JSON.stringify(next, null, 2)), cwd);
+    expect(result).toEqual({});
+  });
+
+  it('allows adding new (not yet complete) sprints', async () => {
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const next = baseRoadmap();
+    next.sprints.push({
+      id: 3,
+      theme: 'Brand new',
+      par: 4,
+      slope: 1,
+      type: 'feature',
+      status: 'planned',
+      tickets: [{ key: 'S3-1', title: 'New', club: 'short_iron', complexity: 'standard' }],
+    });
+    const result = await roadmapEditShippedGuard(writeInput(path, JSON.stringify(next, null, 2)), cwd);
+    expect(result).toEqual({});
+  });
+});

--- a/tests/core/analyzers/git.test.ts
+++ b/tests/core/analyzers/git.test.ts
@@ -173,4 +173,23 @@ describe('findShippedSprintsOnMain', () => {
 
     expect(findShippedSprintsOnMain(tmpDir, 'HEAD')).toEqual(new Set([99]));
   });
+
+  it('refuses unsafe refs (shell-injection guard)', () => {
+    gitInit(tmpDir);
+    gitCommit(tmpDir, 'feat(S99): only on HEAD');
+
+    // Semicolons, backticks, $(), spaces, pipes — anything outside the
+    // SAFE_REF_RE allowlist must short-circuit to an empty set rather than
+    // fall through to the shell.
+    for (const unsafe of [
+      'HEAD; echo pwned',
+      'HEAD`echo pwned`',
+      'HEAD$(echo pwned)',
+      'HEAD || echo pwned',
+      'HEAD | sh',
+      'HEAD\nrm -rf /',
+    ]) {
+      expect(findShippedSprintsOnMain(tmpDir, unsafe)).toEqual(new Set());
+    }
+  });
 });

--- a/tests/core/analyzers/git.test.ts
+++ b/tests/core/analyzers/git.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
-import { analyzeGit } from '../../../src/core/analyzers/git.js';
+import { analyzeGit, extractSprintReferences, findShippedSprintsOnMain } from '../../../src/core/analyzers/git.js';
 
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), 'slope-git-'));
@@ -101,5 +101,76 @@ describe('analyzeGit', () => {
     const result = await analyzeGit(tmpDir);
     // 1 commit in 90 days = 0.08/week → sporadic
     expect(result.inferredCadence).toBe('sporadic');
+  });
+});
+
+describe('extractSprintReferences', () => {
+  it('extracts sprint id from feat(SXX) prefix', () => {
+    expect(extractSprintReferences(['feat(S77): The 19th Hole'])).toEqual(new Set([77]));
+  });
+
+  it('extracts both ids from a multi-sprint commit', () => {
+    expect(extractSprintReferences(['feat(S70+S71): Session Insights'])).toEqual(new Set([70, 71]));
+  });
+
+  it('extracts id from bare (SXX) parenthetical', () => {
+    expect(extractSprintReferences(['feat(pi-extension): harness v1.53.0 (S84) (#303)'])).toEqual(new Set([84]));
+  });
+
+  it('handles ticket key references like SXX-N', () => {
+    expect(extractSprintReferences(['feat(S78-1): wire forceApi flag'])).toEqual(new Set([78]));
+  });
+
+  it('does not match S75 inside S75.5', () => {
+    expect(extractSprintReferences(['feat(S75.5): The Bug Clearing'])).toEqual(new Set());
+  });
+
+  it('aggregates across multiple commit subjects', () => {
+    const subjects = [
+      'feat(S77): The 19th Hole',
+      'feat(S78): The Wiring',
+      'chore: bump version 1.51.0',
+      'feat(S77-3): cleanup',
+    ];
+    expect(extractSprintReferences(subjects)).toEqual(new Set([77, 78]));
+  });
+
+  it('returns empty set for commits without sprint refs', () => {
+    expect(extractSprintReferences(['chore: bump version', 'fix: typo'])).toEqual(new Set());
+  });
+});
+
+describe('findShippedSprintsOnMain', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty set for non-git directory', () => {
+    expect(findShippedSprintsOnMain(tmpDir)).toEqual(new Set());
+  });
+
+  it('detects sprint ids from commit subjects on the default branch', () => {
+    gitInit(tmpDir);
+    // git init may default to 'master' on older systems — write to whichever exists
+    gitCommit(tmpDir, 'feat(S70+S71): parallel session insights');
+    gitCommit(tmpDir, 'feat(S77): the 19th hole');
+    gitCommit(tmpDir, 'chore: bump version');
+
+    // Helper resolves main → master → HEAD
+    const result = findShippedSprintsOnMain(tmpDir);
+    expect(result).toEqual(new Set([70, 71, 77]));
+  });
+
+  it('honors explicit ref argument', () => {
+    gitInit(tmpDir);
+    gitCommit(tmpDir, 'feat(S99): only on HEAD');
+
+    expect(findShippedSprintsOnMain(tmpDir, 'HEAD')).toEqual(new Set([99]));
   });
 });

--- a/tests/core/guard.test.ts
+++ b/tests/core/guard.test.ts
@@ -11,8 +11,8 @@ import type { GuardResult } from '../../src/core/guard.js';
 import '../../src/core/adapters/claude-code.js';
 
 describe('GUARD_DEFINITIONS', () => {
-  it('has 29 guard definitions', () => {
-    expect(GUARD_DEFINITIONS).toHaveLength(29);
+  it('has 30 guard definitions', () => {
+    expect(GUARD_DEFINITIONS).toHaveLength(30);
   });
 
   it('all guards have required fields', () => {

--- a/tests/core/guard.test.ts
+++ b/tests/core/guard.test.ts
@@ -11,8 +11,8 @@ import type { GuardResult } from '../../src/core/guard.js';
 import '../../src/core/adapters/claude-code.js';
 
 describe('GUARD_DEFINITIONS', () => {
-  it('has 30 guard definitions', () => {
-    expect(GUARD_DEFINITIONS).toHaveLength(30);
+  it('has 31 guard definitions', () => {
+    expect(GUARD_DEFINITIONS).toHaveLength(31);
   });
 
   it('all guards have required fields', () => {

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -6,6 +6,7 @@ import {
   parseRoadmap,
   formatRoadmapSummary,
   formatStrategicContext,
+  findNextPlannedSprint,
 } from '../../src/core/roadmap.js';
 import type { RoadmapDefinition, RoadmapSprint, RoadmapTicket } from '../../src/core/roadmap.js';
 
@@ -510,5 +511,115 @@ describe('formatStrategicContext', () => {
   it('returns null for unknown sprint', () => {
     const context = formatStrategicContext(makeRoadmap(), 99);
     expect(context).toBeNull();
+  });
+});
+
+// --- findNextPlannedSprint (GH #290) ---
+
+describe('findNextPlannedSprint', () => {
+  it('returns the lowest-id non-complete sprint after current', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        { ...makeSprint(7), status: 'complete' } as any,
+        { ...makeSprint(8, { depends_on: [7] }), status: 'complete' } as any,
+        { ...makeSprint(9, { depends_on: [8] }), status: 'planned' } as any,
+      ],
+    });
+    const next = findNextPlannedSprint(roadmap, 8);
+    expect(next?.id).toBe(9);
+  });
+
+  it('skips complete sprints', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        makeSprint(7),
+        { ...makeSprint(8, { depends_on: [7] }), status: 'complete' } as any,
+        makeSprint(9, { depends_on: [8] }),
+      ],
+    });
+    const next = findNextPlannedSprint(roadmap, 7);
+    expect(next?.id).toBe(9);
+  });
+
+  it('returns null when no later sprints exist', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        { ...makeSprint(7), status: 'complete' } as any,
+        { ...makeSprint(8, { depends_on: [7] }), status: 'complete' } as any,
+        { ...makeSprint(9, { depends_on: [8] }), status: 'complete' } as any,
+      ],
+    });
+    expect(findNextPlannedSprint(roadmap, 9)).toBeNull();
+  });
+
+  it('prefers a candidate whose dependencies are all satisfied', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        { ...makeSprint(7), status: 'complete' } as any,
+        // S8 still planned; S9 depends on 7 (which IS complete) but has higher id
+        makeSprint(8),
+        makeSprint(9, { depends_on: [7] }),
+      ],
+    });
+    // S8 has no deps so it's also "ready" — by id order, S8 wins (lowest ready)
+    const next = findNextPlannedSprint(roadmap, 7);
+    expect(next?.id).toBe(8);
+  });
+
+  it('falls back to lowest-id candidate when nothing is fully unblocked', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        makeSprint(7),
+        // S8 depends on S7 (planned, not complete) — blocked
+        makeSprint(8, { depends_on: [7] }),
+        // S9 depends on S8 — also blocked
+        makeSprint(9, { depends_on: [8] }),
+      ],
+    });
+    const next = findNextPlannedSprint(roadmap, 6);
+    expect(next?.id).toBe(7);
+  });
+});
+
+// --- formatStrategicContext: next sprint surfacing (GH #290) ---
+
+describe('formatStrategicContext next-sprint output', () => {
+  it('includes next sprint with ready status when deps complete', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        { ...makeSprint(7), status: 'complete' } as any,
+        makeSprint(8, { depends_on: [7] }),
+        makeSprint(9, { depends_on: [8] }),
+      ],
+    });
+    const context = formatStrategicContext(roadmap, 7);
+    expect(context).toContain('Next: S8');
+    expect(context).toContain('(ready)');
+  });
+
+  it('shows blocked status when next sprint has incomplete deps', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        makeSprint(7),
+        makeSprint(8, { depends_on: [7] }),
+        makeSprint(9, { depends_on: [7, 8] }),
+      ],
+    });
+    const context = formatStrategicContext(roadmap, 7);
+    // S8 is the next; depends on S7 which is not complete
+    expect(context).toContain('Next: S8');
+    expect(context).toContain('blocked by S7');
+  });
+
+  it('omits Next line when no later sprints exist', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        makeSprint(7),
+        makeSprint(8, { depends_on: [7] }),
+        makeSprint(9, { depends_on: [8] }),
+      ],
+    });
+    const context = formatStrategicContext(roadmap, 9);
+    expect(context).not.toContain('Next:');
   });
 });

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -394,6 +394,97 @@ describe('validateRoadmap with scorecards', () => {
   });
 });
 
+// --- validateRoadmap with shipped sprint drift detection ---
+
+describe('validateRoadmap with shipped sprint IDs', () => {
+  it('errors when sprint shipped on main but status is null', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        makeSprint(7),
+        makeSprint(8, { depends_on: [7] }),
+        makeSprint(9, { depends_on: [8] }),
+      ],
+    });
+    const shipped = new Set([7]);
+    const result = validateRoadmap(roadmap, undefined, shipped);
+    expect(
+      result.errors.some(
+        e => e.sprint === 7 && e.message.includes('shipped commits') && e.message.includes('planned'),
+      ),
+    ).toBe(true);
+  });
+
+  it('errors when sprint shipped but status is "planned"', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        { ...makeSprint(7), status: 'planned' } as any,
+        makeSprint(8, { depends_on: [7] }),
+        makeSprint(9, { depends_on: [8] }),
+      ],
+    });
+    const result = validateRoadmap(roadmap, undefined, new Set([7]));
+    expect(
+      result.errors.some(e => e.sprint === 7 && e.message.includes('shipped commits')),
+    ).toBe(true);
+  });
+
+  it('does not error when shipped and status is "complete"', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        { ...makeSprint(7), status: 'complete' } as any,
+        makeSprint(8, { depends_on: [7] }),
+        makeSprint(9, { depends_on: [8] }),
+      ],
+    });
+    const result = validateRoadmap(roadmap, undefined, new Set([7]));
+    expect(result.errors.filter(e => e.message.includes('shipped commits'))).toHaveLength(0);
+  });
+
+  it('warns when status is "complete" but sprint not in shipped set (phantom)', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        { ...makeSprint(7), status: 'complete' } as any,
+        makeSprint(8, { depends_on: [7] }),
+        makeSprint(9, { depends_on: [8] }),
+      ],
+    });
+    const result = validateRoadmap(roadmap, undefined, new Set([8])); // 7 missing
+    expect(
+      result.warnings.some(
+        w => w.sprint === 7 && w.message.includes('no shipped commits'),
+      ),
+    ).toBe(true);
+  });
+
+  it('skips drift check when shippedSprintIds not provided', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        makeSprint(7),
+        makeSprint(8, { depends_on: [7] }),
+        makeSprint(9, { depends_on: [8] }),
+      ],
+    });
+    const result = validateRoadmap(roadmap);
+    expect(result.errors.filter(e => e.message.includes('shipped commits'))).toHaveLength(0);
+    expect(result.warnings.filter(w => w.message.includes('shipped commits'))).toHaveLength(0);
+  });
+
+  it('runs alongside scorecard cross-check independently', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        // S7: shipped + scorecard but status=planned → error from drift, warn from scorecards
+        { ...makeSprint(7), status: 'planned' } as any,
+        makeSprint(8, { depends_on: [7] }),
+        makeSprint(9, { depends_on: [8] }),
+      ],
+    });
+    const scorecards = [{ sprint_number: 7 }];
+    const result = validateRoadmap(roadmap, scorecards, new Set([7]));
+    expect(result.errors.some(e => e.message.includes('shipped commits'))).toBe(true);
+    expect(result.warnings.some(w => w.message.includes('scorecard'))).toBe(true);
+  });
+});
+
 // --- formatStrategicContext ---
 
 describe('formatStrategicContext', () => {


### PR DESCRIPTION
## Summary

Closes 5 GH issues with the drift detection infrastructure SLOPE lacked during S70–S84 (when 11 sprints shipped without scorecards and roadmap statuses went stale).

| Ticket | Issue | Deliverable |
|---|---|---|
| S86-1 | #319 | `slope roadmap validate` detects status drift against git log |
| S86-2 | #320 | `roadmap-edit-shipped` guard blocks paper-tickets on complete sprints |
| S86-3 | #291 | `post-hole-enforcement` Stop guard surfaces incomplete close-out |
| S86-4 | #318 (data) | Backfilled 11 missing scorecards (S70, S74–S83) |
| S86-5 | #290 | Briefing surfaces next planned sprint, dependency-resolved |

## Tickets

### S86-1: Validator status drift detection
- Extends `validateRoadmap` with optional `shippedSprintIds: Set<number>` parameter
- New helpers in `src/core/analyzers/git.ts`: `extractSprintReferences` (pure regex), `findShippedSprintsOnMain` (calls git log)
- New `castRoadmapStructure` so checks fire even with unrelated structural issues
- Wires the previously-orphaned scorecard cross-check into the CLI

### S86-2: roadmap-edit-shipped guard
- New mechanical PreToolUse guard on Edit/Write — blocks paper-tickets exactly like the S78-5/S78-6 incident from PR #296
- Override: `SLOPE_ALLOW_SHIPPED_EDIT=1` in shell

### S86-3: post-hole-enforcement guard
- Advisory Stop hook surfacing shipped sprints with status drift OR missing scorecards
- Override to mechanical via `SLOPE_POST_HOLE_BLOCK=1`

### S86-4: Scorecard backfill
- 11 new scorecards in `docs/retros/sprint-{70,74-83}.json`
- Honest but lossy: each marked `_backfilled: true`; defaults to par; original CI/PR signals not preserved
- The `slope retro backfill` CLI tooling from #318 stays open as follow-up

### S86-5: Briefing next-sprint
- `findNextPlannedSprint` with dep-resolution
- Briefing now falls back to `castRoadmapStructure` when parseRoadmap returns null

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 3147 pass, 23 skipped (was 3118 before; +29 new tests)
- [x] `node dist/cli/index.js roadmap validate` shows drift errors when status reverted (verified)
- [x] `node dist/cli/index.js briefing` shows STRATEGIC CONTEXT with Next: line
- [ ] Reviewer sanity-check of backfilled scorecards (treat scores as par placeholders)
- [ ] Reviewer test of guard override env vars

## Stats

- 12 new files, 8 modified
- ~1,100 lines added
- New guard count: 31 (was 29)

Closes #319.
Closes #320.
Closes #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-hole enforcement checks and a guard to block or warn on shipped sprints missing scorecards or roadmap completion
  * Added protection against editing completed roadmap sprints
  * Roadmap validation now reports mismatches with shipped state and surfaces the next planned sprint
  * Improved detection of shipped sprints via VCS history

* **Documentation**
  * Backfilled historical sprint retro data for sprints 70–83

* **Tests**
  * Added comprehensive tests for new guards, VCS detection, and roadmap logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->