### PR TITLE
fix(auto-card): only emit shots for roadmap tickets (#352)

### DIFF
--- a/src/cli/commands/auto-card.ts
+++ b/src/cli/commands/auto-card.ts
@@ -1,8 +1,8 @@
 import { execSync } from 'node:child_process';
 import { writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { buildScorecard, buildAgentBreakdowns, computeSlope, parseTestOutput, classifyShotFromSignals, buildGhCommand, parsePRJson, mergePRChecksWithCI } from '../../core/index.js';
-import type { ShotRecord, CISignal, PRSignal, ShotResult, AgentBreakdown } from '../../core/index.js';
+import { buildScorecard, buildAgentBreakdowns, computeSlope, parseTestOutput, classifyShotFromSignals, buildGhCommand, parsePRJson, mergePRChecksWithCI, parseRoadmap } from '../../core/index.js';
+import type { ShotRecord, CISignal, PRSignal, ShotResult, AgentBreakdown, RoadmapDefinition } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { resolveStore } from '../store.js';
 
@@ -52,6 +52,57 @@ function inferTicketKey(subject: string, index: number, sprintNumber: number): s
   return `S${sprintNumber}-${index + 1}`;
 }
 
+/** Load the roadmap if it parses cleanly. Returns null when missing or
+ *  invalid — auto-card still works in that case (legacy untracked behavior). */
+function loadRoadmap(cwd: string): RoadmapDefinition | null {
+  try {
+    const config = loadConfig();
+    const roadmapPath = join(cwd, config.roadmapPath);
+    if (!existsSync(roadmapPath)) return null;
+    return parseRoadmap(JSON.parse(readFileSync(roadmapPath, 'utf8'))).roadmap;
+  } catch {
+    return null;
+  }
+}
+
+/** Match a commit subject to a roadmap ticket key for the given sprint.
+ *  Accepts an explicit `S{N}-{M}` mention OR a `(S{N})` umbrella reference
+ *  combined with a positional fallback to the next un-assigned ticket.
+ *  Returns null when the commit references no ticket from this sprint —
+ *  the caller decides whether to drop the commit (default) or keep it
+ *  with a synthetic key (--include-untracked). (#352) */
+export function matchSprintTicket(
+  subject: string,
+  sprintNumber: number,
+  allowedKeys: ReadonlyArray<string>,
+  positionalCursor: { next: number },
+): string | null {
+  // 1. Explicit `S{N}-{M}` mention that's actually in this sprint
+  const exact = subject.match(/\bS(\d+)-(\d+)\b/i);
+  if (exact && parseInt(exact[1], 10) === sprintNumber) {
+    const key = `S${sprintNumber}-${exact[2]}`;
+    if (allowedKeys.includes(key)) return key;
+  }
+
+  // 2. Other-sprint key — definitely not ours, drop
+  if (exact && parseInt(exact[1], 10) !== sprintNumber) return null;
+
+  // 3. `(S{N})` umbrella — assume next un-assigned ticket from the sprint.
+  // The negative lookahead blocks `-`, `.`, and digits after the sprint
+  // number so we don't treat `(S1-9)` as an S1 umbrella (it's a specific
+  // ticket reference handled in step 1) or `(S10)` as `(S1)`.
+  const umbrella = subject.match(new RegExp(`[(\\s+]S${sprintNumber}(?![-.\\d])`, 'i'));
+  if (umbrella) {
+    while (positionalCursor.next < allowedKeys.length) {
+      return allowedKeys[positionalCursor.next++];
+    }
+    return null;
+  }
+
+  // 4. No reference to this sprint at all — drop
+  return null;
+}
+
 function inferClub(filesChanged: number): ShotRecord['club'] {
   if (filesChanged >= 10) return 'driver';
   if (filesChanged >= 5) return 'long_iron';
@@ -78,24 +129,80 @@ export async function autoCardCommand(args: string[]): Promise<void> {
 
   const sprintNumber = parseInt(opts.sprint ?? '', 10);
   if (!sprintNumber) {
-    console.error('\nUsage: slope auto-card --sprint=<N> [--since=<date>] [--branch=<ref>] [--theme=<text>] [--player=<name>] [--test-output=<file>] [--pr=<number>] [--swarm=<id>] [--dry-run]\n');
-    console.error('  --sprint       Sprint number (required)');
-    console.error('  --since        Git log start date, e.g. "2026-02-20" (optional)');
-    console.error('  --branch       Git ref to scan (default: HEAD)');
-    console.error('  --theme        Sprint theme (default: auto-generated)');
-    console.error('  --player       Player name for multi-developer repos');
-    console.error('  --test-output  Path to test runner output file (Vitest/Jest) for CI-aware scoring');
-    console.error('  --pr           PR number to fetch review/check metadata via `gh` CLI');
-    console.error('  --swarm        Swarm ID — map commits to agents for per-agent breakdowns');
-    console.error('  --dry-run      Print scorecard JSON without writing to disk\n');
+    console.error('\nUsage: slope auto-card --sprint=<N> [--since=<date>] [--branch=<ref>] [--theme=<text>] [--player=<name>] [--test-output=<file>] [--pr=<number>] [--swarm=<id>] [--include-untracked] [--dry-run]\n');
+    console.error('  --sprint             Sprint number (required)');
+    console.error('  --since              Git log start date, e.g. "2026-02-20" (optional)');
+    console.error('  --branch             Git ref to scan (default: HEAD)');
+    console.error('  --theme              Sprint theme (default: auto-generated)');
+    console.error('  --player             Player name for multi-developer repos');
+    console.error('  --test-output        Path to test runner output file (Vitest/Jest) for CI-aware scoring');
+    console.error('  --pr                 PR number to fetch review/check metadata via `gh` CLI');
+    console.error('  --swarm              Swarm ID — map commits to agents for per-agent breakdowns');
+    console.error('  --include-untracked  Keep commits with no roadmap ticket (legacy behavior; inflates par)');
+    console.error('  --dry-run            Print scorecard JSON without writing to disk\n');
     process.exit(1);
   }
 
-  const commits = getCommits(opts.since, opts.branch);
+  const allCommits = getCommits(opts.since, opts.branch);
 
-  if (commits.length === 0) {
+  if (allCommits.length === 0) {
     console.error('\nNo commits found. Try specifying --since or --branch.\n');
     process.exit(1);
+  }
+
+  // Filter commits to those that reference a roadmap ticket for this sprint
+  // (#352). Without this, every recent commit on HEAD becomes a shot — so a
+  // sprint with 6 planned tickets gets inflated to S1-7…S1-N from setup
+  // commits. Opt-out via --include-untracked for the legacy behavior.
+  const cwd = process.cwd();
+  const roadmap = loadRoadmap(cwd);
+  const sprint = roadmap?.sprints.find(s => s.id === sprintNumber);
+  const includeUntracked = args.includes('--include-untracked');
+
+  let commits: CommitInfo[];
+  let assignedKeys: (string | null)[];
+
+  if (sprint && !includeUntracked) {
+    const allowedKeys = sprint.tickets.map(t => t.key);
+    const cursor = { next: 0 };
+    const matches = allCommits.map(c => matchSprintTicket(c.subject, sprintNumber, allowedKeys, cursor));
+    const kept: CommitInfo[] = [];
+    const keptKeys: string[] = [];
+    const dropped: CommitInfo[] = [];
+    for (let i = 0; i < allCommits.length; i++) {
+      const key = matches[i];
+      if (key) {
+        kept.push(allCommits[i]);
+        keptKeys.push(key);
+      } else {
+        dropped.push(allCommits[i]);
+      }
+    }
+
+    if (dropped.length > 0) {
+      console.error(`  Filtered ${dropped.length} commit(s) with no S${sprintNumber} roadmap ticket reference:`);
+      for (const c of dropped.slice(0, 5)) {
+        console.error(`    - ${c.hash.slice(0, 8)} ${c.subject}`);
+      }
+      if (dropped.length > 5) console.error(`    ... and ${dropped.length - 5} more`);
+      console.error(`  Use --include-untracked to keep them as synthetic shots.\n`);
+    }
+
+    if (kept.length === 0) {
+      console.error(`  No commits in scan window reference S${sprintNumber} tickets.`);
+      console.error(`  Either narrow with --since=<date>/--branch=<ref>, or use --include-untracked.\n`);
+      process.exit(1);
+    }
+
+    commits = kept;
+    assignedKeys = keptKeys;
+  } else {
+    commits = allCommits;
+    assignedKeys = allCommits.map(() => null); // legacy positional inference
+    if (!sprint && !includeUntracked) {
+      // No roadmap entry for this sprint — surface a hint, but proceed.
+      console.error(`  Note: roadmap has no S${sprintNumber} sprint definition. Falling back to positional ticket keys; pass --include-untracked to silence this hint.\n`);
+    }
   }
 
   // Parse CI output if provided
@@ -146,7 +253,10 @@ export async function autoCardCommand(args: string[]): Promise<void> {
     });
 
     return {
-      ticket_key: inferTicketKey(commit.subject, i, sprintNumber),
+      // Prefer the roadmap-matched key (set above when filtering ran);
+      // fall back to legacy positional inference for --include-untracked
+      // and no-roadmap cases.
+      ticket_key: assignedKeys[i] ?? inferTicketKey(commit.subject, i, sprintNumber),
       title: commit.subject,
       club: inferClub(commit.filesChanged),
       result: classification.result as ShotResult,
@@ -196,7 +306,7 @@ export async function autoCardCommand(args: string[]): Promise<void> {
     return;
   }
 
-  const cwd = process.cwd();
+  // cwd already resolved above for the roadmap lookup
   const outPath = join(cwd, config.scorecardDir, `sprint-${sprintNumber}.json`);
 
   if (existsSync(outPath)) {

--- a/tests/cli/commands/auto-card.test.ts
+++ b/tests/cli/commands/auto-card.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { matchSprintTicket } from '../../../src/cli/commands/auto-card.js';
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const SLOPE_BIN = resolve(REPO_ROOT, 'dist', 'cli', 'index.js');
+
+describe('matchSprintTicket (#352 helper)', () => {
+  const allowedKeys = ['S1-1', 'S1-2', 'S1-3'];
+
+  it('returns the explicit S{N}-{M} key when it is in the allowed set', () => {
+    const cursor = { next: 0 };
+    expect(matchSprintTicket('feat(S1-2): add thing', 1, allowedKeys, cursor)).toBe('S1-2');
+  });
+
+  it('returns null for an explicit key not in this sprint', () => {
+    const cursor = { next: 0 };
+    // Roadmap only has S1-1..S1-3 — a commit referencing S1-9 is invented
+    expect(matchSprintTicket('feat(S1-9): bogus', 1, allowedKeys, cursor)).toBeNull();
+  });
+
+  it('returns null when the commit references a different sprint', () => {
+    const cursor = { next: 0 };
+    expect(matchSprintTicket('feat(S2-1): another sprint', 1, allowedKeys, cursor)).toBeNull();
+  });
+
+  it('returns null for setup/bootstrap commits with no sprint reference', () => {
+    const cursor = { next: 0 };
+    expect(matchSprintTicket('chore(SLOPE): update repo for SLOPE 1.55', 1, allowedKeys, cursor)).toBeNull();
+    expect(matchSprintTicket('Initialize Cooper validation project', 1, allowedKeys, cursor)).toBeNull();
+    expect(matchSprintTicket('docs(SLOPE): refresh codebase map', 1, allowedKeys, cursor)).toBeNull();
+  });
+
+  it('handles the (S{N}) umbrella by advancing through the allowed keys', () => {
+    const cursor = { next: 0 };
+    expect(matchSprintTicket('feat(S1): umbrella one', 1, allowedKeys, cursor)).toBe('S1-1');
+    expect(matchSprintTicket('feat(S1): umbrella two', 1, allowedKeys, cursor)).toBe('S1-2');
+  });
+
+  it('returns null once positional cursor exhausts the allowed keys', () => {
+    const cursor = { next: 3 }; // already past the last allowed key
+    expect(matchSprintTicket('feat(S1): one too many', 1, allowedKeys, cursor)).toBeNull();
+  });
+});
+
+function setupRepoWithRoadmap(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'slope-auto-card-'));
+  mkdirSync(join(dir, '.slope'), { recursive: true });
+  mkdirSync(join(dir, 'docs', 'backlog'), { recursive: true });
+  mkdirSync(join(dir, 'docs', 'retros'), { recursive: true });
+  writeFileSync(join(dir, '.slope', 'config.json'), JSON.stringify({
+    roadmapPath: 'docs/backlog/roadmap.json',
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+  }));
+  writeFileSync(join(dir, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+    name: 'Test',
+    phases: [{ name: 'P1', sprints: [1] }],
+    sprints: [{
+      id: 1,
+      theme: 'First Sprint',
+      par: 4,
+      slope: 1,
+      type: 'feature',
+      tickets: [
+        { key: 'S1-1', title: 'first', club: 'wedge', complexity: 'small' },
+        { key: 'S1-2', title: 'second', club: 'wedge', complexity: 'small' },
+        { key: 'S1-3', title: 'third', club: 'wedge', complexity: 'small' },
+      ],
+    }],
+  }));
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email t@t', { cwd: dir });
+  execSync('git config user.name t', { cwd: dir });
+  return dir;
+}
+
+function commitWith(cwd: string, message: string) {
+  execSync('git commit -q --allow-empty -m ' + JSON.stringify(message), { cwd });
+}
+
+describe('slope auto-card --dry-run roadmap filtering (#352)', () => {
+  beforeAll(() => {
+    if (!existsSync(SLOPE_BIN)) {
+      throw new Error(`dist not built — run \`pnpm build\` first. Expected ${SLOPE_BIN}`);
+    }
+  });
+
+  it('drops setup/bootstrap commits and emits only roadmap-keyed shots', () => {
+    const cwd = setupRepoWithRoadmap();
+    try {
+      commitWith(cwd, 'Initialize Cooper validation project');
+      commitWith(cwd, 'chore(SLOPE): update repo for SLOPE 1.55');
+      commitWith(cwd, 'feat(S1-1): real ticket one');
+      commitWith(cwd, 'feat(S1-2): real ticket two');
+
+      const out = execSync(`node ${SLOPE_BIN} auto-card --sprint=1 --dry-run`, {
+        cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const card = JSON.parse(out.trim());
+      const keys = (card.shots as Array<{ ticket_key: string }>).map(s => s.ticket_key);
+
+      // Order is git-log order (newest first), but the SET must be exactly
+      // {S1-1, S1-2} — no invented S1-7+ keys from the bootstrap commits.
+      expect(new Set(keys)).toEqual(new Set(['S1-1', 'S1-2']));
+      expect(keys).not.toContain('S1-3'); // no commit for it
+      // Any S1-N where N > 3 is invented — that's the bug
+      expect(keys.some(k => {
+        const m = /^S1-(\d+)$/.exec(k);
+        return m ? parseInt(m[1], 10) > 3 : false;
+      })).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('warns about and lists dropped commits on stderr', () => {
+    const cwd = setupRepoWithRoadmap();
+    try {
+      commitWith(cwd, 'chore: unrelated cleanup');
+      commitWith(cwd, 'feat(S1-1): real ticket');
+
+      // Capture stderr by redirecting via a shell. execSync's `stderr` property
+      // on success is undefined, and the dry-run exits 0, so route stderr
+      // through stdout for inspection.
+      const combined = execSync(
+        `node ${SLOPE_BIN} auto-card --sprint=1 --dry-run 2>&1 1>/dev/null`,
+        { cwd, encoding: 'utf8', shell: '/bin/sh' },
+      );
+      expect(combined).toMatch(/Filtered 1 commit/);
+      expect(combined).toContain('chore: unrelated cleanup');
+      expect(combined).toContain('--include-untracked');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('--include-untracked keeps every commit (legacy behavior)', () => {
+    const cwd = setupRepoWithRoadmap();
+    try {
+      commitWith(cwd, 'chore(SLOPE): bootstrap');
+      commitWith(cwd, 'docs(SLOPE): refresh map');
+      commitWith(cwd, 'feat(S1-1): real ticket');
+
+      const out = execSync(`node ${SLOPE_BIN} auto-card --sprint=1 --include-untracked --dry-run`, {
+        cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const card = JSON.parse(out.trim());
+      expect((card.shots as unknown[]).length).toBe(3);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('exits non-zero when filtering eliminates every commit', () => {
+    const cwd = setupRepoWithRoadmap();
+    try {
+      commitWith(cwd, 'chore(SLOPE): bootstrap');
+      commitWith(cwd, 'docs: random');
+
+      let exitCode: number | null = null;
+      let stderr = '';
+      try {
+        execSync(`node ${SLOPE_BIN} auto-card --sprint=1 --dry-run`, {
+          cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+        });
+      } catch (e) {
+        const err = e as { status?: number; stderr?: string };
+        exitCode = err.status ?? null;
+        stderr = err.stderr ?? '';
+      }
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toMatch(/No commits .* reference S1 tickets/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to legacy positional inference when sprint is not in roadmap', () => {
+    const cwd = setupRepoWithRoadmap();
+    try {
+      // Sprint 2 has no roadmap entry — fall back to old behavior
+      commitWith(cwd, 'feat: anything');
+
+      const out = execSync(`node ${SLOPE_BIN} auto-card --sprint=2 --dry-run`, {
+        cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const card = JSON.parse(out.trim());
+      expect(card.shots.length).toBe(1);
+      expect(card.shots[0].ticket_key).toBe('S2-1'); // legacy positional
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});
+


### PR DESCRIPTION
## Bug

\`slope auto-card --sprint=1 --dry-run\` in Cooper invented \`S1-7\`…\`S1-11\` from setup/bootstrap commits even though the sprint roadmap defined only \`S1-1\`…\`S1-6\`. Per the issue:

> Inventing S1-7+ tickets makes the sprint look larger than planned and can distort par/slope/score and review expectations.

Root cause: \`getCommits\` returned every \`git log HEAD\` commit, and \`inferTicketKey\` fell back to \`S{N}-{index+1}\` whenever a commit subject didn't already match a ticket pattern. Roadmap was never consulted.

## Fix

Roadmap-aware filtering in \`autoCardCommand\`:

1. Load the roadmap; resolve the sprint definition for \`--sprint=N\`
2. For each commit, run \`matchSprintTicket(subject, N, allowedKeys, cursor)\`:
   - Explicit \`S{N}-{M}\` mention that's actually in the allowed set → use it
   - \`(S{N})\` umbrella commit → next un-assigned key (with negative-lookahead so \`(S1-9)\`/\`(S1.5)\`/\`(S10)\` don't get misread as \`(S1)\`)
   - Anything else → drop, with a stderr summary of examples
3. If filtering eliminates everything, exit non-zero with a hint to narrow scope or use \`--include-untracked\`

\`--include-untracked\` opts into the previous positional behavior. Same path runs when the roadmap is missing or has no entry for the requested sprint, so this isn't a hard regression.

## Tests

New \`tests/cli/commands/auto-card.test.ts\`:

- 6 unit cases for \`matchSprintTicket\`: exact in-sprint, key not in roadmap, other-sprint, untracked setup commits, umbrella, cursor-exhausted
- 5 CLI dry-run cases: filtering drops bootstrap commits, stderr hint with example, \`--include-untracked\` keeps everything, all-filtered exits non-zero, no-roadmap-entry falls back to legacy positional inference

All 11 pass. Full suite 3287 passing; only the pre-existing flaky \`analyzeGit\` test fails (unrelated).

Closes #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)