### PR TITLE
fix(doctor): respect dry-run when applying fixes

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -791,6 +791,7 @@ export async function doctorCommand(args: string[]): Promise<void> {
   const cwd = process.cwd();
   let checks = runDoctorChecks(cwd);
   const shouldFix = args.includes('--fix');
+  const dryRun = args.includes('--dry-run');
 
   formatResults(checks);
 
@@ -798,6 +799,15 @@ export async function doctorCommand(args: string[]): Promise<void> {
     const fixable = checks.filter(c => (c.status === 'fail' || c.status === 'warn') && c.fixable);
     if (fixable.length === 0) {
       console.log('\n  Nothing to fix — all checks passed.');
+      return;
+    }
+
+    if (dryRun) {
+      console.log('\n  [dry-run] Fixes that would be applied:\n');
+      for (const check of fixable) {
+        console.log(`  [dry-run] ${check.name}: ${check.message}`);
+      }
+      console.log('\n  Re-run without --dry-run to apply fixes.');
       return;
     }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -521,7 +521,7 @@ Usage:
   slope sprint start|gate|status|reset               Manage sprint lifecycle state
   slope worktree cleanup [--path|--all] [--dry-run]  Clean up stale worktrees
   slope loop status|config|run|continuous|...        Autonomous sprint execution loop
-  slope doctor [--fix]                               Check repo health and fix issues
+  slope doctor [--fix] [--dry-run]                   Check repo health and fix issues
   slope version                                      Show current version
   slope version bump [<version>] [--dry-run]         Bump version, create PR, merge
 

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { runDoctorChecks, runDoctorFixes } from '../../../src/cli/commands/doctor.js';
+import { doctorCommand, runDoctorChecks, runDoctorFixes } from '../../../src/cli/commands/doctor.js';
 import { SLOPE_BIN_PREAMBLE } from '../../../src/core/harness.js';
 
 // Ensure metaphors are registered
@@ -47,6 +47,32 @@ describe('doctor checks', () => {
 
   afterEach(() => {
     rmSync(cwd, { recursive: true, force: true });
+  });
+
+  describe('doctor --fix --dry-run', () => {
+    it('previews fixable checks without writing changes', async () => {
+      setupSlopeDir(cwd);
+      const gitignorePath = join(cwd, '.gitignore');
+      const before = readFileSync(gitignorePath, 'utf8');
+      const logs: string[] = [];
+      const logSpy = vi.spyOn(console, 'log').mockImplementation((message = '') => {
+        logs.push(String(message));
+      });
+      const originalCwd = process.cwd();
+
+      try {
+        process.chdir(cwd);
+        await doctorCommand(['--fix', '--dry-run']);
+      } finally {
+        process.chdir(originalCwd);
+        logSpy.mockRestore();
+      }
+
+      expect(readFileSync(gitignorePath, 'utf8')).toBe(before);
+      expect(logs.join('\n')).toContain('[dry-run] Fixes that would be applied');
+      expect(logs.join('\n')).toContain('gitignore-noise');
+      expect(logs.join('\n')).not.toContain('Applying fixes');
+    });
   });
 
   // --- S65-1: version drift ---


### PR DESCRIPTION
## Summary
- detect `--dry-run` in `doctorCommand` before running doctor fixes
- print fixable checks as dry-run preview instead of mutating files
- add regression coverage that `doctor --fix --dry-run` leaves `.gitignore` unchanged
- include `--dry-run` in top-level doctor help

Closes #360.

## Validation
- `npm exec -- pnpm install --frozen-lockfile`
- `npm exec -- pnpm exec vitest run tests/cli/commands/doctor.test.ts tests/cli/doctor-gitignore-noise.test.ts`
- `npm exec -- pnpm run typecheck`
- `npm exec -- pnpm test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` flag to the `slope doctor --fix` command. When used together, it previews applicable fixes and displays which checks would be resolved without modifying files. Re-run without `--dry-run` to apply fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/362)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->