### PR TITLE
fix: align hook install count with slope doctor (#307)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -361,7 +361,12 @@ function checkGuards(cwd: string): DoctorCheck[] {
 
   try {
     const hooksConfig = JSON.parse(readFileSync(hooksPath, 'utf8'));
-    const installedCount = Object.keys(hooksConfig.installed ?? {}).length;
+    // Count only guard-prefixed entries — session-start/session-end and
+    // other non-guard hooks live in the same registry but shouldn't
+    // contribute to the "guards installed" tally (#307).
+    const installed = hooksConfig.installed ?? {};
+    const installedGuards = Object.keys(installed).filter(k => k.startsWith('guard-'));
+    const installedCount = installedGuards.length;
     const totalGuards = GUARD_DEFINITIONS.length;
 
     if (installedCount === 0) {
@@ -375,13 +380,13 @@ function checkGuards(cwd: string): DoctorCheck[] {
       checks.push({
         name: 'guards',
         status: 'ok',
-        message: `${installedCount} hooks installed (${totalGuards} guards available) — run \`slope guard recommend\` to see suggestions`,
+        message: `${installedCount} of ${totalGuards} guard hooks installed — run \`slope hook add --level=full\` to install the rest`,
       });
     } else {
       checks.push({
         name: 'guards',
         status: 'ok',
-        message: `${installedCount} hooks installed (${totalGuards} guards available)`,
+        message: `${installedCount} of ${totalGuards} guard hooks installed`,
       });
     }
   } catch {

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -314,7 +314,12 @@ function installGuardHooks(cwd: string, level: 'scoring' | 'essential' | 'full',
   }
   saveHooksConfig(cwd, hooksConfig);
 
-  console.log(`\n  Installed ${guards.length} guard hooks (level: ${guards.some(g => g.level === 'full') ? 'full' : 'scoring'}):`);
+  // Re-read the config we just saved to report the actual persisted count.
+  // Previously reported guards.length, which over-counted when an adapter
+  // dropped a guard during installGuards() (#307 mismatch with slope doctor).
+  const persistedCount = Object.keys(loadHooksConfig(cwd).installed ?? {})
+    .filter(k => k.startsWith('guard-')).length;
+  console.log(`\n  Installed ${persistedCount} of ${guards.length} guard hooks (level: ${guards.some(g => g.level === 'full') ? 'full' : 'scoring'}):`);
   for (const g of guards) {
     console.log(`    ${g.name.padEnd(16)} [${g.hookEvent}] ${g.description}`);
   }


### PR DESCRIPTION
## Summary

Two count metrics, two inconsistent reports. Both now agree.

| Source | Was | Now |
|---|---|---|
| \`slope hook add\` | \`Installed 28 guard hooks\` (intended count) | \`Installed M of N guard hooks\` (M = persisted, N = intended) |
| \`slope doctor\` | \`26 hooks installed (28 guards available)\` (counted ALL hooks-config entries) | \`M of N guard hooks installed\` (counts only \`guard-\` prefixed entries) |

Both count the same thing from the same source of truth (\`hooks-config.installed\`), so the user no longer has to mentally reconcile two contradictory numbers.

If an adapter drops a guard during \`installGuards()\` (e.g., when the harness doesn't support that hookEvent), the M-of-N form now surfaces the mismatch honestly instead of papering over it.

Closes #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)