### PR TITLE
feat(S90): The Vault — memory ↔ store reunification

### DIFF
--- a/src/core/json-memory-backend.ts
+++ b/src/core/json-memory-backend.ts
@@ -1,0 +1,100 @@
+/**
+ * JsonMemoryBackend — file-backed implementation (legacy default).
+ *
+ * Wraps the original `.slope/memories.json` behavior in the MemoryBackend
+ * interface so callers can swap to a store-backed adapter without changing
+ * the memory.ts public API. Preserves atomic writes (temp + rename) and
+ * v0 → v1 migration.
+ */
+
+import { existsSync, readFileSync, writeFileSync, renameSync, copyFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type { MemoryBackend } from './memory-backend.js';
+import type { Memory, MemoriesFile } from './memory-types.js';
+import { validateMemoryRow } from './memory-validation.js';
+
+const MEMORIES_FILE = 'memories.json';
+const CURRENT_VERSION = 1;
+
+export class JsonMemoryBackend implements MemoryBackend {
+  readonly kind = 'json' as const;
+  private path: string;
+  private cwd: string;
+
+  constructor(cwd: string) {
+    this.cwd = cwd;
+    this.path = join(cwd, '.slope', MEMORIES_FILE);
+  }
+
+  load(): MemoriesFile {
+    if (!existsSync(this.path)) {
+      return { version: CURRENT_VERSION, memories: [] };
+    }
+    try {
+      const raw = JSON.parse(readFileSync(this.path, 'utf8'));
+      if (raw && typeof raw === 'object' && 'version' in raw) {
+        const version = Number(raw.version);
+        if (version === 1) {
+          const memories = Array.isArray(raw.memories) ? raw.memories.map(validateMemoryRow) : [];
+          return { version: CURRENT_VERSION, memories };
+        }
+        // Unknown future version — back up before returning empty
+        const backupPath = `${this.path}.v${version}.bak`;
+        try {
+          copyFileSync(this.path, backupPath);
+          console.error(`SLOPE memory: unknown memories.json version=${version}; backed up to ${backupPath} and starting fresh.`);
+        } catch (err) {
+          console.error(`SLOPE memory: unknown memories.json version=${version}; backup failed (${(err as Error).message}). Starting fresh.`);
+        }
+        return { version: CURRENT_VERSION, memories: [] };
+      }
+      // No version field — try v0 migration (plain array)
+      if (Array.isArray(raw)) {
+        return { version: CURRENT_VERSION, memories: raw.map(validateMemoryRow) };
+      }
+      return { version: CURRENT_VERSION, memories: [] };
+    } catch (err) {
+      console.error(`SLOPE memory: failed to parse ${this.path} (${(err as Error).message}). Treating as empty.`);
+      return { version: CURRENT_VERSION, memories: [] };
+    }
+  }
+
+  saveAll(data: MemoriesFile): void {
+    mkdirSync(join(this.cwd, '.slope'), { recursive: true });
+    const tmp = `${this.path}.tmp.${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n');
+    renameSync(tmp, this.path);
+  }
+
+  add(memory: Memory): void {
+    const data = this.load();
+    data.memories.push(memory);
+    this.saveAll(data);
+  }
+
+  remove(id: string): boolean {
+    const data = this.load();
+    const idx = data.memories.findIndex(m => m.id === id);
+    if (idx === -1) return false;
+    data.memories.splice(idx, 1);
+    this.saveAll(data);
+    return true;
+  }
+
+  update(id: string, fields: Partial<Pick<Memory, 'text' | 'category' | 'weight' | 'updatedAt'>>): Memory | null {
+    const data = this.load();
+    const mem = data.memories.find(m => m.id === id);
+    if (!mem) return null;
+    if (fields.text !== undefined) mem.text = fields.text;
+    if (fields.category !== undefined) mem.category = fields.category;
+    if (fields.weight !== undefined) mem.weight = Math.max(1, Math.min(10, fields.weight));
+    if (fields.updatedAt !== undefined) mem.updatedAt = fields.updatedAt;
+    else mem.updatedAt = new Date().toISOString();
+    this.saveAll(data);
+    return mem;
+  }
+
+  getById(id: string): Memory | undefined {
+    return this.load().memories.find(m => m.id === id);
+  }
+}

--- a/src/core/memory-backend.ts
+++ b/src/core/memory-backend.ts
@@ -1,0 +1,37 @@
+/**
+ * MemoryStore — pluggable backend for cross-session memory persistence.
+ *
+ * Resolves the architect finding from PR #293 (GH #294): the memory module
+ * was writing directly to `.slope/memories.json` via node:fs, bypassing the
+ * store-sqlite/store-pg abstraction that already handles sessions, claims,
+ * scorecards, and common-issues.
+ *
+ * The interface is sync to preserve the existing memory.ts public API
+ * (addMemory/searchMemories etc.) without forcing a synchronous-to-async
+ * migration of every call site (auto-memory hooks, CLI, briefing).
+ */
+
+import type { Memory, MemoriesFile } from './memory-types.js';
+
+export interface MemoryBackend {
+  /** Read all memories. */
+  load(): MemoriesFile;
+
+  /** Replace all memories with the given file (used for import/migration). */
+  saveAll(data: MemoriesFile): void;
+
+  /** Insert a new memory. */
+  add(memory: Memory): void;
+
+  /** Remove by id. Returns true if removed, false if not found. */
+  remove(id: string): boolean;
+
+  /** Patch the memory in place; returns the updated row, or null if not found. */
+  update(id: string, fields: Partial<Pick<Memory, 'text' | 'category' | 'weight' | 'updatedAt'>>): Memory | null;
+
+  /** Lookup by id. */
+  getById(id: string): Memory | undefined;
+
+  /** Identify the backend (for diagnostics). */
+  readonly kind: 'json' | 'sqlite' | 'pg';
+}

--- a/src/core/memory-types.ts
+++ b/src/core/memory-types.ts
@@ -1,0 +1,30 @@
+// Memory types extracted into a sibling so memory.ts and memory-backend.ts
+// can both import without a circular dependency.
+
+export type MemoryCategory = 'workflow' | 'style' | 'project' | 'hazard' | 'other';
+export type MemorySource = 'manual' | 'auto-guard' | 'auto-workflow';
+
+export interface Memory {
+  id: string;
+  text: string;
+  category: MemoryCategory;
+  weight: number; // 1–10 relevance
+  source: MemorySource;
+  createdAt: string;
+  updatedAt: string;
+  /** Optional session that produced this memory (auto-* sources). */
+  sourceSessionId?: string;
+}
+
+export interface MemoriesFile {
+  version: number;
+  memories: Memory[];
+}
+
+export interface MemorySearchOptions {
+  query?: string;
+  category?: MemoryCategory;
+  source?: MemorySource;
+  limit?: number;
+  minWeight?: number;
+}

--- a/src/core/memory-validation.ts
+++ b/src/core/memory-validation.ts
@@ -1,0 +1,41 @@
+// Shared validation for Memory rows — extracted so JsonMemoryBackend and
+// SqliteMemoryBackend (in src/store/) can both import without circulars.
+
+import { randomUUID } from 'node:crypto';
+import type { Memory, MemoryCategory, MemorySource } from './memory-types.js';
+
+const VALID_CATEGORIES: MemoryCategory[] = ['workflow', 'style', 'project', 'hazard', 'other'];
+const VALID_SOURCES: MemorySource[] = ['manual', 'auto-guard', 'auto-workflow'];
+
+function nowISO(): string {
+  return new Date().toISOString();
+}
+
+/** Validate and normalize a Memory row. Throws TypeError on invalid category/source. */
+export function validateMemoryRow(input: unknown): Memory {
+  if (!input || typeof input !== 'object') {
+    throw new TypeError('Memory must be an object');
+  }
+  const m = input as Record<string, unknown>;
+  const category = (m.category as MemoryCategory) ?? 'other';
+  const source = (m.source as MemorySource) ?? 'manual';
+
+  if (!VALID_CATEGORIES.includes(category)) {
+    throw new TypeError(`Invalid memory category: ${category}`);
+  }
+  if (!VALID_SOURCES.includes(source)) {
+    throw new TypeError(`Invalid memory source: ${source}`);
+  }
+
+  const weight = typeof m.weight === 'number' ? m.weight : 5;
+  return {
+    id: typeof m.id === 'string' ? m.id : randomUUID(),
+    text: typeof m.text === 'string' ? m.text : '',
+    category,
+    weight: Math.max(1, Math.min(10, weight)),
+    source,
+    createdAt: typeof m.createdAt === 'string' ? m.createdAt : nowISO(),
+    updatedAt: typeof m.updatedAt === 'string' ? m.updatedAt : nowISO(),
+    ...(typeof m.sourceSessionId === 'string' ? { sourceSessionId: m.sourceSessionId } : {}),
+  };
+}

--- a/src/core/memory.ts
+++ b/src/core/memory.ts
@@ -1,37 +1,37 @@
 /**
- * Cross-session memory storage core.
- * Persistent learned patterns, preferences, and project quirks in .slope/memories.json
+ * Cross-session memory storage — public API.
+ *
+ * As of S90 (GH #294), persistence routes through a MemoryBackend so the
+ * memory module no longer writes JSON directly. Behavior:
+ *
+ *   - If `.slope/slope.db` exists, SqliteMemoryBackend is used. On first
+ *     open it imports any existing `.slope/memories.json` into the store
+ *     and renames the JSON to `.bak` (one-time migration).
+ *   - Otherwise JsonMemoryBackend is used (legacy default for repos that
+ *     haven't initialized the SQLite store).
+ *
+ * Public API signatures are unchanged — callers (auto-memory hooks, the
+ * memory CLI command, briefing) keep working without `await`.
  */
 
-import { existsSync, readFileSync, writeFileSync, renameSync, copyFileSync, mkdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 
-// ── Types ───────────────────────────────────────────
+import type { MemoryBackend } from './memory-backend.js';
+import { JsonMemoryBackend } from './json-memory-backend.js';
+import { SqliteMemoryBackend } from '../store/sqlite-memory-backend.js';
 
-export type MemoryCategory = 'workflow' | 'style' | 'project' | 'hazard' | 'other';
-export type MemorySource = 'manual' | 'auto-guard' | 'auto-workflow';
+import type { Memory, MemoriesFile, MemoryCategory, MemorySource, MemorySearchOptions } from './memory-types.js';
 
-export interface Memory {
-  id: string;
-  text: string;
-  category: MemoryCategory;
-  weight: number; // 1–10 relevance
-  source: MemorySource;
-  createdAt: string;
-  updatedAt: string;
-  /** Optional session that produced this memory (auto-* sources). */
-  sourceSessionId?: string;
-}
+// Re-export types so existing imports continue to work.
+export type { Memory, MemoriesFile, MemoryCategory, MemorySource, MemorySearchOptions } from './memory-types.js';
 
-/**
- * Detect probable secrets in a memory's text. Used as a guardrail before
- * writing memories that auto-inject into briefings (S73-3).
- *
- * Detects: sk-* (OpenAI/Anthropic), ghp_* / gho_* (GitHub), AWS access keys
- * (AKIA prefix + 16 chars), JWT-shaped 3-part dot-separated base64, and
- * generic hex/base64 strings ≥ 32 chars after `password=`/`token=` etc.
- */
+// Re-export validateMemory + secret detection helpers (still part of public API).
+export { validateMemoryRow as validateMemory } from './memory-validation.js';
+
+// ── Secret detection (unchanged from pre-S90) ──────────
+
 const SECRET_PATTERNS: RegExp[] = [
   /\bsk-[A-Za-z0-9_-]{20,}\b/,
   /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b/,
@@ -47,144 +47,50 @@ export function detectSecret(text: string): string | null {
   return null;
 }
 
-export interface MemoriesFile {
-  version: number;
-  memories: Memory[];
-}
-
-export interface MemorySearchOptions {
-  query?: string;
-  category?: MemoryCategory;
-  source?: MemorySource;
-  limit?: number;
-  minWeight?: number;
-}
-
-// ── Constants ───────────────────────────────────────
-
-const MEMORIES_FILE = 'memories.json';
-const CURRENT_VERSION = 1;
-
-// ── Internal helpers ────────────────────────────────
-
-function getPath(cwd: string): string {
-  return join(cwd, '.slope', MEMORIES_FILE);
-}
-
-function generateId(): string {
-  return randomUUID();
-}
-
-function now(): string {
-  return new Date().toISOString();
-}
-
-function validateMemory(m: unknown): Memory {
-  if (!m || typeof m !== 'object') {
-    throw new TypeError('Memory must be an object');
-  }
-  const mem = m as Record<string, unknown>;
-
-  const validCategories: MemoryCategory[] = ['workflow', 'style', 'project', 'hazard', 'other'];
-  const validSources: MemorySource[] = ['manual', 'auto-guard', 'auto-workflow'];
-
-  const category = (mem.category as MemoryCategory) ?? 'other';
-  const source = (mem.source as MemorySource) ?? 'manual';
-
-  if (!validCategories.includes(category)) {
-    throw new TypeError(`Invalid memory category: ${category}`);
-  }
-  if (!validSources.includes(source)) {
-    throw new TypeError(`Invalid memory source: ${source}`);
-  }
-
-  const weight = typeof mem.weight === 'number' ? mem.weight : 5;
-  const clampedWeight = Math.max(1, Math.min(10, weight));
-
-  return {
-    id: typeof mem.id === 'string' ? mem.id : generateId(),
-    text: typeof mem.text === 'string' ? mem.text : '',
-    category,
-    weight: clampedWeight,
-    source,
-    createdAt: typeof mem.createdAt === 'string' ? mem.createdAt : now(),
-    updatedAt: typeof mem.updatedAt === 'string' ? mem.updatedAt : now(),
-    ...(typeof mem.sourceSessionId === 'string' ? { sourceSessionId: mem.sourceSessionId } : {}),
-  };
-}
-
-/** Public for callers that want to validate before pushing (e.g. import). */
-export { validateMemory };
-
-function migrateV0toV1(raw: unknown): MemoriesFile {
-  // v0: plain array of memories without version wrapper
-  if (Array.isArray(raw)) {
-    return {
-      version: 1,
-      memories: raw.map(validateMemory),
-    };
-  }
-  // Unknown shape — start fresh
-  return { version: 1, memories: [] };
-}
-
-// ── Public API ──────────────────────────────────────
-
-export function loadMemories(cwd: string): MemoriesFile {
-  const path = getPath(cwd);
-  if (!existsSync(path)) {
-    return { version: CURRENT_VERSION, memories: [] };
-  }
-
-  try {
-    const raw = JSON.parse(readFileSync(path, 'utf8'));
-
-    if (raw && typeof raw === 'object' && 'version' in raw) {
-      const version = Number(raw.version);
-      if (version === 1) {
-        const memories = Array.isArray(raw.memories)
-          ? raw.memories.map(validateMemory)
-          : [];
-        return { version: CURRENT_VERSION, memories };
-      }
-      // Unknown future version — back up before returning empty so we don't silently nuke user data
-      const backupPath = `${path}.v${version}.bak`;
-      try {
-        copyFileSync(path, backupPath);
-        console.error(`SLOPE memory: unknown memories.json version=${version}; backed up to ${backupPath} and starting fresh.`);
-      } catch (err) {
-        console.error(`SLOPE memory: unknown memories.json version=${version}; backup failed (${(err as Error).message}). Starting fresh — original file untouched until next write.`);
-      }
-      return { version: CURRENT_VERSION, memories: [] };
-    }
-
-    // No version field — try v0 migration
-    return migrateV0toV1(raw);
-  } catch (err) {
-    console.error(`SLOPE memory: failed to parse ${path} (${(err as Error).message}). Treating as empty.`);
-    return { version: CURRENT_VERSION, memories: [] };
-  }
-}
-
-/**
- * Atomic write: write to temp file then rename. Reduces (but doesn't eliminate)
- * the multi-agent last-write-wins window — concurrent writers each load,
- * mutate, and write, so the loser's changes can still be lost. A future
- * follow-up should layer this on the store interface with proper locking.
- */
-export function saveMemories(cwd: string, data: MemoriesFile): void {
-  const path = getPath(cwd);
-  mkdirSync(join(cwd, '.slope'), { recursive: true });
-  const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n');
-  renameSync(tmp, path);
-}
-
 export class SecretDetectedError extends Error {
   constructor(public pattern: string) {
     super(`Memory text matches secret pattern (${pattern}); refusing to persist. Pass allowSecrets:true to override.`);
     this.name = 'SecretDetectedError';
   }
+}
+
+// ── Backend resolution ─────────────────────────────────
+
+/**
+ * Pick a backend based on whether a SQLite slope.db exists. Lazy-load the
+ * SQLite backend so projects without better-sqlite3 binding (or no slope.db)
+ * never try to open one.
+ *
+ * Override via `SLOPE_MEMORY_BACKEND=json|sqlite` for testing.
+ */
+export function getMemoryBackend(cwd: string): MemoryBackend {
+  const override = process.env.SLOPE_MEMORY_BACKEND;
+  if (override === 'json') return new JsonMemoryBackend(cwd);
+
+  const dbPath = join(cwd, '.slope', 'slope.db');
+  if (override === 'sqlite' || existsSync(dbPath)) {
+    try {
+      return new SqliteMemoryBackend(cwd, dbPath);
+    } catch (err) {
+      console.error(`SLOPE memory: SQLite backend unavailable (${(err as Error).message}); falling back to JSON.`);
+    }
+  }
+
+  return new JsonMemoryBackend(cwd);
+}
+
+// ── Public API ─────────────────────────────────────────
+
+function nowISO(): string {
+  return new Date().toISOString();
+}
+
+export function loadMemories(cwd: string): MemoriesFile {
+  return getMemoryBackend(cwd).load();
+}
+
+export function saveMemories(cwd: string, data: MemoriesFile): void {
+  getMemoryBackend(cwd).saveAll(data);
 }
 
 export function addMemory(
@@ -204,29 +110,22 @@ export function addMemory(
     if (matched) throw new SecretDetectedError(matched);
   }
 
-  const data = loadMemories(cwd);
   const memory: Memory = {
-    id: generateId(),
+    id: randomUUID(),
     text,
     category: options.category ?? 'other',
     weight: Math.max(1, Math.min(10, options.weight ?? 8)),
     source: options.source ?? 'manual',
-    createdAt: now(),
-    updatedAt: now(),
+    createdAt: nowISO(),
+    updatedAt: nowISO(),
     ...(options.sourceSessionId ? { sourceSessionId: options.sourceSessionId } : {}),
   };
-  data.memories.push(memory);
-  saveMemories(cwd, data);
+  getMemoryBackend(cwd).add(memory);
   return memory;
 }
 
 export function removeMemory(cwd: string, id: string): boolean {
-  const data = loadMemories(cwd);
-  const idx = data.memories.findIndex(m => m.id === id);
-  if (idx === -1) return false;
-  data.memories.splice(idx, 1);
-  saveMemories(cwd, data);
-  return true;
+  return getMemoryBackend(cwd).remove(id);
 }
 
 export function updateMemory(
@@ -234,58 +133,44 @@ export function updateMemory(
   id: string,
   updates: Partial<Pick<Memory, 'text' | 'category' | 'weight'>>,
 ): Memory | null {
-  const data = loadMemories(cwd);
-  const mem = data.memories.find(m => m.id === id);
-  if (!mem) return null;
-
-  if (updates.text !== undefined) mem.text = updates.text;
-  if (updates.category !== undefined) mem.category = updates.category;
-  if (updates.weight !== undefined) mem.weight = Math.max(1, Math.min(10, updates.weight));
-  mem.updatedAt = now();
-
-  saveMemories(cwd, data);
-  return mem;
+  const fields: Partial<Pick<Memory, 'text' | 'category' | 'weight' | 'updatedAt'>> = { ...updates };
+  if (fields.weight !== undefined) {
+    fields.weight = Math.max(1, Math.min(10, fields.weight));
+  }
+  fields.updatedAt = nowISO();
+  return getMemoryBackend(cwd).update(id, fields);
 }
 
 export function searchMemories(
   cwd: string,
   options: MemorySearchOptions = {},
 ): Memory[] {
-  const data = loadMemories(cwd);
+  // searchMemories is read-mostly; load and filter in memory. Pushing the
+  // filter into SQL is a future optimization once we have realistic dataset
+  // sizes — current footprint is small (typical project has <50 memories).
+  const data = getMemoryBackend(cwd).load();
   let results = data.memories;
 
-  if (options.category) {
-    results = results.filter(m => m.category === options.category);
-  }
-
-  if (options.source) {
-    results = results.filter(m => m.source === options.source);
-  }
-
+  if (options.category) results = results.filter(m => m.category === options.category);
+  if (options.source) results = results.filter(m => m.source === options.source);
   if (options.minWeight !== undefined) {
     const min = options.minWeight;
     results = results.filter(m => m.weight >= min);
   }
-
   if (options.query) {
     const q = options.query.toLowerCase();
     results = results.filter(m => m.text.toLowerCase().includes(q));
   }
 
-  // Sort by weight desc, then recency desc
   results.sort((a, b) => {
     if (b.weight !== a.weight) return b.weight - a.weight;
     return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
   });
 
-  if (options.limit) {
-    results = results.slice(0, options.limit);
-  }
-
+  if (options.limit) results = results.slice(0, options.limit);
   return results;
 }
 
 export function getMemoryById(cwd: string, id: string): Memory | undefined {
-  const data = loadMemories(cwd);
-  return data.memories.find(m => m.id === id);
+  return getMemoryBackend(cwd).getById(id);
 }

--- a/src/core/memory.ts
+++ b/src/core/memory.ts
@@ -61,22 +61,53 @@ export class SecretDetectedError extends Error {
  * SQLite backend so projects without better-sqlite3 binding (or no slope.db)
  * never try to open one.
  *
+ * Memoized per-cwd — repeated calls return the same instance to avoid the
+ * overhead of opening a fresh DB connection (and re-running schema/migration
+ * checks) on every memory operation. Tests can call `clearMemoryBackendCache()`
+ * to reset between fixtures.
+ *
  * Override via `SLOPE_MEMORY_BACKEND=json|sqlite` for testing.
  */
+const _backendCache = new Map<string, MemoryBackend>();
+
+export function clearMemoryBackendCache(): void {
+  _backendCache.clear();
+}
+
 export function getMemoryBackend(cwd: string): MemoryBackend {
   const override = process.env.SLOPE_MEMORY_BACKEND;
-  if (override === 'json') return new JsonMemoryBackend(cwd);
+  // Cache key includes the override so a test toggling the env between calls
+  // doesn't get a stale instance.
+  const cacheKey = `${cwd}::${override ?? 'auto'}`;
+  const cached = _backendCache.get(cacheKey);
+  if (cached) return cached;
+
+  if (override === 'json') {
+    const b = new JsonMemoryBackend(cwd);
+    _backendCache.set(cacheKey, b);
+    return b;
+  }
 
   const dbPath = join(cwd, '.slope', 'slope.db');
   if (override === 'sqlite' || existsSync(dbPath)) {
     try {
-      return new SqliteMemoryBackend(cwd, dbPath);
+      const b = new SqliteMemoryBackend(cwd, dbPath);
+      _backendCache.set(cacheKey, b);
+      return b;
     } catch (err) {
-      console.error(`SLOPE memory: SQLite backend unavailable (${(err as Error).message}); falling back to JSON.`);
+      // Distinguish corruption / I/O errors from missing better-sqlite3
+      // binding so users can tell which layer is broken (#294 review).
+      const msg = (err as Error).message ?? String(err);
+      const cause = /better-sqlite3|cannot find module/i.test(msg)
+        ? 'better-sqlite3 binding unavailable'
+        : 'SQLite open failed (DB corrupt, locked, or unreadable)';
+      console.error(`SLOPE memory: ${cause} — ${msg}; falling back to JSON.`);
     }
   }
 
-  return new JsonMemoryBackend(cwd);
+  const fallback = new JsonMemoryBackend(cwd);
+  _backendCache.set(cacheKey, fallback);
+  return fallback;
 }
 
 // ── Public API ─────────────────────────────────────────

--- a/src/store-pg/index.ts
+++ b/src/store-pg/index.ts
@@ -200,6 +200,29 @@ const MIGRATIONS: Array<{ version: number; sql: string }> = [
       CREATE INDEX IF NOT EXISTS idx_wf_step_exec ON workflow_step_results(execution_id);
     `,
   },
+  {
+    // v5: memories table parallel to sqlite migration v8 (GH #294 / S90).
+    // Postgres MemoryBackend implementation is a follow-up — schema is in
+    // place so the table is ready when an async backend ships.
+    version: 5,
+    sql: `
+      CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL DEFAULT 'default',
+        text TEXT NOT NULL,
+        category TEXT NOT NULL,
+        weight INTEGER NOT NULL,
+        source TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        source_session_id TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_memories_project ON memories(project_id);
+      CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);
+      CREATE INDEX IF NOT EXISTS idx_memories_source ON memories(source);
+      CREATE INDEX IF NOT EXISTS idx_memories_weight ON memories(weight);
+    `,
+  },
 ];
 
 export interface PostgresStoreOptions {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -188,6 +188,24 @@ const MIGRATIONS: Array<{ version: number; sql: string }> = [
       ALTER TABLE workflow_executions ADD COLUMN definition_hash TEXT;
     `,
   },
+  {
+    version: 8,
+    sql: `
+      CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY,
+        text TEXT NOT NULL,
+        category TEXT NOT NULL,
+        weight INTEGER NOT NULL,
+        source TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        source_session_id TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);
+      CREATE INDEX IF NOT EXISTS idx_memories_source ON memories(source);
+      CREATE INDEX IF NOT EXISTS idx_memories_weight ON memories(weight);
+    `,
+  },
 ];
 
 /** Latest schema version — total number of migrations available. */

--- a/src/store/sqlite-memory-backend.ts
+++ b/src/store/sqlite-memory-backend.ts
@@ -1,0 +1,211 @@
+/**
+ * SqliteMemoryBackend — better-sqlite3 backed memory storage.
+ *
+ * Lives in src/store/ alongside SqliteSlopeStore. Uses the same
+ * `.slope/slope.db` file but a dedicated `memories` table (added in
+ * migration v8). Keeps the API sync via better-sqlite3 prepared statements.
+ *
+ * Migration: on first open, if a sibling `.slope/memories.json` exists and
+ * the memories table is empty, contents are imported and the JSON file is
+ * renamed to `.slope/memories.json.bak` so the original is preserved as a
+ * one-time backup.
+ */
+
+import { existsSync, renameSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import type { Database as DatabaseType } from 'better-sqlite3';
+import type { MemoryBackend } from '../core/memory-backend.js';
+import type { Memory, MemoriesFile, MemoryCategory, MemorySource } from '../core/memory-types.js';
+import { validateMemoryRow } from '../core/memory-validation.js';
+
+const CURRENT_VERSION = 1;
+
+interface MemoryRow {
+  id: string;
+  text: string;
+  category: string;
+  weight: number;
+  source: string;
+  created_at: string;
+  updated_at: string;
+  source_session_id: string | null;
+}
+
+function rowToMemory(r: MemoryRow): Memory {
+  return {
+    id: r.id,
+    text: r.text,
+    category: r.category as MemoryCategory,
+    weight: r.weight,
+    source: r.source as MemorySource,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+    ...(r.source_session_id ? { sourceSessionId: r.source_session_id } : {}),
+  };
+}
+
+export class SqliteMemoryBackend implements MemoryBackend {
+  readonly kind = 'sqlite' as const;
+  private db: DatabaseType;
+  private cwd: string;
+
+  /** True after the importJsonIfPresent() pass has run for this instance. */
+  private importedJson = false;
+
+  constructor(cwd: string, dbPath: string) {
+    this.cwd = cwd;
+    this.db = new Database(dbPath);
+    this.ensureSchema();
+    this.importJsonIfPresent();
+  }
+
+  /**
+   * Idempotent: create the memories table if it doesn't exist. Independent
+   * of the SqliteSlopeStore migration system so the backend can be used
+   * standalone (tests, embedded use). The full migration is owned by
+   * SqliteSlopeStore (v8).
+   */
+  private ensureSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY,
+        text TEXT NOT NULL,
+        category TEXT NOT NULL,
+        weight INTEGER NOT NULL,
+        source TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        source_session_id TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);
+      CREATE INDEX IF NOT EXISTS idx_memories_source ON memories(source);
+      CREATE INDEX IF NOT EXISTS idx_memories_weight ON memories(weight);
+    `);
+  }
+
+  /** One-time migration from .slope/memories.json. Runs at most once per
+   *  backend instance and only if the table is currently empty. */
+  private importJsonIfPresent(): void {
+    if (this.importedJson) return;
+    this.importedJson = true;
+
+    const jsonPath = join(this.cwd, '.slope', 'memories.json');
+    if (!existsSync(jsonPath)) return;
+
+    // Skip when the table already has rows (avoids re-importing on every open)
+    const count = (this.db.prepare('SELECT COUNT(*) as c FROM memories').get() as { c: number }).c;
+    if (count > 0) return;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(jsonPath, 'utf8'));
+    } catch (err) {
+      console.error(`SLOPE memory: could not parse ${jsonPath} during migration (${(err as Error).message}). Leaving JSON in place.`);
+      return;
+    }
+
+    const rows: unknown[] = Array.isArray(parsed)
+      ? parsed
+      : (parsed as { memories?: unknown[] })?.memories ?? [];
+
+    if (rows.length === 0) {
+      // Empty JSON — still rename so we don't keep checking
+      this.renameJsonBackup(jsonPath);
+      return;
+    }
+
+    let imported = 0;
+    const insert = this.prepareInsert();
+    const txn = this.db.transaction((rs: unknown[]) => {
+      for (const r of rs) {
+        try {
+          const m = validateMemoryRow(r);
+          insert.run(toRow(m));
+          imported++;
+        } catch (err) {
+          console.error(`SLOPE memory: skipping invalid row during migration (${(err as Error).message})`);
+        }
+      }
+    });
+    txn(rows);
+
+    this.renameJsonBackup(jsonPath);
+    console.error(`SLOPE memory: imported ${imported} row(s) from memories.json into store; original renamed to .bak`);
+  }
+
+  private renameJsonBackup(jsonPath: string): void {
+    try {
+      renameSync(jsonPath, `${jsonPath}.bak`);
+    } catch (err) {
+      console.error(`SLOPE memory: could not rename ${jsonPath} after import (${(err as Error).message}). Manual cleanup recommended.`);
+    }
+  }
+
+  private prepareInsert() {
+    return this.db.prepare(`
+      INSERT OR REPLACE INTO memories (id, text, category, weight, source, created_at, updated_at, source_session_id)
+      VALUES (@id, @text, @category, @weight, @source, @created_at, @updated_at, @source_session_id)
+    `);
+  }
+
+  load(): MemoriesFile {
+    const rows = this.db.prepare('SELECT * FROM memories ORDER BY weight DESC, updated_at DESC').all() as MemoryRow[];
+    return { version: CURRENT_VERSION, memories: rows.map(rowToMemory) };
+  }
+
+  saveAll(data: MemoriesFile): void {
+    const txn = this.db.transaction((rs: Memory[]) => {
+      this.db.prepare('DELETE FROM memories').run();
+      const insert = this.prepareInsert();
+      for (const m of rs) insert.run(toRow(m));
+    });
+    txn(data.memories);
+  }
+
+  add(memory: Memory): void {
+    this.prepareInsert().run(toRow(memory));
+  }
+
+  remove(id: string): boolean {
+    const result = this.db.prepare('DELETE FROM memories WHERE id = ?').run(id);
+    return result.changes > 0;
+  }
+
+  update(id: string, fields: Partial<Pick<Memory, 'text' | 'category' | 'weight' | 'updatedAt'>>): Memory | null {
+    const existing = this.getById(id);
+    if (!existing) return null;
+    const next: Memory = {
+      ...existing,
+      ...(fields.text !== undefined ? { text: fields.text } : {}),
+      ...(fields.category !== undefined ? { category: fields.category } : {}),
+      ...(fields.weight !== undefined ? { weight: Math.max(1, Math.min(10, fields.weight)) } : {}),
+      updatedAt: fields.updatedAt ?? new Date().toISOString(),
+    };
+    this.prepareInsert().run(toRow(next));
+    return next;
+  }
+
+  getById(id: string): Memory | undefined {
+    const row = this.db.prepare('SELECT * FROM memories WHERE id = ?').get(id) as MemoryRow | undefined;
+    return row ? rowToMemory(row) : undefined;
+  }
+
+  /** Close the underlying connection. Test/teardown helper. */
+  close(): void {
+    this.db.close();
+  }
+}
+
+function toRow(m: Memory): Record<string, unknown> {
+  return {
+    id: m.id,
+    text: m.text,
+    category: m.category,
+    weight: m.weight,
+    source: m.source,
+    created_at: m.createdAt,
+    updated_at: m.updatedAt,
+    source_session_id: m.sourceSessionId ?? null,
+  };
+}

--- a/tests/cli/store.test.ts
+++ b/tests/cli/store.test.ts
@@ -108,7 +108,7 @@ describe('slope store status', () => {
 
     const parsed = JSON.parse(output);
     expect(parsed.type).toBe('sqlite');
-    expect(parsed.schemaVersion).toBe(7);
+    expect(parsed.schemaVersion).toBe(8);
     expect(typeof parsed.sessions).toBe('number');
     expect(typeof parsed.claims).toBe('number');
     expect(typeof parsed.scorecards).toBe('number');
@@ -117,7 +117,7 @@ describe('slope store status', () => {
 });
 
 describe('slope store migrate status', () => {
-  it('shows version 7 and up to date', async () => {
+  it('shows version 8 and up to date', async () => {
     const logs: string[] = [];
     const spy = vi.spyOn(console, 'log').mockImplementation((...args) => { logs.push(args.join(' ')); });
 
@@ -126,8 +126,8 @@ describe('slope store migrate status', () => {
     const output = logs.join('\n');
     spy.mockRestore();
 
-    expect(output).toContain('Current schema version: 7');
-    expect(output).toContain('Total migrations:       7');
+    expect(output).toContain('Current schema version: 8');
+    expect(output).toContain('Total migrations:       8');
     expect(output).toContain('up to date');
   });
 });

--- a/tests/core/memory-backend-selection.test.ts
+++ b/tests/core/memory-backend-selection.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import Database from 'better-sqlite3';
+import {
+  getMemoryBackend,
+  addMemory,
+  loadMemories,
+  searchMemories,
+} from '../../src/core/memory.js';
+
+function setupRepo(opts: { withDb?: boolean } = {}): string {
+  const cwd = mkdtempSync(join(tmpdir(), 'slope-mem-sel-'));
+  mkdirSync(join(cwd, '.slope'), { recursive: true });
+  if (opts.withDb) {
+    // Touch the db file so the factory picks the SQLite backend
+    const db = new Database(join(cwd, '.slope', 'slope.db'));
+    db.close();
+  }
+  return cwd;
+}
+
+describe('getMemoryBackend (GH #294 — backend selection)', () => {
+  let cwd: string;
+
+  afterEach(() => {
+    if (cwd) rmSync(cwd, { recursive: true, force: true });
+    delete process.env.SLOPE_MEMORY_BACKEND;
+  });
+
+  it('picks JSON backend when no slope.db exists', () => {
+    cwd = setupRepo();
+    expect(getMemoryBackend(cwd).kind).toBe('json');
+  });
+
+  it('picks SQLite backend when slope.db exists', () => {
+    cwd = setupRepo({ withDb: true });
+    expect(getMemoryBackend(cwd).kind).toBe('sqlite');
+  });
+
+  it('SLOPE_MEMORY_BACKEND=json forces JSON even with slope.db present', () => {
+    cwd = setupRepo({ withDb: true });
+    process.env.SLOPE_MEMORY_BACKEND = 'json';
+    expect(getMemoryBackend(cwd).kind).toBe('json');
+  });
+
+  it('addMemory writes through the SQLite backend when slope.db exists', () => {
+    cwd = setupRepo({ withDb: true });
+    addMemory(cwd, 'remember me', { category: 'workflow', weight: 9 });
+
+    // Memory should be queryable via the public API
+    const all = loadMemories(cwd);
+    expect(all.memories).toHaveLength(1);
+    expect(all.memories[0].text).toBe('remember me');
+
+    // No JSON file should exist (SQLite path doesn't write one)
+    expect(existsSync(join(cwd, '.slope', 'memories.json'))).toBe(false);
+  });
+
+  it('one-time JSON migration moves data into the store on first SQLite open', () => {
+    cwd = setupRepo({ withDb: true });
+    // Simulate a pre-existing JSON file from before S90
+    const jsonPath = join(cwd, '.slope', 'memories.json');
+    writeFileSync(jsonPath, JSON.stringify({
+      version: 1,
+      memories: [{
+        id: 'pre-existing',
+        text: 'legacy memory',
+        category: 'project',
+        weight: 7,
+        source: 'manual',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      }],
+    }));
+
+    // First call to a public function triggers the SQLite backend, which migrates
+    const found = searchMemories(cwd, { query: 'legacy' });
+    expect(found).toHaveLength(1);
+    expect(found[0].id).toBe('pre-existing');
+
+    // JSON should have been renamed to .bak
+    expect(existsSync(jsonPath)).toBe(false);
+    expect(existsSync(`${jsonPath}.bak`)).toBe(true);
+  });
+});

--- a/tests/core/store-health.test.ts
+++ b/tests/core/store-health.test.ts
@@ -23,7 +23,7 @@ describe('checkStoreHealth', () => {
     const result = await checkStoreHealth(store, 'sqlite');
     expect(result.healthy).toBe(true);
     expect(result.type).toBe('sqlite');
-    expect(result.schemaVersion).toBe(7);
+    expect(result.schemaVersion).toBe(8);
     expect(result.stats.sessions).toBe(0);
     expect(result.stats.claims).toBe(0);
     expect(result.stats.scorecards).toBe(0);

--- a/tests/store/sqlite-memory-backend.test.ts
+++ b/tests/store/sqlite-memory-backend.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SqliteMemoryBackend } from '../../src/store/sqlite-memory-backend.js';
+import type { Memory } from '../../src/core/memory-types.js';
+
+function setupRepo(): { cwd: string; dbPath: string } {
+  const cwd = mkdtempSync(join(tmpdir(), 'slope-sqlite-mem-'));
+  mkdirSync(join(cwd, '.slope'), { recursive: true });
+  return { cwd, dbPath: join(cwd, '.slope', 'slope.db') };
+}
+
+function makeMemory(overrides: Partial<Memory> = {}): Memory {
+  const now = new Date().toISOString();
+  return {
+    id: `mem-${Math.random().toString(36).slice(2, 10)}`,
+    text: 'test memory',
+    category: 'project',
+    weight: 5,
+    source: 'manual',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('SqliteMemoryBackend (GH #294)', () => {
+  let cwd: string;
+  let dbPath: string;
+  let backend: SqliteMemoryBackend;
+
+  beforeEach(() => {
+    ({ cwd, dbPath } = setupRepo());
+    backend = new SqliteMemoryBackend(cwd, dbPath);
+  });
+
+  afterEach(() => {
+    backend.close();
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('reports kind: sqlite', () => {
+    expect(backend.kind).toBe('sqlite');
+  });
+
+  it('returns empty list when table is fresh', () => {
+    const data = backend.load();
+    expect(data.version).toBe(1);
+    expect(data.memories).toEqual([]);
+  });
+
+  it('add then load round-trips a memory', () => {
+    const m = makeMemory({ text: 'remember this', weight: 8 });
+    backend.add(m);
+    const { memories } = backend.load();
+    expect(memories).toHaveLength(1);
+    expect(memories[0]).toEqual(m);
+  });
+
+  it('sorts load() by weight desc, then updated_at desc', () => {
+    const a = makeMemory({ id: 'a', weight: 3, updatedAt: '2026-01-01T00:00:00Z' });
+    const b = makeMemory({ id: 'b', weight: 9, updatedAt: '2026-01-02T00:00:00Z' });
+    const c = makeMemory({ id: 'c', weight: 9, updatedAt: '2026-01-03T00:00:00Z' });
+    backend.add(a); backend.add(b); backend.add(c);
+    const ids = backend.load().memories.map(m => m.id);
+    expect(ids).toEqual(['c', 'b', 'a']);
+  });
+
+  it('remove deletes by id', () => {
+    const m = makeMemory();
+    backend.add(m);
+    expect(backend.remove(m.id)).toBe(true);
+    expect(backend.load().memories).toHaveLength(0);
+  });
+
+  it('remove returns false when id is missing', () => {
+    expect(backend.remove('does-not-exist')).toBe(false);
+  });
+
+  it('update patches the row in place', () => {
+    const m = makeMemory({ text: 'old', weight: 5 });
+    backend.add(m);
+    const updated = backend.update(m.id, { text: 'new', weight: 9 });
+    expect(updated?.text).toBe('new');
+    expect(updated?.weight).toBe(9);
+    expect(backend.getById(m.id)?.text).toBe('new');
+  });
+
+  it('update returns null when id is missing', () => {
+    expect(backend.update('missing', { text: 'x' })).toBeNull();
+  });
+
+  it('update clamps weight to [1,10]', () => {
+    const m = makeMemory();
+    backend.add(m);
+    expect(backend.update(m.id, { weight: 99 })?.weight).toBe(10);
+    expect(backend.update(m.id, { weight: 0 })?.weight).toBe(1);
+  });
+
+  it('saveAll replaces the entire dataset', () => {
+    backend.add(makeMemory({ id: 'a' }));
+    backend.add(makeMemory({ id: 'b' }));
+    backend.saveAll({ version: 1, memories: [makeMemory({ id: 'c' })] });
+    const ids = backend.load().memories.map(m => m.id);
+    expect(ids).toEqual(['c']);
+  });
+
+  it('preserves sourceSessionId across round-trip', () => {
+    const m = makeMemory({ sourceSessionId: 'session-xyz' });
+    backend.add(m);
+    expect(backend.getById(m.id)?.sourceSessionId).toBe('session-xyz');
+  });
+});
+
+describe('SqliteMemoryBackend JSON migration', () => {
+  let cwd: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ cwd, dbPath } = setupRepo());
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('imports existing memories.json on first open', () => {
+    const jsonPath = join(cwd, '.slope', 'memories.json');
+    const m = makeMemory({ id: 'imported', text: 'from json' });
+    writeFileSync(jsonPath, JSON.stringify({ version: 1, memories: [m] }));
+
+    const backend = new SqliteMemoryBackend(cwd, dbPath);
+    try {
+      const loaded = backend.load();
+      expect(loaded.memories).toHaveLength(1);
+      expect(loaded.memories[0].id).toBe('imported');
+      expect(loaded.memories[0].text).toBe('from json');
+
+      // Original JSON should be renamed to .bak
+      expect(existsSync(jsonPath)).toBe(false);
+      expect(existsSync(`${jsonPath}.bak`)).toBe(true);
+    } finally {
+      backend.close();
+    }
+  });
+
+  it('migrates v0 plain-array JSON shape', () => {
+    const jsonPath = join(cwd, '.slope', 'memories.json');
+    const m = makeMemory({ id: 'legacy', text: 'pre-v1' });
+    writeFileSync(jsonPath, JSON.stringify([m]));
+
+    const backend = new SqliteMemoryBackend(cwd, dbPath);
+    try {
+      expect(backend.load().memories[0].id).toBe('legacy');
+    } finally {
+      backend.close();
+    }
+  });
+
+  it('skips migration when table is already populated', () => {
+    // First open imports
+    const jsonPath = join(cwd, '.slope', 'memories.json');
+    writeFileSync(jsonPath, JSON.stringify({ version: 1, memories: [makeMemory({ id: 'first' })] }));
+    new SqliteMemoryBackend(cwd, dbPath).close();
+
+    // Re-create the JSON (different content) and re-open
+    writeFileSync(jsonPath, JSON.stringify({ version: 1, memories: [makeMemory({ id: 'second' })] }));
+    const backend = new SqliteMemoryBackend(cwd, dbPath);
+    try {
+      const ids = backend.load().memories.map(m => m.id);
+      // 'first' came from the original migration; 'second' should NOT be imported
+      expect(ids).toContain('first');
+      expect(ids).not.toContain('second');
+    } finally {
+      backend.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Resolves PR #293 architect finding A1 (GH #294): the memory subsystem was writing directly to \`.slope/memories.json\` via \`node:fs\`, bypassing the store-sqlite abstraction that already handles sessions, claims, scorecards, and common-issues.

## Architecture

```
src/core/memory-types.ts             Memory + MemoriesFile types (extracted)
src/core/memory-validation.ts        validateMemoryRow() shared helper
src/core/memory-backend.ts           MemoryBackend interface
src/core/json-memory-backend.ts      JsonMemoryBackend (legacy default)
src/store/sqlite-memory-backend.ts   SqliteMemoryBackend (new)
src/core/memory.ts                   Public API delegates via factory
```

## Backend selection

Sync API, transparent to callers:

| Condition | Backend |
|---|---|
| \`.slope/slope.db\` exists | SqliteMemoryBackend |
| \`SLOPE_MEMORY_BACKEND=sqlite\` env | SqliteMemoryBackend (forced) |
| \`SLOPE_MEMORY_BACKEND=json\` env | JsonMemoryBackend (forced — for tests) |
| Otherwise | JsonMemoryBackend |

## One-time JSON migration

When SqliteMemoryBackend opens and the memories table is empty, any existing \`.slope/memories.json\` is imported in a transaction and the JSON file is renamed to \`.bak\`. Idempotent — subsequent opens skip when the table has rows. Handles both v0 (plain array) and v1 (versioned object) JSON shapes.

## Schema

- **sqlite migration v8** adds the memories table (canonical schema home)
- **postgres migration v5** adds the matching table with \`project_id\` for multi-tenant aggregation
- PG backend implementation deferred to follow-up — schema is in place so future async PostgresMemoryBackend ships without another migration

## Public API unchanged

\`addMemory\`/\`removeMemory\`/\`searchMemories\`/etc. keep their sync signatures. Auto-memory guard hooks, the memory CLI, and briefing all keep working with **zero call-site changes**.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 3121 pass, 23 skipped (1 pre-existing flaky cadence test, unrelated)
- [x] 14 new tests in \`tests/store/sqlite-memory-backend.test.ts\`
- [x] 5 new tests in \`tests/core/memory-backend-selection.test.ts\`
- [x] All 28 existing memory tests pass against JsonMemoryBackend
- [ ] Reviewer test: open a real repo with existing memories.json, run any memory CLI command, confirm migration completes silently

## Stats

- 4 new source files, 2 modified, 2 new test files, 19 new tests
- Single architectural concern across 4 ordered tickets (S90-1 → S90-4)
- ~810 lines added net

Closes #294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented flexible memory persistence system supporting multiple storage backends with automatic backend selection.
  * Added seamless automatic migration of existing memory data when switching storage formats.

* **Tests**
  * Updated test expectations for database schema version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->