### PR TITLE
feat: gitignore audit in slope doctor (#323)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -32,6 +32,9 @@ export function runDoctorChecks(cwd: string): DoctorCheck[] {
   // 2. Check .gitignore contains .slope/
   checks.push(checkGitignore(cwd));
 
+  // 2b. Check .gitignore covers common-noise patterns (#323)
+  checks.push(...checkGitignoreNoise(cwd));
+
   // 3. Check SQLite store exists
   checks.push(checkStore(cwd));
 
@@ -92,6 +95,49 @@ function checkGitignore(cwd: string): DoctorCheck {
     return { name: 'gitignore', status: 'ok', message: '.slope/ is in .gitignore' };
   }
   return { name: 'gitignore', status: 'warn', message: '.slope/ not in .gitignore — local state may be committed', fixable: true };
+}
+
+/** Curated list of common-noise patterns that should typically be gitignored.
+ *  Used by checkGitignoreNoise (#323) so projects don't accidentally commit
+ *  macOS metadata, editor temps, OS junk, or agent caches. */
+export const COMMON_NOISE_PATTERNS: ReadonlyArray<{ pattern: string; reason: string }> = [
+  { pattern: '.DS_Store', reason: 'macOS Finder metadata' },
+  { pattern: '._*', reason: 'macOS resource forks' },
+  { pattern: 'Thumbs.db', reason: 'Windows thumbnail cache' },
+  { pattern: 'desktop.ini', reason: 'Windows folder metadata' },
+  { pattern: '*.swp', reason: 'Vim swap files' },
+  { pattern: '*.swo', reason: 'Vim swap files' },
+  { pattern: '*~', reason: 'Editor backup files (Emacs/etc.)' },
+  { pattern: '.idea/', reason: 'JetBrains IDE settings' },
+  { pattern: 'node_modules/', reason: 'Node dependencies' },
+];
+
+/** Check whether the project's .gitignore covers common-noise patterns.
+ *  Reports a warning per missing pattern so users can fix multiple in one
+ *  pass via slope doctor --fix. Returns [] if no .gitignore exists (the
+ *  primary checkGitignore handles that). */
+function checkGitignoreNoise(cwd: string): DoctorCheck[] {
+  const gitignorePath = join(cwd, '.gitignore');
+  if (!existsSync(gitignorePath)) return [];
+
+  // Strip inline comments and trim — matches the format we write in the
+  // --fix path so re-checks after a fix find the pattern as "present".
+  const lines = readFileSync(gitignorePath, 'utf8')
+    .split('\n')
+    .map(l => l.replace(/\s+#.*$/, '').trim())
+    .filter(l => l && !l.startsWith('#'));
+  const present = new Set(lines);
+
+  const missing = COMMON_NOISE_PATTERNS.filter(p => !present.has(p.pattern));
+  if (missing.length === 0) {
+    return [{ name: 'gitignore-noise', status: 'ok', message: 'Common-noise patterns covered' }];
+  }
+  return [{
+    name: 'gitignore-noise',
+    status: 'warn',
+    message: `${missing.length} common-noise pattern(s) missing: ${missing.slice(0, 3).map(m => m.pattern).join(', ')}${missing.length > 3 ? ', ...' : ''} — run \`slope doctor --fix\` to add`,
+    fixable: true,
+  }];
 }
 
 function checkStore(cwd: string): DoctorCheck {
@@ -475,6 +521,22 @@ export async function runDoctorFixes(cwd: string, checks: DoctorCheck[]): Promis
         if (!/^\/?\.slope\/?$/m.test(content)) {
           writeFileSync(gitignorePath, content + '\n# SLOPE local state (sessions, handoffs, sprint-state, DB)\n.slope/\n');
           fixed.push('Added .slope/ to .gitignore');
+        }
+        break;
+      }
+      case 'gitignore-noise': {
+        // Append any missing common-noise patterns under a single section
+        // header so reviewers can see why they appeared in one diff.
+        const gitignorePath = join(cwd, '.gitignore');
+        const content = existsSync(gitignorePath) ? readFileSync(gitignorePath, 'utf8') : '';
+        const lines = content.split('\n').map(l => l.trim());
+        const present = new Set(lines.filter(l => l && !l.startsWith('#')));
+        const missing = COMMON_NOISE_PATTERNS.filter(p => !present.has(p.pattern));
+        if (missing.length > 0) {
+          const block = '\n# Common-noise patterns (added by slope doctor --fix)\n' +
+            missing.map(p => `${p.pattern}    # ${p.reason}`).join('\n') + '\n';
+          writeFileSync(gitignorePath, content + block);
+          fixed.push(`Added ${missing.length} common-noise pattern(s) to .gitignore`);
         }
         break;
       }

--- a/tests/cli/doctor-gitignore-noise.test.ts
+++ b/tests/cli/doctor-gitignore-noise.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runDoctorChecks, runDoctorFixes, COMMON_NOISE_PATTERNS } from '../../src/cli/commands/doctor.js';
+
+function makeTmpRepo(): string {
+  return mkdtempSync(join(tmpdir(), 'slope-doctor-noise-'));
+}
+
+describe('checkGitignoreNoise (#323)', () => {
+  let cwd: string;
+
+  beforeEach(() => { cwd = makeTmpRepo(); });
+  afterEach(() => { rmSync(cwd, { recursive: true, force: true }); });
+
+  it('skips when .gitignore is missing (primary check handles that)', () => {
+    const checks = runDoctorChecks(cwd);
+    const noise = checks.find(c => c.name === 'gitignore-noise');
+    expect(noise).toBeUndefined();
+  });
+
+  it('reports OK when all common-noise patterns are present', () => {
+    const all = COMMON_NOISE_PATTERNS.map(p => p.pattern).join('\n');
+    writeFileSync(join(cwd, '.gitignore'), `.slope/\n${all}\n`);
+    const checks = runDoctorChecks(cwd);
+    const noise = checks.find(c => c.name === 'gitignore-noise');
+    expect(noise?.status).toBe('ok');
+  });
+
+  it('warns with count + sample when patterns are missing', () => {
+    writeFileSync(join(cwd, '.gitignore'), '.slope/\n');
+    const checks = runDoctorChecks(cwd);
+    const noise = checks.find(c => c.name === 'gitignore-noise');
+    expect(noise?.status).toBe('warn');
+    expect(noise?.message).toMatch(/\d+ common-noise pattern\(s\) missing:/);
+    // .DS_Store is at the head of the curated list — should appear in the sample
+    expect(noise?.message).toContain('.DS_Store');
+    expect(noise?.fixable).toBe(true);
+  });
+
+  it('does not double-flag patterns that are present (commented vs uncommented)', () => {
+    writeFileSync(join(cwd, '.gitignore'), '.DS_Store\n# .swp is for vim users\n');
+    const checks = runDoctorChecks(cwd);
+    const noise = checks.find(c => c.name === 'gitignore-noise');
+    // .DS_Store is uncommented, so it's NOT in the missing list (sample omits it)
+    expect(noise?.status).toBe('warn');
+    expect(noise?.message).not.toMatch(/missing:[^.]*\.DS_Store/);
+    // Comments are stripped, so the comment-only mention of .swp doesn't count
+    // — *.swp remains missing. The displayed sample shows the first 3 only,
+    // so we just check the count reflects the un-sampled pattern.
+    expect(noise?.message).toMatch(/\d+ common-noise/);
+  });
+
+  it('--fix appends missing patterns and re-check is OK', async () => {
+    writeFileSync(join(cwd, '.gitignore'), '.slope/\n');
+    const before = runDoctorChecks(cwd);
+    const fixed = await runDoctorFixes(cwd, before);
+
+    expect(fixed.some(m => m.includes('common-noise pattern'))).toBe(true);
+
+    const content = readFileSync(join(cwd, '.gitignore'), 'utf8');
+    for (const p of COMMON_NOISE_PATTERNS) {
+      expect(content).toContain(p.pattern);
+    }
+
+    const after = runDoctorChecks(cwd);
+    const noise = after.find(c => c.name === 'gitignore-noise');
+    expect(noise?.status).toBe('ok');
+  });
+
+  it('preserves existing .gitignore contents when adding patterns', async () => {
+    writeFileSync(join(cwd, '.gitignore'), '.slope/\n# my custom comment\nmy-custom-rule\n');
+    const before = runDoctorChecks(cwd);
+    await runDoctorFixes(cwd, before);
+    const content = readFileSync(join(cwd, '.gitignore'), 'utf8');
+    expect(content).toContain('# my custom comment');
+    expect(content).toContain('my-custom-rule');
+    expect(content).toContain('.DS_Store');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a curated common-noise audit to \`slope doctor\` so the .DS_Store oversight from PR #317 doesn't recur. \`slope doctor --fix\` now also applies the cleanup.

## Curated patterns

| Pattern | Reason |
|---|---|
| \`.DS_Store\` | macOS Finder metadata |
| \`._*\` | macOS resource forks |
| \`Thumbs.db\` | Windows thumbnail cache |
| \`desktop.ini\` | Windows folder metadata |
| \`*.swp\` / \`*.swo\` | Vim swap files |
| \`*~\` | Editor backup files (Emacs/etc.) |
| \`.idea/\` | JetBrains IDE settings |
| \`node_modules/\` | Node dependencies |

## Output

\`\`\`
$ slope doctor
...
[WARN] gitignore-noise: 8 common-noise pattern(s) missing: ._*, Thumbs.db, desktop.ini, ... — run \`slope doctor --fix\` to add
...

$ slope doctor --fix
[FIXED] Added 8 common-noise pattern(s) to .gitignore
\`\`\`

## Test plan

- [x] 6 cases in \`tests/cli/doctor-gitignore-noise.test.ts\` covering all-present, count + sample warning, comment-stripping, fix appends + re-check OK, custom content preserved.
- [x] \`pnpm typecheck\` clean
- [ ] Reviewer test on a real repo with various pre-existing .gitignore states

Closes #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)