### PR TITLE
fix(agent): exclude completed tickets from nextTicket (#348)

### DIFF
--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -137,8 +137,12 @@ export async function collectAgentStatus(cwd: string): Promise<AgentStatus> {
   // Phase
   const phase: AgentStatus['phase'] = sprintState?.phase ?? 'unknown';
 
-  // Active claims (from store)
+  // Active claims + completed tickets (from store, single open)
+  // Completed = any ticket with a `decision` event of kind `ticket_done`.
+  // `slope ticket done` writes those, so we use them to advance nextTicket
+  // past finished work even after the claim has been released. (#348)
   const activeClaims: string[] = [];
+  const completedTickets = new Set<string>();
   if (currentSprint != null) {
     try {
       const store = await resolveStore(cwd);
@@ -146,16 +150,26 @@ export async function collectAgentStatus(cwd: string): Promise<AgentStatus> {
       for (const c of claims) {
         if (c.target) activeClaims.push(c.target);
       }
+      try {
+        const events = await store.getEventsBySprint(currentSprint);
+        for (const e of events) {
+          if (e.type === 'decision' && e.ticket_key && (e.data as { kind?: string })?.kind === 'ticket_done') {
+            completedTickets.add(e.ticket_key);
+          }
+        }
+      } catch {
+        // events optional — older stores may not have them
+      }
       store.close();
     } catch {
       // store unavailable — return empty
     }
   }
 
-  // Next ticket: prefer the agent's existing active claim (in roadmap order)
-  // — finishing what's already in flight beats starting something new. Only
-  // when nothing is claimed do we recommend the first un-claimed ticket.
-  // (#342: status was reporting next=S1-2 while user already held S1-1.)
+  // Next ticket priority:
+  //   1. The agent's active claim (finishing in-flight work beats starting new) — #342
+  //   2. The first ticket that is neither claimed by anyone nor already done — #348
+  //   3. null when the sprint is exhausted
   let nextTicket: string | null = null;
   let blockedBy: number[] = [];
   if (roadmap && currentSprint != null) {
@@ -166,7 +180,7 @@ export async function collectAgentStatus(cwd: string): Promise<AgentStatus> {
       if (inFlight) {
         nextTicket = inFlight.key;
       } else {
-        const next = sprint.tickets.find(t => !claimed.has(t.key));
+        const next = sprint.tickets.find(t => !claimed.has(t.key) && !completedTickets.has(t.key));
         nextTicket = next?.key ?? null;
       }
       blockedBy = computeBlockers(roadmap, sprint);

--- a/tests/cli/commands/agent.test.ts
+++ b/tests/cli/commands/agent.test.ts
@@ -243,6 +243,71 @@ describe('agent status (GH #310)', () => {
     expect(status.recommendedCommands).not.toContain('slope claim S1-2');
   });
 
+  it('advances past tickets recorded as done by `slope ticket done` (#348)', async () => {
+    writeVision(cwd);
+    writeRoadmap(cwd, [
+      { id: 1, theme: 'A', par: 4, slope: 1, type: 'feature', tickets: [
+        { key: 'S1-1', title: 't1', club: 'wedge', complexity: 'small' },
+        { key: 'S1-2', title: 't2', club: 'wedge', complexity: 'small' },
+        { key: 'S1-3', title: 't3', club: 'wedge', complexity: 'small' },
+      ] },
+    ]);
+    writeSprintState(cwd, {
+      sprint: 1,
+      phase: 'implementing',
+      gates: { tests: false, code_review: false, architect_review: false, scorecard: false, review_md: false },
+      started_at: '2026-05-07T00:00:00Z',
+      updated_at: '2026-05-07T00:00:00Z',
+    });
+
+    // Mirror what `slope ticket done S1-1` writes: a `decision` event with
+    // kind=ticket_done. The claim has already been released, so activeClaims
+    // is empty. Without the #348 fix, status would still recommend S1-1.
+    const store = await resolveStore(cwd);
+    await store.insertEvent({
+      type: 'decision',
+      sprint_number: 1,
+      ticket_key: 'S1-1',
+      data: { kind: 'ticket_done', player: 'agent', commit: 'abc1234' },
+    });
+    store.close();
+
+    const status = await collectAgentStatus(cwd);
+    expect(status.activeClaims).toEqual([]);
+    expect(status.nextTicket).toBe('S1-2');
+  });
+
+  it('returns null nextTicket when every ticket is done (#348)', async () => {
+    writeVision(cwd);
+    writeRoadmap(cwd, [
+      { id: 1, theme: 'A', par: 4, slope: 1, type: 'feature', tickets: [
+        { key: 'S1-1', title: 't1', club: 'wedge', complexity: 'small' },
+        { key: 'S1-2', title: 't2', club: 'wedge', complexity: 'small' },
+      ] },
+    ]);
+    writeSprintState(cwd, {
+      sprint: 1,
+      phase: 'implementing',
+      gates: { tests: true, code_review: true, architect_review: true, scorecard: false, review_md: false },
+      started_at: '2026-05-07T00:00:00Z',
+      updated_at: '2026-05-07T00:00:00Z',
+    });
+
+    const store = await resolveStore(cwd);
+    for (const k of ['S1-1', 'S1-2']) {
+      await store.insertEvent({
+        type: 'decision',
+        sprint_number: 1,
+        ticket_key: k,
+        data: { kind: 'ticket_done', player: 'agent' },
+      });
+    }
+    store.close();
+
+    const status = await collectAgentStatus(cwd);
+    expect(status.nextTicket).toBeNull();
+  });
+
   it('falls back to first un-claimed ticket when no claims exist (#342 regression)', async () => {
     writeVision(cwd);
     writeRoadmap(cwd, [


### PR DESCRIPTION
## Bug

Follow-on from #342. After \`slope ticket done S1-1\`:
- Claim on S1-1 is released ✓
- A \`decision/ticket_done\` event is written to the store ✓
- But \`slope agent status\` still reports \`Next ticket: S1-1\` ✗

Reproduced from a fresh repo on @slope-dev/slope 1.55.1 (per the issue report). \`collectAgentStatus\` only looked at the active-claims set when picking nextTicket — once the claim was released, S1-1 reappeared as the first un-claimed candidate.

## Fix

In \`collectAgentStatus\`:
1. While the store is open, also fetch \`store.getEventsBySprint(currentSprint)\`
2. Build a \`completedTickets\` set from \`decision\` events with \`data.kind === 'ticket_done'\`
3. When falling back to the un-claimed candidate, exclude completed tickets

Priority is now:
1. Active claim (existing #342 behavior — finishing in-flight work wins)
2. First ticket that is neither claimed nor done (new for #348)
3. \`null\` when the sprint is exhausted

## Tests

\`tests/cli/commands/agent.test.ts\`:
- New: ticket-done event for S1-1 → \`nextTicket = S1-2\`
- New: every ticket done → \`nextTicket = null\`
- All 13 agent tests pass; pre-existing #342 + happy-path tests unchanged

The pre-existing flaky \`tests/core/analyzers/git.test.ts > analyzeGit > infers daily cadence\` failure is unrelated.

Closes #348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)