### PR TITLE
fix(review): --help is read-only; never mutates review state (#353)

### DIFF
--- a/src/cli/commands/review-state.ts
+++ b/src/cli/commands/review-state.ts
@@ -490,9 +490,115 @@ function amendCommand(args: string[], cwd: string): void {
 
 // --- Main Command Router ---
 
+/** Per-subcommand usage text. Kept inside the dispatcher so `--help` can
+ *  short-circuit before any state-mutating handler runs (#353). */
+function printReviewHelp(sub: string | undefined): void {
+  switch (sub) {
+    case 'start':
+      console.log(`Usage: slope review start [--rounds=N | --tier=<tier>]
+
+Start a review on the current plan. Tiers map to round counts:
+  skip      0 rounds   research/infra/docs-only sprints
+  light     1 round    1-2 tickets, familiar patterns, single-package
+  standard  2 rounds   3-4 tickets, multi-package, schema/API changes
+  deep      3 rounds   5+ tickets, new infrastructure, architectural changes
+
+Without --rounds or --tier, the tier is auto-detected from the most recent
+plan file in .claude/plans/ or ~/.claude/plans/.`);
+      break;
+    case 'round':
+      console.log(`Usage: slope review round
+
+Mark one review round complete. Errors when no review is in progress
+(start one with \`slope review start\`).`);
+      break;
+    case 'status':
+      console.log(`Usage: slope review status
+
+Print the active review's tier and rounds-remaining counter, or "No
+active review" when none is in progress.`);
+      break;
+    case 'reset':
+      console.log(`Usage: slope review reset
+
+Clear any active review state. Use when a plan has been replaced or you
+want to restart the review counter.`);
+      break;
+    case 'recommend':
+      console.log(`Usage: slope review recommend
+
+Suggest which implementation review types (architect/code/ml/security/
+ux) apply to the current sprint based on the diff and ticket metadata.`);
+      break;
+    case 'findings':
+      console.log(`Usage: slope review findings <add|list|clear> [options]
+
+Subcommands:
+  add    Record a review finding (--type, --ticket, --severity, --description)
+  list   List recorded findings (optionally --sprint=N)
+  clear  Clear all findings`);
+      break;
+    case 'amend':
+      console.log(`Usage: slope review amend [--sprint=N]
+
+Apply recorded findings to the sprint scorecard as hazards and recompute
+the score. Defaults to the latest sprint with a scorecard on disk.`);
+      break;
+    case 'defer':
+      console.log(`Usage: slope review defer --from=<sprint> --description="..." [--to=<sprint>] [--severity=<low|medium|high|critical>] [--category=<text>]
+
+Record a finding to address in a future sprint instead of amending the
+current scorecard.`);
+      break;
+    case 'deferred':
+      console.log(`Usage: slope review deferred [--sprint=N]
+
+List deferred findings, optionally filtered by their target sprint.`);
+      break;
+    case 'resolve':
+      console.log(`Usage: slope review resolve <id> [--note="..."]
+
+Mark a deferred finding as resolved. Use \`slope review deferred\` to
+look up ids.`);
+      break;
+    case 'run':
+      console.log(`Usage: slope review run [options]
+
+Run a structured review pass on the current sprint plan or PR. Pass
+\`--help\` after \`run\` for full options.`);
+      break;
+    default:
+      console.log(`Usage: slope review <subcommand> [options]
+
+Subcommands:
+  start       Start a review (auto-detects tier or use --rounds/--tier)
+  round       Mark one review round complete
+  status      Show active review state
+  reset       Clear active review state
+  recommend   Suggest implementation review types for the current sprint
+  findings    Record/list/clear review findings
+  amend       Apply findings to the sprint scorecard
+  defer       Record a finding to address in a later sprint
+  deferred    List deferred findings
+  resolve     Mark a deferred finding as resolved
+  run         Run a structured review pass
+
+Use \`slope review <subcommand> --help\` for per-subcommand options.`);
+  }
+}
+
 export async function reviewStateCommand(args: string[]): Promise<void> {
   const cwd = process.cwd();
   const sub = args[0];
+
+  // --help/-h must short-circuit BEFORE any subcommand handler runs.
+  // Previously `slope review start --help` actually started a review and
+  // `slope review round --help` advanced the round counter — agents
+  // probing command syntax with --help were corrupting review state. (#353)
+  if (args.includes('--help') || args.includes('-h')) {
+    printReviewHelp(sub);
+    return;
+  }
 
   switch (sub) {
     case 'start':

--- a/tests/cli/review-state.test.ts
+++ b/tests/cli/review-state.test.ts
@@ -80,6 +80,88 @@ describe('reviewStateCommand', () => {
     return reviewStateCommand(args);
   }
 
+  describe('--help is read-only (#353)', () => {
+    it('does NOT start a review when called as `slope review start --help`', async () => {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await runCommand(['start', '--help']);
+        // No state file should be written — the bug was that --help
+        // triggered the start handler and wrote review-state.json.
+        expect(loadReviewState(tmpDir)).toBeNull();
+        // Help output should mention the subcommand
+        const helpText = log.mock.calls.map(c => c[0] as string).join('\n');
+        expect(helpText).toMatch(/Usage: slope review start/);
+        expect(helpText).toMatch(/--rounds|--tier/);
+      } finally {
+        log.mockRestore();
+      }
+    });
+
+    it('does NOT advance the round counter when called as `slope review round --help`', async () => {
+      // Pre-seed an in-progress review so the bug would have been visible
+      mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+      const initial: ReviewState = {
+        rounds_required: 3,
+        rounds_completed: 1,
+        tier: 'deep',
+        started_at: '2026-05-10T00:00:00.000Z',
+      };
+      saveReviewState(tmpDir, initial);
+
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await runCommand(['round', '--help']);
+        // Counter must be untouched
+        const state = loadReviewState(tmpDir)!;
+        expect(state.rounds_completed).toBe(1);
+        const helpText = log.mock.calls.map(c => c[0] as string).join('\n');
+        expect(helpText).toMatch(/Usage: slope review round/);
+      } finally {
+        log.mockRestore();
+      }
+    });
+
+    it('prints subcommand-specific help for findings/amend/reset/recommend', async () => {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        for (const sub of ['findings', 'amend', 'reset', 'recommend']) {
+          log.mockClear();
+          await runCommand([sub, '--help']);
+          const helpText = log.mock.calls.map(c => c[0] as string).join('\n');
+          expect(helpText).toMatch(new RegExp(`Usage: slope review ${sub}`));
+        }
+      } finally {
+        log.mockRestore();
+      }
+    });
+
+    it('prints top-level help for `slope review --help` (no subcommand)', async () => {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await runCommand(['--help']);
+        const helpText = log.mock.calls.map(c => c[0] as string).join('\n');
+        expect(helpText).toMatch(/Usage: slope review <subcommand>/);
+        expect(helpText).toContain('start');
+        expect(helpText).toContain('round');
+        expect(helpText).toContain('findings');
+      } finally {
+        log.mockRestore();
+      }
+    });
+
+    it('-h short flag is also read-only', async () => {
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await runCommand(['start', '-h']);
+        expect(loadReviewState(tmpDir)).toBeNull();
+        const helpText = log.mock.calls.map(c => c[0] as string).join('\n');
+        expect(helpText).toMatch(/Usage: slope review start/);
+      } finally {
+        log.mockRestore();
+      }
+    });
+  });
+
   describe('start', () => {
     it('creates review-state.json with --rounds', async () => {
       await runCommand(['start', '--rounds=2']);


### PR DESCRIPTION
## Bug

\`\`\`
$ slope review start --help
Review started: Deep (3 rounds). Run 'slope review round' after each review round.

$ slope review round --help
Round 1/3 complete. 2 rounds remaining.
\`\`\`

Both \`--help\` calls actually mutated review state instead of printing usage. Agents (Codex, Claude Code, opencode) routinely probe command syntax with \`--help\` — this corruption made review-driven workflows brittle.

## Fix

The \`reviewStateCommand\` dispatcher now intercepts \`--help\`/\`-h\` BEFORE routing to subcommand handlers. A new \`printReviewHelp(sub)\` prints subcommand-specific usage for start/round/status/reset/recommend/findings/amend/defer/deferred/resolve/run, plus a top-level subcommand index when no \`sub\` is given.

## Tests

5 new in \`tests/cli/review-state.test.ts\`:
- \`start --help\` writes no \`review-state.json\`
- \`round --help\` does not advance \`rounds_completed\`
- \`findings/amend/reset/recommend --help\` print subcommand-specific usage
- bare \`slope review --help\` prints the top-level subcommand index
- \`-h\` short flag is also read-only

All 29 review-state tests pass; full suite 3298 passing (only pre-existing flaky \`analyzeGit\` test fails, unrelated).

## Follow-up

Other multi-subcommand dispatchers (\`sprint\`, \`initiative\`, \`workflow\`, \`loop\`, \`flows\`, \`roadmap\`, \`memory\`) lack the same dispatcher-level \`--help\` short-circuit. Not in this issue's repro, but worth a defensive sweep next round — agents will eventually trip the same shape elsewhere.

Closes #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)