### PR TITLE
fix(sprint-plan): honor absolute --output= path (#341)

### DIFF
--- a/src/cli/commands/sprint-plan.ts
+++ b/src/cli/commands/sprint-plan.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { parseRoadmap, extractHazardIndex, loadScorecards } from '../../core/index.js';
 import type { RoadmapDefinition, RoadmapSprint } from '../../core/index.js';
 import { loadConfig } from '../config.js';
@@ -92,16 +92,21 @@ export async function sprintPlanCommand(args: string[]): Promise<void> {
   // Render
   const md = renderSprintPlan(sprint, roadmap, hazardLines);
 
-  // Output path
+  // Output path — use resolve() so an absolute --output=/tmp/... is honored
+  // verbatim instead of being silently coerced to a repo-relative path
+  // (#341). join(cwd, '/tmp/x') drops the leading slash; resolve() doesn't.
   const outputPath = outputArg
     ? outputArg.slice('--output='.length)
     : `docs/backlog/sprint-${sprintId}-plan.md`;
-  const outputAbs = join(cwd, outputPath);
+  const outputAbs = resolve(cwd, outputPath);
 
   mkdirSync(dirname(outputAbs), { recursive: true });
   writeFileSync(outputAbs, md);
 
-  console.log(`Wrote ${outputPath}`);
+  // Report the resolved absolute path so the user knows exactly where the
+  // file landed — the previous "Wrote <relative>" form was misleading when
+  // an absolute path got rewritten.
+  console.log(`Wrote ${outputAbs}`);
   console.log(`  Tickets: ${sprint.tickets.length}`);
   console.log(`  Par: ${sprint.par} | Slope: ${sprint.slope}`);
 }

--- a/tests/cli/commands/sprint-plan.test.ts
+++ b/tests/cli/commands/sprint-plan.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { renderSprintPlan } from '../../../src/cli/commands/sprint-plan.js';
 import type { RoadmapDefinition, RoadmapSprint, RoadmapTicket } from '../../../src/core/index.js';
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const SLOPE_BIN = resolve(REPO_ROOT, 'dist', 'cli', 'index.js');
 
 function makeTicket(key: string, overrides: Partial<RoadmapTicket> = {}): RoadmapTicket {
   return {
@@ -126,5 +133,71 @@ describe('renderSprintPlan (GH #312)', () => {
     const sprint = makeSprint(2);
     const md = renderSprintPlan(sprint, makeRoadmap([sprint]), []);
     expect(md).toContain('No recent hazards on file');
+  });
+});
+
+function setupRepoForCli(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'slope-sprint-plan-'));
+  mkdirSync(join(dir, '.slope'), { recursive: true });
+  mkdirSync(join(dir, 'docs', 'backlog'), { recursive: true });
+  mkdirSync(join(dir, 'docs', 'retros'), { recursive: true });
+  writeFileSync(join(dir, '.slope', 'config.json'), JSON.stringify({
+    roadmapPath: 'docs/backlog/roadmap.json',
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+  }));
+  writeFileSync(join(dir, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+    name: 'Test',
+    phases: [{ name: 'P1', sprints: [1] }],
+    sprints: [{
+      id: 1,
+      theme: 'Test sprint',
+      par: 4,
+      slope: 1,
+      type: 'feature',
+      tickets: [
+        { key: 'S1-1', title: 'first', club: 'wedge', complexity: 'small' },
+      ],
+    }],
+  }));
+  return dir;
+}
+
+describe('slope sprint plan --output (#341)', () => {
+  beforeAll(() => {
+    if (!existsSync(SLOPE_BIN)) {
+      throw new Error(`dist not built — run \`pnpm build\` first. Expected ${SLOPE_BIN}`);
+    }
+  });
+
+  it('honors absolute --output= path instead of stripping leading slash', () => {
+    const cwd = setupRepoForCli();
+    const outDir = mkdtempSync(join(tmpdir(), 'slope-sprint-plan-out-'));
+    const absOut = join(outDir, 'plan.md');
+    try {
+      const out = execSync(`node ${SLOPE_BIN} sprint plan --sprint=1 --output=${absOut}`, {
+        cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      // The plan must land at the absolute path, NOT a repo-relative tmp/
+      expect(existsSync(absOut)).toBe(true);
+      expect(existsSync(join(cwd, absOut.replace(/^\//, '')))).toBe(false);
+      // Reported path is the resolved absolute target — no surprises
+      expect(out).toContain(`Wrote ${absOut}`);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it('still resolves relative --output= against cwd', () => {
+    const cwd = setupRepoForCli();
+    try {
+      execSync(`node ${SLOPE_BIN} sprint plan --sprint=1 --output=custom/plan.md`, {
+        cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      expect(existsSync(join(cwd, 'custom', 'plan.md'))).toBe(true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Bug

\`slope sprint plan --sprint=N --output=/tmp/foo.md\` was silently writing to \`./tmp/foo.md\` (repo-relative) instead of the requested \`/tmp/foo.md\`. The console output also lied about it (\`Wrote /tmp/foo.md\` even though no such file existed).

Root cause: \`path.join(cwd, '/tmp/foo.md')\` drops the leading slash and produces a relative path. Same shape of bug we fixed earlier in \`writeVisionMarkdown\`.

## Fix

- Replace \`join(cwd, outputPath)\` with \`resolve(cwd, outputPath)\` — \`resolve\` honors absolute paths and still anchors relative paths to cwd
- Print the resolved absolute path in the \"Wrote …\" message so the reported path matches reality

## Tests

2 new CLI integration tests in \`tests/cli/commands/sprint-plan.test.ts\`:
- \`--output=/abs/path.md\` lands at the absolute path and NOT a repo-relative version of it
- \`--output=relative/path.md\` still resolves under cwd

All 11 sprint-plan tests pass.

Closes #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)