### PR TITLE
fix: slope init --codex actually creates AGENTS.md (#340)

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -724,7 +724,19 @@ function installForProvider(cwd: string, provider: InitProvider, metaphor: Metap
       installOpenCodePlugin(cwd);
       break;
     case 'codex':
-      // Codex uses AGENTS.md (already generated) + .codex/hooks.json for guards
+      // Codex uses AGENTS.md as the project context surface — generate it
+      // here (was previously assumed already-generated, but only the
+      // opencode case calls installOpenCodeTemplates → AGENTS.md isn't
+      // produced unless --opencode was also passed). #340.
+      {
+        const agentsMdPath = join(cwd, 'AGENTS.md');
+        if (!existsSync(agentsMdPath)) {
+          writeFileSync(agentsMdPath, generateAgentsMd(metaphor));
+          console.log(`  Created ${agentsMdPath}`);
+        } else {
+          console.log(`  AGENTS.md already exists — leaving untouched`);
+        }
+      }
       installDefaultHooks(cwd, 'codex');
       console.log('\n  Codex CLI: Guards installed to .codex/hooks.json');
       console.log('  Codex CLI: AGENTS.md provides project context');

--- a/tests/cli/init-codex.test.ts
+++ b/tests/cli/init-codex.test.ts
@@ -14,6 +14,33 @@ describe('slope init --codex (GH #309)', () => {
     }
   });
 
+  it('creates AGENTS.md with project context (#340)', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-init-codex-agents-'));
+    try {
+      execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      const agentsMd = join(cwd, 'AGENTS.md');
+      expect(existsSync(agentsMd)).toBe(true);
+      const stat = require('node:fs').statSync(agentsMd);
+      expect(stat.size).toBeGreaterThan(100);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not overwrite existing AGENTS.md (#340)', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-init-codex-existing-'));
+    const agentsMd = join(cwd, 'AGENTS.md');
+    try {
+      const sentinel = '# Custom user content — do not touch\n';
+      require('node:fs').writeFileSync(agentsMd, sentinel);
+      execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      const content = require('node:fs').readFileSync(agentsMd, 'utf8');
+      expect(content).toBe(sentinel);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('installs Codex hooks under .codex/hooks/', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-init-codex-'));
     try {


### PR DESCRIPTION
## Bug

\`slope init --codex\` printed:
\`\`\`
Codex CLI: AGENTS.md provides project context
\`\`\`
…but never actually wrote the file. AGENTS.md generation lived only in \`installOpenCodeTemplates\`, so unless the user also passed \`--opencode\` the file was missing while the output claimed otherwise.

## Fix

Write \`AGENTS.md\` (via existing \`generateAgentsMd\` template) inside the codex install case. Skips if the file already exists so any user-curated content is preserved.

## Tests

2 new in \`tests/cli/init-codex.test.ts\`:
- \`--codex\` creates \`AGENTS.md\` with non-trivial content
- \`--codex\` does NOT overwrite an existing \`AGENTS.md\`

Closes #340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `slope init --codex` now properly generates the `AGENTS.md` configuration file if missing and preserves any existing file content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/343)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->