### PR TITLE
feat: slope retro backfill + status drift surface (#318)

### DIFF
--- a/src/cli/commands/retro.ts
+++ b/src/cli/commands/retro.ts
@@ -1,0 +1,289 @@
+/**
+ * `slope retro` — Retrospective scorecard utilities.
+ *
+ * Currently exposes one subcommand:
+ *   slope retro backfill --sprint=N         Generate a scorecard from git
+ *   slope retro backfill --all-missing      Backfill all shipped-but-missing
+ *
+ * Closes the tooling part of GH #318. The data backfill for S70 + S74-S83
+ * shipped earlier in S86-4 (one-shot script); this command makes the
+ * pattern repeatable for future sprints that ship without their post-hole.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { findShippedSprintsOnMain, parseRoadmap, castRoadmapStructure } from '../../core/index.js';
+import type { RoadmapDefinition, RoadmapSprint } from '../../core/index.js';
+import { loadConfig } from '../config.js';
+
+interface BackfillOptions {
+  sprint?: number;
+  allMissing?: boolean;
+  dryRun?: boolean;
+}
+
+export async function retroCommand(args: string[]): Promise<void> {
+  const sub = args[0];
+
+  if (sub === '--help' || sub === '-h' || sub === undefined) {
+    printHelp();
+    return;
+  }
+
+  if (sub === 'backfill') {
+    await backfillSubcommand(args.slice(1));
+    return;
+  }
+
+  console.error(`\nUnknown retro subcommand: ${sub}\n`);
+  printHelp();
+  process.exit(1);
+}
+
+function printHelp(): void {
+  console.log(`
+slope retro — Retrospective scorecard utilities
+
+Usage:
+  slope retro backfill --sprint=N [--dry-run]   Generate a scorecard from git
+                                                 history for sprint N.
+  slope retro backfill --all-missing [--dry-run] Backfill every shipped sprint
+                                                 that has no scorecard.
+
+Output: docs/retros/sprint-N.json with _backfilled:true marker.
+
+Limitations:
+  - Lossy: original CI/PR signals are not recoverable from commit log.
+  - Defaults all shots to "green" — score:par. Reviewers can amend
+    afterward via \`slope review findings add\` + \`slope review amend\`.
+`);
+}
+
+function parseFlags(args: string[]): BackfillOptions {
+  const opts: BackfillOptions = {};
+  for (const a of args) {
+    if (a.startsWith('--sprint=')) opts.sprint = parseInt(a.slice('--sprint='.length), 10);
+    else if (a === '--all-missing') opts.allMissing = true;
+    else if (a === '--dry-run') opts.dryRun = true;
+  }
+  return opts;
+}
+
+function git(cmd: string, cwd: string): string {
+  try {
+    return execSync(`git ${cmd}`, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }).trim();
+  } catch {
+    return '';
+  }
+}
+
+interface SprintCommit {
+  hash: string;
+  isoDate: string;
+  subject: string;
+}
+
+/** Find commits on main referencing a specific sprint. Matches the same
+ *  patterns as findShippedSprintsOnMain but returns the actual commits.
+ *  Used to build per-shot data for the backfilled scorecard. */
+function commitsForSprint(cwd: string, sprintId: number): SprintCommit[] {
+  const ref = git('symbolic-ref --short refs/remotes/origin/HEAD', cwd) || 'main';
+  // Pattern matches feat(SXX), (SXX), feat(SXX-N), feat(SXX+SYY) — same shapes
+  // findShippedSprintsOnMain detects.
+  const pattern = `[(+]S${sprintId}[+):-]`;
+  const log = git(`log -E --grep="${pattern}" --format="%H|%aI|%s" -n 100 ${ref}`, cwd);
+  if (!log) return [];
+  return log.split('\n').filter(Boolean).map(line => {
+    const [hash, isoDate, ...rest] = line.split('|');
+    return { hash, isoDate, subject: rest.join('|') };
+  }).reverse(); // oldest first
+}
+
+function loadRoadmap(cwd: string): RoadmapDefinition | null {
+  try {
+    const config = loadConfig(cwd);
+    const roadmapPath = join(cwd, config.roadmapPath);
+    if (!existsSync(roadmapPath)) return null;
+    const raw = JSON.parse(readFileSync(roadmapPath, 'utf8'));
+    return parseRoadmap(raw).roadmap ?? castRoadmapStructure(raw);
+  } catch {
+    return null;
+  }
+}
+
+interface BackfillResult {
+  sprint: number;
+  path: string;
+  shots: number;
+  par: number;
+  slope: number;
+  written: boolean;
+  reason?: string;
+}
+
+function inferTicketKey(subject: string, idx: number, sprintId: number): string {
+  // Try to extract S{N}-{M} or S{N}-T{M} from the subject
+  const m = subject.match(/S(\d+)-(T?\d+)/i);
+  if (m && parseInt(m[1], 10) === sprintId) {
+    return `S${sprintId}-${m[2]}`;
+  }
+  return `S${sprintId}-${idx + 1}`;
+}
+
+function inferClub(filesChanged: number): string {
+  if (filesChanged > 15) return 'long_iron';
+  if (filesChanged > 5) return 'short_iron';
+  if (filesChanged > 1) return 'wedge';
+  return 'putter';
+}
+
+export function buildBackfillScorecard(
+  cwd: string,
+  sprintId: number,
+  roadmap: RoadmapDefinition | null,
+): { scorecard: Record<string, unknown> | null; reason?: string } {
+  const commits = commitsForSprint(cwd, sprintId);
+  if (commits.length === 0) {
+    return { scorecard: null, reason: 'no commits found' };
+  }
+
+  const sprint = roadmap?.sprints.find(s => s.id === sprintId);
+  const par = (sprint?.par ?? 4) as 3 | 4 | 5;
+  const slope = sprint?.slope ?? 1;
+  const theme = (sprint as RoadmapSprint & { theme?: string })?.theme
+    ?? extractThemeFromCommits(commits, sprintId);
+
+  const shots = commits.map((c, i) => {
+    const filesRaw = git(`diff-tree --no-commit-id --name-only -r ${c.hash}`, cwd);
+    const filesChanged = filesRaw ? filesRaw.split('\n').filter(Boolean).length : 0;
+    return {
+      ticket_key: inferTicketKey(c.subject, i, sprintId),
+      title: c.subject,
+      club: inferClub(filesChanged),
+      result: 'green',
+      hazards: [],
+      notes: `Backfilled from commit ${c.hash.slice(0, 8)} on main. Original CI/PR signals not preserved.`,
+    };
+  });
+
+  const n = shots.length;
+  const scorecard = {
+    sprint_number: sprintId,
+    theme,
+    par,
+    slope,
+    score: par,
+    score_label: 'par',
+    date: commits[0].isoDate.split('T')[0],
+    shots,
+    stats: {
+      fairways_hit: n,
+      fairways_total: n,
+      greens_in_regulation: n,
+      greens_total: n,
+      putts: 0,
+      penalties: 0,
+      hazards_hit: 0,
+      hazard_penalties: 0,
+      miss_directions: { long: 0, short: 0, left: 0, right: 0 },
+    },
+    conditions: [
+      `Backfilled retroactively via slope retro backfill`,
+      `Source: ${commits.length} commit(s) on main referencing S${sprintId}`,
+      'Original CI/PR/test data not recoverable',
+    ],
+    special_plays: [],
+    bunker_locations: [],
+    yardage_book_updates: [],
+    course_management_notes: [
+      `This scorecard was backfilled by the slope retro backfill command — treat scores as placeholder par.`,
+    ],
+    _backfilled: true,
+    _backfill_source: 'main commit log; sub-ticket detail not preserved',
+    _auto_generated: true,
+  };
+
+  return { scorecard };
+}
+
+function extractThemeFromCommits(commits: SprintCommit[], sprintId: number): string {
+  // Use the most likely "umbrella" commit subject — usually the last (PR
+  // merge commit) since git log is reversed to oldest-first; but for
+  // squash-merges that's the only commit. Strip the conventional prefix.
+  const subj = commits[commits.length - 1].subject;
+  const m = subj.match(/^(?:feat|fix|chore)\([^)]*\):\s*(.+)$/);
+  return m ? m[1] : `Sprint ${sprintId}`;
+}
+
+async function backfillSubcommand(args: string[]): Promise<void> {
+  const opts = parseFlags(args);
+
+  if (!opts.sprint && !opts.allMissing) {
+    console.error('\nUsage: slope retro backfill --sprint=N | --all-missing [--dry-run]\n');
+    process.exit(1);
+  }
+
+  const cwd = process.cwd();
+  const config = loadConfig(cwd);
+  const retroDir = join(cwd, config.scorecardDir);
+  const pattern = config.scorecardPattern;
+  const roadmap = loadRoadmap(cwd);
+
+  // Resolve target sprint list
+  const targets: number[] = [];
+  if (opts.sprint) {
+    targets.push(opts.sprint);
+  } else {
+    const shipped = findShippedSprintsOnMain(cwd);
+    for (const id of [...shipped].sort((a, b) => a - b)) {
+      const path = join(retroDir, pattern.replace('*', String(id)));
+      if (!existsSync(path)) targets.push(id);
+    }
+    if (targets.length === 0) {
+      console.log('\nNo missing scorecards detected.\n');
+      return;
+    }
+    console.log(`\nFound ${targets.length} shipped sprint(s) without scorecards: ${targets.map(t => `S${t}`).join(', ')}\n`);
+  }
+
+  const results: BackfillResult[] = [];
+  for (const sid of targets) {
+    const path = join(retroDir, pattern.replace('*', String(sid)));
+    if (existsSync(path)) {
+      results.push({ sprint: sid, path, shots: 0, par: 0, slope: 0, written: false, reason: 'already exists' });
+      continue;
+    }
+
+    const { scorecard, reason } = buildBackfillScorecard(cwd, sid, roadmap);
+    if (!scorecard) {
+      results.push({ sprint: sid, path, shots: 0, par: 0, slope: 0, written: false, reason });
+      continue;
+    }
+
+    if (!opts.dryRun) {
+      writeFileSync(path, JSON.stringify(scorecard, null, 2) + '\n');
+    }
+    results.push({
+      sprint: sid,
+      path,
+      shots: (scorecard.shots as unknown[]).length,
+      par: scorecard.par as number,
+      slope: scorecard.slope as number,
+      written: !opts.dryRun,
+      reason: opts.dryRun ? 'dry-run' : undefined,
+    });
+  }
+
+  // Print summary
+  for (const r of results) {
+    if (r.written) {
+      console.log(`  S${r.sprint}: wrote ${r.path} (${r.shots} shots, par ${r.par}, slope ${r.slope})`);
+    } else if (r.reason === 'dry-run') {
+      console.log(`  S${r.sprint}: [dry-run] would write ${r.path} (${r.shots} shots, par ${r.par}, slope ${r.slope})`);
+    } else {
+      console.log(`  S${r.sprint}: skipped (${r.reason})`);
+    }
+  }
+  console.log('');
+}

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,5 +1,7 @@
-import { checkConflicts } from '../../core/index.js';
+import { checkConflicts, findShippedSprintsOnMain } from '../../core/index.js';
 import type { SprintClaim, SlopeSession } from '../../core/index.js';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { loadConfig } from '../config.js';
 import { loadScorecards } from '../loader.js';
 import { resolveStore } from '../store.js';
@@ -80,7 +82,38 @@ async function showSprintStatus(store: { list: (n: number) => Promise<SprintClai
     }
   }
 
+  // Surface scorecard drift — shipped sprints with no scorecard on disk.
+  // Helps remind users to run `slope retro backfill` when post-hole work
+  // has been skipped (#318).
+  const drift = computeScorecardDrift(process.cwd());
+  if (drift.missing.length > 0) {
+    console.log(`\n  Scorecard drift: ${drift.missing.length} shipped sprint(s) without scorecards`);
+    const sample = drift.missing.slice(0, 5).map(n => `S${n}`).join(', ');
+    const more = drift.missing.length > 5 ? `, ...` : '';
+    console.log(`    Missing: ${sample}${more}`);
+    console.log(`    Backfill: slope retro backfill --all-missing`);
+  }
+
   console.log('');
+}
+
+/** Detect shipped sprints with no scorecard on disk. Used by status to
+ *  surface the "post-hole skipped" pattern (#318). */
+function computeScorecardDrift(cwd: string): { missing: number[] } {
+  try {
+    const config = loadConfig(cwd);
+    const retroDir = join(cwd, config.scorecardDir);
+    const pattern = config.scorecardPattern;
+    const shipped = findShippedSprintsOnMain(cwd);
+    const missing: number[] = [];
+    for (const id of [...shipped].sort((a, b) => a - b)) {
+      const scorecardPath = join(retroDir, pattern.replace('*', String(id)));
+      if (!existsSync(scorecardPath)) missing.push(id);
+    }
+    return { missing };
+  } catch {
+    return { missing: [] };
+  }
 }
 
 async function showSwarmStatus(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -37,6 +37,7 @@ import { prCommand } from './commands/pr.js';
 import { sessionCommand } from './commands/session.js';
 import { hookCommand } from './commands/hook.js';
 import { roadmapCommand } from './commands/roadmap.js';
+import { retroCommand } from './commands/retro.js';
 import { extractCommand } from './commands/extract.js';
 import { distillCommand } from './commands/distill.js';
 import { guardCommand, guardManageCommand } from './commands/guard.js';
@@ -231,6 +232,12 @@ switch (subcommand) {
     break;
   case 'roadmap':
     roadmapCommand(process.argv.slice(3)).catch(err => {
+      console.error('Error:', err.message);
+      process.exit(1);
+    });
+    break;
+  case 'retro':
+    retroCommand(process.argv.slice(3)).catch(err => {
       console.error('Error:', err.message);
       process.exit(1);
     });

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -433,6 +433,16 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
+    cmd: 'retro', desc: 'Retrospective scorecard utilities', category: 'planning',
+    subcommands: [
+      { name: 'backfill', desc: 'Generate scorecard from git history (#318)', flags: [
+        { flag: '--sprint=<N>', desc: 'Sprint number (or use --all-missing)' },
+        { flag: '--all-missing', desc: 'Backfill every shipped sprint without a scorecard' },
+        { flag: '--dry-run', desc: 'Preview without writing' },
+      ]},
+    ],
+  },
+  {
     cmd: 'vision', desc: 'Display project vision document', category: 'planning',
     subcommands: [
       { name: 'create', desc: 'Create a new vision document', flags: [

--- a/tests/cli/retro-backfill.test.ts
+++ b/tests/cli/retro-backfill.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildBackfillScorecard } from '../../src/cli/commands/retro.js';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const SLOPE_BIN = resolve(REPO_ROOT, 'dist', 'cli', 'index.js');
+
+function setupRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'slope-retro-'));
+  mkdirSync(join(dir, '.slope'), { recursive: true });
+  mkdirSync(join(dir, 'docs', 'backlog'), { recursive: true });
+  mkdirSync(join(dir, 'docs', 'retros'), { recursive: true });
+  writeFileSync(join(dir, '.slope', 'config.json'), JSON.stringify({
+    roadmapPath: 'docs/backlog/roadmap.json',
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+  }));
+  writeFileSync(join(dir, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+    name: 'Test',
+    phases: [{ name: 'P1', sprints: [1, 2] }],
+    sprints: [
+      { id: 1, theme: 'First Sprint', par: 4, slope: 1, type: 'feature', tickets: [
+        { key: 'S1-1', title: 'a', club: 'wedge', complexity: 'small' },
+        { key: 'S1-2', title: 'b', club: 'wedge', complexity: 'small' },
+        { key: 'S1-3', title: 'c', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 2, theme: 'Second Sprint', par: 5, slope: 2, type: 'feature', tickets: [
+        { key: 'S2-1', title: 'a', club: 'wedge', complexity: 'small' },
+        { key: 'S2-2', title: 'b', club: 'wedge', complexity: 'small' },
+        { key: 'S2-3', title: 'c', club: 'wedge', complexity: 'small' },
+      ] },
+    ],
+  }));
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email t@t', { cwd: dir });
+  execSync('git config user.name t', { cwd: dir });
+  execSync('git checkout -q -b main', { cwd: dir });
+  execSync('git commit -q --allow-empty -m initial', { cwd: dir });
+  return dir;
+}
+
+function commitWith(cwd: string, message: string) {
+  execSync('git commit -q --allow-empty -m ' + JSON.stringify(message), { cwd });
+}
+
+describe('buildBackfillScorecard (#318)', () => {
+  let cwd: string;
+
+  beforeEach(() => { cwd = setupRepo(); });
+  afterEach(() => { rmSync(cwd, { recursive: true, force: true }); });
+
+  it('returns null when no commits reference the sprint', () => {
+    const result = buildBackfillScorecard(cwd, 99, null);
+    expect(result.scorecard).toBeNull();
+    expect(result.reason).toContain('no commits found');
+  });
+
+  it('builds a scorecard from commit log with par from roadmap', () => {
+    commitWith(cwd, 'feat(S1-1): hello world');
+    commitWith(cwd, 'feat(S1-2): world hello');
+
+    const roadmapRaw = JSON.parse(readFileSync(join(cwd, 'docs/backlog/roadmap.json'), 'utf8'));
+    const result = buildBackfillScorecard(cwd, 1, roadmapRaw);
+
+    expect(result.scorecard).not.toBeNull();
+    const card = result.scorecard as Record<string, unknown>;
+    expect(card.sprint_number).toBe(1);
+    expect(card.par).toBe(4);
+    expect(card.slope).toBe(1);
+    expect(card.theme).toBe('First Sprint');
+    expect((card.shots as unknown[]).length).toBe(2);
+    expect(card._backfilled).toBe(true);
+    expect(card._auto_generated).toBe(true);
+  });
+
+  it('extracts ticket keys from commit subjects when present', () => {
+    commitWith(cwd, 'feat(S1-1): first');
+    commitWith(cwd, 'feat(S1-2): second');
+
+    const result = buildBackfillScorecard(cwd, 1, null);
+    const shots = (result.scorecard as { shots: { ticket_key: string }[] }).shots;
+    expect(shots[0].ticket_key).toBe('S1-1');
+    expect(shots[1].ticket_key).toBe('S1-2');
+  });
+
+  it('falls back to S{N}-{i+1} when subject lacks ticket key', () => {
+    commitWith(cwd, 'feat(S1): umbrella commit');
+    const result = buildBackfillScorecard(cwd, 1, null);
+    const shots = (result.scorecard as { shots: { ticket_key: string }[] }).shots;
+    expect(shots[0].ticket_key).toBe('S1-1');
+  });
+
+  it('preserves S75.5 vs S75 distinction (does not double-count)', () => {
+    commitWith(cwd, 'feat(S75.5): bug clearing');
+    // S75.5 should NOT match a sprint=75 query
+    const result = buildBackfillScorecard(cwd, 75, null);
+    expect(result.scorecard).toBeNull();
+  });
+});
+
+describe('slope retro backfill CLI (#318)', () => {
+  let cwd: string;
+
+  beforeEach(() => { cwd = setupRepo(); });
+  afterEach(() => { rmSync(cwd, { recursive: true, force: true }); });
+
+  it('writes sprint-N.json and reports counts on success', () => {
+    commitWith(cwd, 'feat(S1-1): a');
+    commitWith(cwd, 'feat(S1-2): b');
+
+    const out = execSync(`node ${SLOPE_BIN} retro backfill --sprint=1`, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    expect(out).toMatch(/S1: wrote .*sprint-1\.json \(2 shots/);
+    expect(existsSync(join(cwd, 'docs', 'retros', 'sprint-1.json'))).toBe(true);
+    const written = JSON.parse(readFileSync(join(cwd, 'docs', 'retros', 'sprint-1.json'), 'utf8'));
+    expect(written._backfilled).toBe(true);
+    expect(written.shots.length).toBe(2);
+  });
+
+  it('--dry-run does not write the file', () => {
+    commitWith(cwd, 'feat(S1-1): a');
+    const out = execSync(`node ${SLOPE_BIN} retro backfill --sprint=1 --dry-run`, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    expect(out).toContain('[dry-run]');
+    expect(existsSync(join(cwd, 'docs', 'retros', 'sprint-1.json'))).toBe(false);
+  });
+
+  it('--all-missing iterates shipped sprints without scorecards', () => {
+    commitWith(cwd, 'feat(S1-1): a');
+    commitWith(cwd, 'feat(S2-1): b');
+    // Pre-populate S1 scorecard so only S2 should be backfilled
+    writeFileSync(join(cwd, 'docs', 'retros', 'sprint-1.json'), '{}');
+
+    const out = execSync(`node ${SLOPE_BIN} retro backfill --all-missing`, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    expect(out).toContain('S2');
+    expect(out).not.toMatch(/S1: wrote/);
+    expect(existsSync(join(cwd, 'docs', 'retros', 'sprint-2.json'))).toBe(true);
+  });
+
+  it('skips when scorecard already exists', () => {
+    commitWith(cwd, 'feat(S1-1): a');
+    writeFileSync(join(cwd, 'docs', 'retros', 'sprint-1.json'), '{}');
+
+    const out = execSync(`node ${SLOPE_BIN} retro backfill --sprint=1`, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    expect(out).toContain('skipped (already exists)');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the tooling part of #318. The data backfill (S70 + S74-S83) shipped in S86-4 via a one-shot script; this PR makes the pattern repeatable.

| Part | Where | Status |
|---|---|---|
| Data backfill (one-shot) | S86-4 | shipped |
| \`slope retro backfill\` CLI | this PR | new |
| \`slope status\` drift surface | this PR | new |

## CLI

\`\`\`
$ slope retro backfill --sprint=70 [--dry-run]
$ slope retro backfill --all-missing [--dry-run]
\`\`\`

Generates one shot per commit with \`_backfilled: true\` and a clear note that original CI/PR signals are not preserved. Reads par/slope/theme from the roadmap entry; falls back to commit subject when roadmap doesn't have the sprint.

## Status surfacing

\`slope status\` now appends a \"Scorecard drift\" section when shipped sprints lack scorecards on disk:

\`\`\`
Scorecard drift: 11 shipped sprint(s) without scorecards
  Missing: S70, S74, S75, S76, S77, ...
  Backfill: slope retro backfill --all-missing
\`\`\`

## Test plan

- [x] 9 cases in \`tests/cli/retro-backfill.test.ts\` covering pure builder + CLI integration
- [x] \`pnpm test\` green (3261 pass; one pre-existing flaky cadence test unrelated)
- [x] Manual: \`slope retro backfill --all-missing --dry-run\` lists missing sprints from main
- [ ] Reviewer: confirm S75/S75.5 distinction is preserved (testcase asserts it)

Closes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)