### PR TITLE
chore: roadmap + S92 scorecard for v1.55.0

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -97,10 +97,18 @@
       "note": "Memory\u2194store reunification (architectural debt from PR #293) + automation hooks for PR/issue/branch hygiene."
     },
     {
-      "name": "Phase 21 \u2014 TBD (next initiative)",
+      "name": "Phase 21 \u2014 Backlog Cleanup",
+      "sprints": [
+        92
+      ],
+      "status": "complete",
+      "note": "Closed the 3 remaining backlog items (#307, #318, #323) from the Phase 18-20 sweep. Shipped in v1.55.0."
+    },
+    {
+      "name": "Phase 22 \u2014 TBD (next initiative)",
       "sprints": [],
       "status": "planned",
-      "note": "Next initiative \u2014 themes TBD. Backlog issues remaining: #307 (hook count), #318 (retro backfill tooling), #323 (gitignore audit)."
+      "note": "Issue queue empty as of v1.55.0. Next initiative themes TBD."
     }
   ],
   "sprints": [
@@ -1217,6 +1225,38 @@
           "club": "wedge",
           "complexity": "small",
           "github_issue": 305
+        }
+      ]
+    },
+    {
+      "id": 92,
+      "theme": "Backlog Cleanup \u2014 empty the queue",
+      "par": 3,
+      "slope": 1,
+      "type": "bug fix + dx",
+      "status": "complete",
+      "note": "Three small follow-ups closing the last items from the Phase 18-20 backlog. Shipped in v1.55.0.",
+      "tickets": [
+        {
+          "key": "S92-1",
+          "title": "Align hook install count with slope doctor count (#307)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 307
+        },
+        {
+          "key": "S92-2",
+          "title": "slope doctor gitignore audit for common-noise patterns (#323)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 323
+        },
+        {
+          "key": "S92-3",
+          "title": "slope retro backfill CLI + status drift surfacing (#318)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 318
         }
       ]
     }

--- a/docs/retros/sprint-92.json
+++ b/docs/retros/sprint-92.json
@@ -1,0 +1,69 @@
+{
+  "sprint_number": 92,
+  "theme": "Backlog Cleanup \u2014 empty the queue",
+  "par": 3,
+  "slope": 1,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-05-08",
+  "shots": [
+    {
+      "ticket_key": "S92-1",
+      "title": "fix(hook,doctor): align guard install counts (#307)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [],
+      "notes": "PR #335"
+    },
+    {
+      "ticket_key": "S92-2",
+      "title": "feat(doctor): gitignore audit for common-noise patterns (#323)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "PR #336"
+    },
+    {
+      "ticket_key": "S92-3",
+      "title": "feat(retro): backfill command + status drift surfacing (#318)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "PR #337"
+    }
+  ],
+  "stats": {
+    "fairways_hit": 3,
+    "fairways_total": 3,
+    "greens_in_regulation": 3,
+    "greens_total": 3,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Released as v1.55.0",
+    "3 PRs merged: #335 (#307), #336 (#323), #337 (#318)",
+    "Followed direct-issue naming convention; commits don't reference S92 (validator will note this)."
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [
+    "src/cli/commands/hook.ts \u2014 re-read persisted count after install",
+    "src/cli/commands/doctor.ts \u2014 guard-prefix filter for installed count, gitignore-noise check + auto-fix",
+    "src/cli/commands/retro.ts \u2014 new command with backfill subcommand",
+    "src/cli/commands/status.ts \u2014 surface scorecard drift"
+  ],
+  "course_management_notes": [
+    "Empties the backlog from session-end of v1.54.0. Issue queue size: 3 \u2192 0."
+  ],
+  "training": [],
+  "nutrition": []
+}


### PR DESCRIPTION
## Summary

Post-v1.55.0 roadmap sync. Records the three follow-up fixes (#307, #318, #323) that emptied the backlog as **S92 — Backlog Cleanup**.

## Changes

- **S92** added to \`docs/backlog/roadmap.json\` (status: complete, par 3, slope 1)
  - S92-1 → #307 (PR #335)
  - S92-2 → #323 (PR #336)
  - S92-3 → #318 (PR #337)
- **Phase 21** renamed from \"TBD\" placeholder to \"Backlog Cleanup\", marked complete
- **Phase 22** placeholder added — issue queue empty as of v1.55.0
- **docs/retros/sprint-92.json** scorecard: par 3, score 3, all green

## Validator state

\`slope roadmap validate\` will note that S92 \"has no shipped commits on main\" — accurate signal. The three PRs (#335/#336/#337) predated the S92 sprint concept and used direct-issue naming (\`fix(hook,doctor)\`, \`feat(doctor)\`, \`feat(retro)\`) instead of \`feat(S92-N)\`. Documented in the scorecard's \`conditions\` section so future readers know it isn't silent drift.

## Issue queue

\`\`\`
v1.54.0 ship → 3 open
v1.55.0 ship → 0 open
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product roadmap to reflect Phase 21 (Backlog Cleanup) completion in v1.55.0
  * Added Sprint 92 retrospective documentation

* **Chores**
  * Closed all remaining backlog items; backlog queue is now empty

<!-- end of auto-generated comment: release notes by coderabbit.ai -->