### PR TITLE
chore: scorecards for S86-S91 with review findings amended

### DIFF
--- a/docs/retros/sprint-86.json
+++ b/docs/retros/sprint-86.json
@@ -1,0 +1,130 @@
+{
+  "sprint_number": 86,
+  "theme": "The Marshal — Drift Detection",
+  "par": 5,
+  "slope": 2,
+  "score": 7,
+  "score_label": "double_bogey",
+  "date": "2026-05-08",
+  "shots": [
+    {
+      "ticket_key": "S86-T1",
+      "title": "slope roadmap validate detects status drift against git log (#319)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] git.ts execSync lacks error logging when encoding fails; empty return masks debugging signals",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S86-T2",
+      "title": "roadmap-edit-shipped guard blocks paper-tickets (#320)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] deepEqual in roadmap-edit-shipped does not handle Date/RegExp/Map/Set; future schema changes risk infinite recursion",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S86-T3",
+      "title": "post-hole-enforcement Stop guard surfaces drift (#291)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] post-hole-enforcement guard marked advisory but respects SLOPE_POST_HOLE_BLOCK env var for blocking; decision behavior not discoverable from guard registration",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "[code review] post-hole-enforcement calls findShippedSprintsOnMain on every Stop without timeout; git log on deep histories could block session end",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S86-T4",
+      "title": "backfill scorecards for S70 + S74-S83 (#318)",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] Backfilled scorecards lack idempotency safeguards; re-running backfill overwrites manual corrections without warning",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "bunker",
+          "severity": "minor",
+          "description": "[architect review] Scorecard backfill to docs/retros/ assumes pattern config matches .json files; no validation against .slope/config.json scorecardPattern",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] Backfilled scorecards default to score:4/par without explicit api enforcement; consumers must check _backfilled flag to avoid inflating handicap",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] scorecard pattern matching silently fails if scorecardPattern contains no wildcards (e.g. sprint.json instead of sprint-*.json)",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S86-T5",
+      "title": "briefing surfaces next planned sprint + theme/title (#290, #324)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "minor",
+          "description": "[architect review] findNextPlannedSprint does not validate against roadmap dependency cycles; relies on separate validateRoadmap call to detect",
+          "gotcha_id": "review:architect"
+        }
+      ]
+    }
+  ],
+  "stats": {
+    "fairways_hit": 5,
+    "fairways_total": 5,
+    "greens_in_regulation": 5,
+    "greens_total": 5,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 9,
+    "hazard_penalties": 2,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [],
+  "nutrition": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Sprint built post-hoc as part of v1.54.0 release. Findings from architect+code reviews recorded via slope review amend."
+  ]
+}

--- a/docs/retros/sprint-87.json
+++ b/docs/retros/sprint-87.json
@@ -1,0 +1,97 @@
+{
+  "sprint_number": 87,
+  "theme": "The Bug Clearing v2 — CLI fixes for external repos",
+  "par": 4,
+  "slope": 1,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-08",
+  "shots": [
+    {
+      "ticket_key": "S87-T1",
+      "title": "slope version reads from installed package, not cwd (#300)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "minor",
+          "description": "[architect review] version.ts path traversal ../../.. assumes fixed build layout; no validation of package.json existence before parse could fail silently",
+          "gotcha_id": "review:architect"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S87-T2",
+      "title": "formatter accepts legacy tickets field as shots alias (#298)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "minor",
+          "description": "[architect review] formatter.ts cast on result field does not validate enum membership; accepts any string as valid ShotResult",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] formatter.ts does not test invalid enum values in legacy tickets result field",
+          "gotcha_id": "review:code"
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] formatter.ts does not validate that legacy approach field is a valid ClubSelection enum member",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S87-T3",
+      "title": "roadmap generate --dry-run no longer writes the file (#304)",
+      "club": "putter",
+      "result": "green",
+      "hazards": []
+    },
+    {
+      "ticket_key": "S87-T4",
+      "title": "slope init no longer creates example scorecard by default (#306)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] init.ts console message 'pass --with-example to keep' is grammatically confusing; should say 'pass --with-example at next init run'",
+          "gotcha_id": "review:code"
+        }
+      ]
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 5,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [],
+  "nutrition": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Sprint built post-hoc as part of v1.54.0 release. Findings from architect+code reviews recorded via slope review amend."
+  ]
+}

--- a/docs/retros/sprint-88.json
+++ b/docs/retros/sprint-88.json
@@ -1,0 +1,115 @@
+{
+  "sprint_number": 88,
+  "theme": "The Compass — Agent State & Status",
+  "par": 4,
+  "slope": 1,
+  "score": 7,
+  "score_label": "triple_plus",
+  "date": "2026-05-08",
+  "shots": [
+    {
+      "ticket_key": "S88-T1",
+      "title": "slope agent status — machine-readable next-step output (#310)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] AgentStatus.phase enum is missing 'pr_review' phase used by initiative logic downstream; limits reusability",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] AgentStatus.recommendedCommands array of strings is fragile; future parsing/typing will be harder; should be {cmd: string}[]",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "bunker",
+          "severity": "minor",
+          "description": "[architect review] collectAgentStatus couples to vision+roadmap+sprint-state+store independently; 7 try/catch blocks suggest fragile assumptions",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "[code review] AgentStatus shape exported as JSON for agent consumption but has no versioning marker; breaking changes will be silent",
+          "gotcha_id": "review:code"
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] loadRoadmap defined in ticket.ts duplicates logic in agent.ts; should extract to shared util",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S88-T2",
+      "title": "slope agent next-md generates AGENT_NEXT.md (#315)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] nextMdSubcommand --output parsing doesn't validate = presence; --output without = produces undefined path",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S88-T3",
+      "title": "slope sprint begin bundles start + claim + briefing + prep (#311)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] sprint begin imports briefing and prep dynamically with no error handling; mid-flow failure leaves sprint state persisted",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "[code review] sprint begin does not validate roadmap.sprints exists before calling sprint.tickets; corrupt roadmap causes runtime error",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S88-T4",
+      "title": "slope ticket done releases claim and emits next step (#316)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": []
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 8,
+    "hazard_penalties": 2.5,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [],
+  "nutrition": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Sprint built post-hoc as part of v1.54.0 release. Findings from architect+code reviews recorded via slope review amend."
+  ]
+}

--- a/docs/retros/sprint-89.json
+++ b/docs/retros/sprint-89.json
@@ -1,0 +1,134 @@
+{
+  "sprint_number": 89,
+  "theme": "The Toolkit — Agent Workflow Commands",
+  "par": 4,
+  "slope": 1,
+  "score": 12,
+  "score_label": "triple_plus",
+  "date": "2026-05-08",
+  "shots": [
+    {
+      "ticket_key": "S89-T1",
+      "title": "slope sprint plan generates markdown plan file (#312)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] Kahn topo-sort fallback masks both cycles and incomplete traversals without distinguishing root cause; output order ambiguous on failure",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "major",
+          "description": "[code review] Hazard extraction casts bunker_locations to object but array can contain strings; type assertion will throw at runtime",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S89-T2",
+      "title": "slope gate aliases for initiative review machinery (#313)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] VALID_REVIEWERS includes both 'ux' and 'ux-designer'; unclear if these are equivalent or map to different review types",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] recordReview error in try/catch lacks stderr logging if Error.message is empty; user sees blank failure reason",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S89-T3",
+      "title": "slope commit-ready pre-commit checklist (#314)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "critical",
+          "description": "[architect review] checkCodebaseMap staleness check uses nested git subshell that silently returns OK if CODEBASE.md is untracked/new",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "bunker",
+          "severity": "major",
+          "description": "[architect review] commit-ready missing validation that sprint-state.json phase is consistent with its gates; can show pending gates in complete phase",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "[code review] checkCodebaseMap staleness hardcoded to 30 commits; no config override for fast-moving repos where 2 weeks of commits is stale threshold",
+          "gotcha_id": "review:code"
+        },
+        {
+          "type": "rough",
+          "severity": "major",
+          "description": "[code review] collectCommitReady skips claim check when sprintCheck.ok=false; user gets warn+no suggestion for missing sprint state",
+          "gotcha_id": "review:code"
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] checkPendingGates calls pendingGates(state) without validating state.gates object structure exists; incomplete gates return partial results",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S89-T4",
+      "title": "first-class slope init --codex profile (#309)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] installDefaultHooks assumes .codex parent exists; recursive mkdir succeeds but permission errors would silently fail hooks installation",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "[code review] init --codex tests verify hooks installed but not executable (+x) or shebang validity; non-functional hooks could ship",
+          "gotcha_id": "review:code"
+        }
+      ]
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 11,
+    "hazard_penalties": 7.5,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [],
+  "nutrition": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Sprint built post-hoc as part of v1.54.0 release. Findings from architect+code reviews recorded via slope review amend."
+  ]
+}

--- a/docs/retros/sprint-90.json
+++ b/docs/retros/sprint-90.json
@@ -1,0 +1,115 @@
+{
+  "sprint_number": 90,
+  "theme": "The Vault — Memory ↔ Store Reunification",
+  "par": 4,
+  "slope": 2,
+  "score": 9,
+  "score_label": "triple_plus",
+  "date": "2026-05-08",
+  "shots": [
+    {
+      "ticket_key": "S90-T1",
+      "title": "extend MemoryBackend interface (#294)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "minor",
+          "description": "[architect review] MemoryBackend.saveAll() docstring unclear—method semantics are truncate-then-insert (destructive), not append; rename to replaceAll() or clarify intent",
+          "gotcha_id": "review:architect"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S90-T2",
+      "title": "implement SqliteMemoryBackend + JSON migration",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] PG schema v5 includes project_id (multi-tenant), SQLite v8 omits it; future PG MemoryBackend will have schema mismatch—add project_id to SQLite v8 now for forward compatibility",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "critical",
+          "description": "[code review] importJsonIfPresent transaction doesn't halt on validateMemoryRow error—remaining rows import silently; wrap per-row validation in try-catch or throw early",
+          "gotcha_id": "review:code"
+        },
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "[code review] SqliteMemoryBackend.ensureSchema errors swallowed in constructor; if schema creation fails, getMemoryBackend falls back to JSON without signaling error",
+          "gotcha_id": "review:code"
+        },
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "[code review] renameJsonBackup silently ignores failures (permission denied, etc.); JSON stays in place; re-opens re-attempt import; user unaware of loop until log spam appears",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S90-T3",
+      "title": "migrate memory.ts to use backend factory",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] Backend fallback doesn't distinguish between DB corruption and missing better-sqlite3 binding—both silently fall back to JSON, creating divergence where new writes bypass corrupted SQLite store",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] JSON to SQLite migration runs on every SqliteMemoryBackend instantiation with no process-level locking; two agents initializing simultaneously can race on JSON rename",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] getMemoryBackend creates new backend instance per call (no memoization)—multiple database opens, repeated schema checks, and re-attempted migrations on every memory operation",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S90-T4",
+      "title": "tests + cleanup",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": []
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 8,
+    "hazard_penalties": 4.5,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [],
+  "nutrition": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Sprint built post-hoc as part of v1.54.0 release. Findings from architect+code reviews recorded via slope review amend."
+  ]
+}

--- a/docs/retros/sprint-91.json
+++ b/docs/retros/sprint-91.json
@@ -1,0 +1,116 @@
+{
+  "sprint_number": 91,
+  "theme": "The Pit Crew — Automation Hooks",
+  "par": 4,
+  "slope": 1,
+  "score": 7,
+  "score_label": "triple_plus",
+  "date": "2026-05-08",
+  "shots": [
+    {
+      "ticket_key": "S91-T1",
+      "title": "slope vision create --write-md tracks markdown mirror (#305)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] writeVisionMarkdown accepts absolute path without validation; --write-md=/etc/passwd could escape intended directory",
+          "gotcha_id": "review:architect"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S91-T2",
+      "title": "branch hygiene checks in slope doctor (#322)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] detectMainBranch does not validate local branch existence; detached HEAD could report non-existent main branch as valid",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] git helper swallows all errors including permission denied; impossible to distinguish command failures from absence",
+          "gotcha_id": "review:code"
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] merged branch name regex depends on exact git output format; spacing changes cause silent false positives",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S91-T3",
+      "title": "slope pr finalize auto-injects Closes #N (#321)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] git log fallback chain uses shell OR syntax in execSync string argument; first command will fail silently before retry succeeds",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "[code review] planPrFinalize calls gh without try-catch; auth failure mid-execution surfaces error without context to user",
+          "gotcha_id": "review:code"
+        }
+      ]
+    },
+    {
+      "ticket_key": "S91-T4",
+      "title": "pr-review guard surfaces review-tier recommendation (#302)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "[architect review] inferBaseRef returns null safely but caller defaults to origin/main without verifying ref exists; failed recommendations go unreported",
+          "gotcha_id": "review:architect"
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] computeRecommendations silently fails and returns empty array; user cannot distinguish missing recommendations from computation error",
+          "gotcha_id": "review:code"
+        }
+      ]
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 8,
+    "hazard_penalties": 2.5,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [],
+  "nutrition": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Sprint built post-hoc as part of v1.54.0 release. Findings from architect+code reviews recorded via slope review amend."
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the post-hole loop for v1.54.0. Adds 6 scorecards (\`docs/retros/sprint-{86..91}.json\`) with architect+code review findings injected as hazards via \`slope review amend\`.

## Score breakdown

| Sprint | Par | Score | Label | Hazards |
|---|---|---|---|---|
| S86 | 5 | 7 | double_bogey | 4 from 9 findings |
| S87 | 4 | 4 | par | 4 (no severity penalties) |
| S88 | 4 | 7 | triple_plus | 4 from 8 findings |
| S89 | 4 | 12 | triple_plus | 4 from 11 findings |
| S90 | 4 | 9 | triple_plus | 4 from 8 findings |
| S91 | 4 | 7 | triple_plus | 4 from 8 findings |

Five of six sprints had review-discovered hazards worth recording — consistent with the "reviews catch hazards only post-implementation" pattern documented in MEMORY.md from the S43-S45 phase. S87 (the bug-clearing sprint) was the cleanest — its findings were minor enum-validation gaps with zero severity penalty.

## Validator state

- \`slope roadmap validate\`: phantom-sprint warnings cleared. Only the deliberate S75/S75.5/S76 numbering gap and pre-existing oversized-sprint warnings remain.
- \`slope card\`: last-5 handicap +3.8 (was +0.2 before review pass) — honest signal of the hazard-heavy v1.54.0.

## Process note

This is the post-hole work the post-hole-enforcement guard (S86-3) was designed to surface. Without scorecards, the guard would have warned on every session-end until they were built. Now satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)