### PR TITLE
fix(agent): nextTicket prefers active claim over un-claimed peers (#342)

### DIFF
--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -152,15 +152,23 @@ export async function collectAgentStatus(cwd: string): Promise<AgentStatus> {
     }
   }
 
-  // Next ticket: first ticket of the current sprint not currently claimed
+  // Next ticket: prefer the agent's existing active claim (in roadmap order)
+  // — finishing what's already in flight beats starting something new. Only
+  // when nothing is claimed do we recommend the first un-claimed ticket.
+  // (#342: status was reporting next=S1-2 while user already held S1-1.)
   let nextTicket: string | null = null;
   let blockedBy: number[] = [];
   if (roadmap && currentSprint != null) {
     const sprint = roadmap.sprints.find(s => s.id === currentSprint);
     if (sprint) {
       const claimed = new Set(activeClaims);
-      const next = sprint.tickets.find(t => !claimed.has(t.key));
-      nextTicket = next?.key ?? null;
+      const inFlight = sprint.tickets.find(t => claimed.has(t.key));
+      if (inFlight) {
+        nextTicket = inFlight.key;
+      } else {
+        const next = sprint.tickets.find(t => !claimed.has(t.key));
+        nextTicket = next?.key ?? null;
+      }
       blockedBy = computeBlockers(roadmap, sprint);
     }
   }

--- a/tests/cli/commands/agent.test.ts
+++ b/tests/cli/commands/agent.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { collectAgentStatus, renderAgentMarkdown } from '../../../src/cli/commands/agent.js';
 import type { AgentStatus } from '../../../src/cli/commands/agent.js';
+import { resolveStore } from '../../../src/cli/store.js';
 
 function makeTmpRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'slope-agent-'));
@@ -208,6 +209,59 @@ describe('agent status (GH #310)', () => {
     expect(md).toContain('Next command: —');
     expect(md).not.toContain('## Pending gates');
     expect(md).not.toContain('## Blocked');
+  });
+
+  it('reports the active claim as nextTicket instead of skipping ahead (#342)', async () => {
+    writeVision(cwd);
+    writeRoadmap(cwd, [
+      { id: 1, theme: 'A', par: 4, slope: 1, type: 'feature', tickets: [
+        { key: 'S1-1', title: 't1', club: 'wedge', complexity: 'small' },
+        { key: 'S1-2', title: 't2', club: 'wedge', complexity: 'small' },
+        { key: 'S1-3', title: 't3', club: 'wedge', complexity: 'small' },
+      ] },
+    ]);
+    writeSprintState(cwd, {
+      sprint: 1,
+      phase: 'implementing',
+      gates: { tests: false, code_review: false, architect_review: false, scorecard: false, review_md: false },
+      started_at: '2026-05-07T00:00:00Z',
+      updated_at: '2026-05-07T00:00:00Z',
+    });
+
+    // Create a real claim on S1-1 so the agent has work in flight
+    const store = await resolveStore(cwd);
+    await store.claim({ sprint_number: 1, player: 'agent', target: 'S1-1', scope: 'ticket' });
+    store.close();
+
+    const status = await collectAgentStatus(cwd);
+    expect(status.activeClaims).toContain('S1-1');
+    // The bug: status used to skip to S1-2 here. Finishing the in-flight
+    // ticket beats starting a new one — nextTicket should be S1-1.
+    expect(status.nextTicket).toBe('S1-1');
+    // And we shouldn't be told to claim again — we already hold one.
+    expect(status.recommendedCommands).not.toContain('slope claim S1-1');
+    expect(status.recommendedCommands).not.toContain('slope claim S1-2');
+  });
+
+  it('falls back to first un-claimed ticket when no claims exist (#342 regression)', async () => {
+    writeVision(cwd);
+    writeRoadmap(cwd, [
+      { id: 1, theme: 'A', par: 4, slope: 1, type: 'feature', tickets: [
+        { key: 'S1-1', title: 't1', club: 'wedge', complexity: 'small' },
+        { key: 'S1-2', title: 't2', club: 'wedge', complexity: 'small' },
+      ] },
+    ]);
+    writeSprintState(cwd, {
+      sprint: 1,
+      phase: 'implementing',
+      gates: { tests: false, code_review: false, architect_review: false, scorecard: false, review_md: false },
+      started_at: '2026-05-07T00:00:00Z',
+      updated_at: '2026-05-07T00:00:00Z',
+    });
+
+    const status = await collectAgentStatus(cwd);
+    expect(status.activeClaims).toEqual([]);
+    expect(status.nextTicket).toBe('S1-1');
   });
 
   it('returns null nextTicket when sprint is unknown to roadmap', async () => {


### PR DESCRIPTION
## Bug

\`slope agent status\` reported \`Next ticket: S1-2\` while the agent already held an active claim on S1-1. The status block looked like:

\`\`\`
Active claims: S1-1
Next ticket: S1-2
\`\`\`

…which tells the agent to skip past in-flight work. That's the opposite of what we want — finishing what's already claimed beats picking up something new.

## Root cause

\`collectAgentStatus\` computed \`nextTicket\` as \"first roadmap ticket that is NOT in the claimed set.\" Active claims were filtered out instead of being preferred.

## Fix

In \`src/cli/commands/agent.ts\`:
- If any roadmap ticket has a matching active claim, use that as \`nextTicket\` (in roadmap order)
- Otherwise, fall back to the first un-claimed ticket (existing behavior)

Side-benefit: the \`implementing\`-phase recommendation already only suggests \`slope claim\` when \`activeClaims.length === 0\`, so we don't double-claim.

## Tests

Added 2 tests to \`tests/cli/commands/agent.test.ts\`:
- Real claim on S1-1 → \`nextTicket = S1-1\`, no \`slope claim\` re-recommended
- No claims → falls back to first un-claimed ticket (regression)

All 11 agent tests pass; \`pnpm typecheck\` clean.

Closes #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)