### PR TITLE
fix(agent): use scorecards as source of truth for blockedBy (#356)

### DIFF
--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import {
   parseRoadmap,
   detectLatestSprint,
+  loadScorecards,
 } from '../../core/index.js';
 import type { RoadmapDefinition, RoadmapSprint } from '../../core/index.js';
 import { loadConfig } from '../config.js';
@@ -166,6 +167,26 @@ export async function collectAgentStatus(cwd: string): Promise<AgentStatus> {
     }
   }
 
+  // Sprints completed = roadmap entry has `status: complete` OR a scorecard
+  // exists on disk for that sprint. The scorecard signal matches what
+  // `slope roadmap status` uses (#356) — agent status was previously only
+  // looking at the roadmap status field, which isn't auto-updated when a
+  // sprint closes, so it kept reporting stale `blockedBy: [N]` even after
+  // the upstream sprint was completed.
+  const completedSprintIds = new Set<number>();
+  for (const s of roadmap?.sprints ?? []) {
+    if ((s as RoadmapSprint & { status?: string }).status === 'complete') {
+      completedSprintIds.add(s.id);
+    }
+  }
+  try {
+    for (const card of loadScorecards(config, cwd)) {
+      completedSprintIds.add(card.sprint_number);
+    }
+  } catch {
+    // scorecards optional — keep going with whatever the roadmap had
+  }
+
   // Next ticket priority:
   //   1. The agent's active claim (finishing in-flight work beats starting new) — #342
   //   2. The first ticket that is neither claimed by anyone nor already done — #348
@@ -183,7 +204,7 @@ export async function collectAgentStatus(cwd: string): Promise<AgentStatus> {
         const next = sprint.tickets.find(t => !claimed.has(t.key) && !completedTickets.has(t.key));
         nextTicket = next?.key ?? null;
       }
-      blockedBy = computeBlockers(roadmap, sprint);
+      blockedBy = computeBlockers(sprint, completedSprintIds);
     }
   }
 
@@ -222,13 +243,12 @@ export async function collectAgentStatus(cwd: string): Promise<AgentStatus> {
   };
 }
 
-function computeBlockers(roadmap: RoadmapDefinition, sprint: RoadmapSprint): number[] {
-  const completedIds = new Set(
-    roadmap.sprints
-      .filter(s => (s as RoadmapSprint & { status?: string }).status === 'complete')
-      .map(s => s.id),
-  );
-  return (sprint.depends_on ?? []).filter(d => !completedIds.has(d));
+/** A sprint is blocked when any of its `depends_on` upstreams is not yet
+ *  in the completed-sprint set. The set is built by the caller from BOTH
+ *  roadmap `status: complete` AND scorecards on disk — matching the
+ *  source of truth `slope roadmap status` already uses (#356). */
+function computeBlockers(sprint: RoadmapSprint, completedSprintIds: Set<number>): number[] {
+  return (sprint.depends_on ?? []).filter(d => !completedSprintIds.has(d));
 }
 
 function recommendCommands(state: {

--- a/tests/cli/commands/agent.test.ts
+++ b/tests/cli/commands/agent.test.ts
@@ -92,6 +92,52 @@ describe('agent status (GH #310)', () => {
     expect(status.recommendedCommands).toContain('slope briefing');
   });
 
+  it('clears blockedBy when upstream sprint has a scorecard but no roadmap status field (#356)', async () => {
+    writeVision(cwd);
+    writeRoadmap(cwd, [
+      // S1 has NO `status: complete` — closing a sprint via gates+scorecard
+      // doesn't currently mutate the roadmap JSON. roadmap status reads
+      // scorecard files directly; agent status now does the same.
+      { id: 1, theme: 'Foundation', par: 4, slope: 1, type: 'feature', tickets: [
+        { key: 'S1-1', title: 't1', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 2, theme: 'Next', par: 4, slope: 1, type: 'feature', depends_on: [1], tickets: [
+        { key: 'S2-1', title: 't1', club: 'wedge', complexity: 'small' },
+        { key: 'S2-2', title: 't2', club: 'wedge', complexity: 'small' },
+      ] },
+    ]);
+    // Drop a real S1 scorecard on disk — this is the signal `roadmap status`
+    // already trusts as "S1 is done".
+    writeFileSync(join(cwd, 'docs', 'retros', 'sprint-1.json'), JSON.stringify({
+      sprint_number: 1,
+      theme: 'Foundation',
+      par: 4,
+      slope: 1,
+      score: 4,
+      score_label: 'par',
+      date: '2026-05-08',
+      shots: [],
+      stats: { fairways_hit: 0, fairways_total: 0, greens_in_regulation: 0, greens_total: 0, putts: 0, penalties: 0, hazards_hit: 0, hazard_penalties: 0, miss_directions: { long: 0, short: 0, left: 0, right: 0 } },
+      conditions: [],
+      special_plays: [],
+      bunker_locations: [],
+      yardage_book_updates: [],
+      course_management_notes: [],
+    }));
+    writeSprintState(cwd, {
+      sprint: 2,
+      phase: 'implementing',
+      gates: { tests: false, code_review: false, architect_review: false, scorecard: false, review_md: false },
+      started_at: '2026-05-09T00:00:00Z',
+      updated_at: '2026-05-09T00:00:00Z',
+    });
+
+    const status = await collectAgentStatus(cwd);
+    // S1 IS complete (scorecard exists); S2 is no longer blocked
+    expect(status.blockedBy).toEqual([]);
+    expect(status.recommendedCommands).not.toContain('slope roadmap status');
+  });
+
   it('reports blockedBy when current sprint depends on incomplete sprint', async () => {
     writeVision(cwd);
     writeRoadmap(cwd, [


### PR DESCRIPTION
## Bug

\`slope agent status --json\` reported contradictory state vs. \`slope roadmap status\`:

\`\`\`json
{ \"currentSprint\": 2, \"blockedBy\": [1], ... }
\`\`\`

while \`slope roadmap status --sprint=2\` correctly showed:
\`\`\`
S1 Project Foundation … ✓ completed
S2 Landing Page …       ▶ active
\`\`\`

For Cooper this meant agents kept being told S2 was blocked by an already-completed S1.

## Root cause

\`computeBlockers\` in \`src/cli/commands/agent.ts\` only treated a sprint as completed if its roadmap JSON entry had \`status: complete\`. But that field isn't auto-mutated by gate completion or scorecard write. \`roadmap status\` (the user-trusted source) builds its completed-set from scorecards on disk via \`loadScorecards\`. The two commands were reading different signals.

## Fix

In \`collectAgentStatus\`, build a \`completedSprintIds\` set from BOTH:
1. Roadmap entries with \`status: complete\` (preserved for projects that do explicitly mark completion)
2. \`loadScorecards(config, cwd).map(s => s.sprint_number)\` — the same signal \`roadmap status\` uses

Pass the set into a simplified \`computeBlockers(sprint, completedSprintIds)\`. The scorecard read is wrapped in try/catch so projects without retros still work.

## Tests

\`tests/cli/commands/agent.test.ts\`:
- New: S1 has a scorecard but no \`status: complete\` in the roadmap → \`S2.blockedBy === []\` and \`slope roadmap status\` is not in the recommended commands
- Existing #342, #348, and \"blocked by incomplete sprint\" tests still pass (14 agent tests total)

Full suite: 3294 passing; only the pre-existing flaky \`analyzeGit\` test fails (unrelated).

Closes #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)