### PR TITLE
fix(S93): integrate doctor and worktree recovery fixes

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 import { detectPlatforms, type InitProvider } from './init.js';
@@ -25,9 +25,17 @@ export interface DoctorCheck {
 /** Run all health checks on a SLOPE-configured repo. */
 export function runDoctorChecks(cwd: string): DoctorCheck[] {
   const checks: DoctorCheck[] = [];
+  const stateCwd = resolveSlopeStateCwd(cwd);
+  if (stateCwd !== cwd) {
+    checks.push({
+      name: 'worktree-state',
+      status: 'ok',
+      message: `Linked worktree using SLOPE state from ${stateCwd}`,
+    });
+  }
 
   // 1. Check .slope/config.json exists and is valid JSON
-  checks.push(checkConfig(cwd));
+  checks.push(checkConfig(stateCwd, cwd));
 
   // 2. Check .gitignore contains .slope/
   checks.push(checkGitignore(cwd));
@@ -36,10 +44,10 @@ export function runDoctorChecks(cwd: string): DoctorCheck[] {
   checks.push(...checkGitignoreNoise(cwd));
 
   // 3. Check SQLite store exists
-  checks.push(checkStore(cwd));
+  checks.push(checkStore(stateCwd, cwd));
 
   // 4. Check common-issues.json exists
-  checks.push(checkCommonIssues(cwd));
+  checks.push(checkCommonIssues(stateCwd, cwd));
 
   // 5. Check docs/retros/ directory exists
   checks.push(checkRetrosDir(cwd));
@@ -51,13 +59,13 @@ export function runDoctorChecks(cwd: string): DoctorCheck[] {
   checks.push(checkCodebaseMap(cwd));
 
   // 8. Check version drift
-  checks.push(checkVersion(cwd));
+  checks.push(checkVersion(stateCwd, cwd));
 
   // 9. Check config schema validity
-  checks.push(...checkConfigSchema(cwd));
+  checks.push(...checkConfigSchema(stateCwd, cwd));
 
   // 10. Check guards are installed for detected platforms
-  checks.push(...checkGuards(cwd));
+  checks.push(...checkGuards(stateCwd, cwd));
 
   // 11. Check hook script staleness
   checks.push(...checkHookScripts(cwd));
@@ -71,14 +79,44 @@ export function runDoctorChecks(cwd: string): DoctorCheck[] {
   return checks;
 }
 
-function checkConfig(cwd: string): DoctorCheck {
+function stateNote(stateCwd: string, cwd: string): string {
+  return stateCwd === cwd ? '' : ` (from primary worktree ${stateCwd})`;
+}
+
+function resolveSlopeStateCwd(cwd: string): string {
+  if (existsSync(join(cwd, '.slope', 'config.json'))) return cwd;
+  for (const worktree of listGitWorktrees(cwd)) {
+    if (resolve(worktree) === resolve(cwd)) continue;
+    if (existsSync(join(worktree, '.slope', 'config.json'))) return worktree;
+  }
+  return cwd;
+}
+
+function listGitWorktrees(cwd: string): string[] {
+  try {
+    const raw = execSync('git worktree list --porcelain', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return raw
+      .split('\n')
+      .filter(line => line.startsWith('worktree '))
+      .map(line => line.slice('worktree '.length).trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function checkConfig(cwd: string, originalCwd = cwd): DoctorCheck {
   const configPath = join(cwd, '.slope', 'config.json');
   if (!existsSync(configPath)) {
     return { name: 'config', status: 'fail', message: '.slope/config.json missing — run `slope init`', fixable: true };
   }
   try {
     JSON.parse(readFileSync(configPath, 'utf8'));
-    return { name: 'config', status: 'ok', message: '.slope/config.json valid' };
+    return { name: 'config', status: 'ok', message: `.slope/config.json valid${stateNote(cwd, originalCwd)}` };
   } catch {
     // Corrupt config — not auto-fixable (would lose custom settings)
     return { name: 'config', status: 'fail', message: '.slope/config.json is invalid JSON — fix manually or delete and run `slope init`' };
@@ -140,20 +178,20 @@ function checkGitignoreNoise(cwd: string): DoctorCheck[] {
   }];
 }
 
-function checkStore(cwd: string): DoctorCheck {
+function checkStore(cwd: string, originalCwd = cwd): DoctorCheck {
   const dbPath = join(cwd, '.slope', 'slope.db');
   if (!existsSync(dbPath)) {
     return { name: 'store', status: 'warn', message: '.slope/slope.db missing — sessions and events will not be tracked', fixable: true };
   }
-  return { name: 'store', status: 'ok', message: '.slope/slope.db exists' };
+  return { name: 'store', status: 'ok', message: `.slope/slope.db exists${stateNote(cwd, originalCwd)}` };
 }
 
-function checkCommonIssues(cwd: string): DoctorCheck {
+function checkCommonIssues(cwd: string, originalCwd = cwd): DoctorCheck {
   const path = join(cwd, '.slope', 'common-issues.json');
   if (!existsSync(path)) {
     return { name: 'common-issues', status: 'warn', message: '.slope/common-issues.json missing', fixable: true };
   }
-  return { name: 'common-issues', status: 'ok', message: '.slope/common-issues.json exists' };
+  return { name: 'common-issues', status: 'ok', message: `.slope/common-issues.json exists${stateNote(cwd, originalCwd)}` };
 }
 
 function checkRetrosDir(cwd: string): DoctorCheck {
@@ -203,7 +241,7 @@ function getPackageVersion(): string {
   return pkg.version;
 }
 
-function checkVersion(cwd: string): DoctorCheck {
+function checkVersion(cwd: string, originalCwd = cwd): DoctorCheck {
   const configPath = join(cwd, '.slope', 'config.json');
   if (!existsSync(configPath)) {
     return { name: 'version', status: 'warn', message: 'Cannot check version — .slope/config.json missing', fixable: false };
@@ -217,13 +255,13 @@ function checkVersion(cwd: string): DoctorCheck {
     if (config.slopeVersion !== pkgVersion) {
       return { name: 'version', status: 'warn', message: `config.slopeVersion (${config.slopeVersion}) differs from package (${pkgVersion}) — run \`slope doctor --fix\``, fixable: true };
     }
-    return { name: 'version', status: 'ok', message: `config.slopeVersion matches package (${pkgVersion})` };
+    return { name: 'version', status: 'ok', message: `config.slopeVersion matches package (${pkgVersion})${stateNote(cwd, originalCwd)}` };
   } catch {
     return { name: 'version', status: 'warn', message: 'Cannot check version — .slope/config.json unreadable', fixable: false };
   }
 }
 
-function checkConfigSchema(cwd: string): DoctorCheck[] {
+function checkConfigSchema(cwd: string, originalCwd = cwd): DoctorCheck[] {
   const checks: DoctorCheck[] = [];
   const configPath = join(cwd, '.slope', 'config.json');
   if (!existsSync(configPath)) return checks;
@@ -269,7 +307,7 @@ function checkConfigSchema(cwd: string): DoctorCheck[] {
   }
 
   if (checks.length === 0) {
-    checks.push({ name: 'config-schema', status: 'ok', message: 'Config schema valid' });
+    checks.push({ name: 'config-schema', status: 'ok', message: `Config schema valid${stateNote(cwd, originalCwd)}` });
   }
 
   return checks;
@@ -391,7 +429,7 @@ function checkHookScripts(cwd: string): DoctorCheck[] {
   return checks;
 }
 
-function checkGuards(cwd: string): DoctorCheck[] {
+function checkGuards(cwd: string, originalCwd = cwd): DoctorCheck[] {
   const checks: DoctorCheck[] = [];
   const hooksPath = join(cwd, '.slope', 'hooks.json');
 
@@ -426,13 +464,13 @@ function checkGuards(cwd: string): DoctorCheck[] {
       checks.push({
         name: 'guards',
         status: 'ok',
-        message: `${installedCount} of ${totalGuards} guard hooks installed — run \`slope hook add --level=full\` to install the rest`,
+        message: `${installedCount} of ${totalGuards} guard hooks installed${stateNote(cwd, originalCwd)} — run \`slope hook add --level=full\` to install the rest`,
       });
     } else {
       checks.push({
         name: 'guards',
         status: 'ok',
-        message: `${installedCount} of ${totalGuards} guard hooks installed`,
+        message: `${installedCount} of ${totalGuards} guard hooks installed${stateNote(cwd, originalCwd)}`,
       });
     }
   } catch {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -791,6 +791,7 @@ export async function doctorCommand(args: string[]): Promise<void> {
   const cwd = process.cwd();
   let checks = runDoctorChecks(cwd);
   const shouldFix = args.includes('--fix');
+  const dryRun = args.includes('--dry-run');
 
   formatResults(checks);
 
@@ -798,6 +799,15 @@ export async function doctorCommand(args: string[]): Promise<void> {
     const fixable = checks.filter(c => (c.status === 'fail' || c.status === 'warn') && c.fixable);
     if (fixable.length === 0) {
       console.log('\n  Nothing to fix — all checks passed.');
+      return;
+    }
+
+    if (dryRun) {
+      console.log('\n  [dry-run] Fixes that would be applied:\n');
+      for (const check of fixable) {
+        console.log(`  [dry-run] ${check.name}: ${check.message}`);
+      }
+      console.log('\n  Re-run without --dry-run to apply fixes.');
       return;
     }
 

--- a/src/cli/guards/worktree-check.ts
+++ b/src/cli/guards/worktree-check.ts
@@ -138,5 +138,7 @@ function isWorktreeRecoveryInput(input: HookInput): boolean {
     ? input.tool_input.command.trim()
     : '';
 
-  return command === 'EnterWorktree' || /^git\s+worktree\s+add(?:\s|$)/.test(command);
+  return command === 'EnterWorktree'
+    || /^git\s+worktree\s+add(?:\s|$)/.test(command)
+    || /^git\s+-C\s+(?:"[^"]+"|'[^']+'|\S+)\s+worktree\s+add(?:\s|$)/.test(command);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -521,7 +521,7 @@ Usage:
   slope sprint start|gate|status|reset               Manage sprint lifecycle state
   slope worktree cleanup [--path|--all] [--dry-run]  Clean up stale worktrees
   slope loop status|config|run|continuous|...        Autonomous sprint execution loop
-  slope doctor [--fix]                               Check repo health and fix issues
+  slope doctor [--fix] [--dry-run]                   Check repo health and fix issues
   slope version                                      Show current version
   slope version bump [<version>] [--dry-run]         Bump version, create PR, merge
 

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
 import { runDoctorChecks, runDoctorFixes } from '../../../src/cli/commands/doctor.js';
 import { SLOPE_BIN_PREAMBLE } from '../../../src/core/harness.js';
 
@@ -47,6 +48,34 @@ describe('doctor checks', () => {
 
   afterEach(() => {
     rmSync(cwd, { recursive: true, force: true });
+  });
+
+  describe('linked worktree state discovery', () => {
+    it('uses primary worktree .slope state when a linked worktree lacks local ignored state', () => {
+      setupSlopeDir(cwd);
+      writeFileSync(join(cwd, '.slope', 'slope.db'), '');
+      writeFileSync(join(cwd, 'README.md'), '# test repo\n');
+      execSync('git init', { cwd, stdio: 'ignore' });
+      execSync('git config user.email test@example.com', { cwd, stdio: 'ignore' });
+      execSync('git config user.name "Test User"', { cwd, stdio: 'ignore' });
+      execSync('git add .gitignore README.md docs/backlog/roadmap.json', { cwd, stdio: 'ignore' });
+      execSync('git commit -m init', { cwd, stdio: 'ignore' });
+
+      const linked = join(tmpdir(), `slope-doctor-linked-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      execSync(`git worktree add -b linked-state-test "${linked}"`, { cwd, stdio: 'ignore' });
+      try {
+        const checks = runDoctorChecks(linked);
+
+        expect(checks.find(c => c.name === 'worktree-state')?.message).toContain(cwd);
+        expect(checks.find(c => c.name === 'config')).toMatchObject({ status: 'ok' });
+        expect(checks.find(c => c.name === 'store')).toMatchObject({ status: 'ok' });
+        expect(checks.find(c => c.name === 'common-issues')).toMatchObject({ status: 'ok' });
+        expect(checks.find(c => c.name === 'version')?.message).not.toContain('missing');
+        expect(checks.find(c => c.name === 'guards')?.message).not.toContain('No hooks installed');
+      } finally {
+        execSync(`git worktree remove --force "${linked}"`, { cwd, stdio: 'ignore' });
+      }
+    });
   });
 
   // --- S65-1: version drift ---

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { runDoctorChecks, runDoctorFixes } from '../../../src/cli/commands/doctor.js';
+import { doctorCommand, runDoctorChecks, runDoctorFixes } from '../../../src/cli/commands/doctor.js';
 import { SLOPE_BIN_PREAMBLE } from '../../../src/core/harness.js';
 
 // Ensure metaphors are registered
@@ -47,6 +47,32 @@ describe('doctor checks', () => {
 
   afterEach(() => {
     rmSync(cwd, { recursive: true, force: true });
+  });
+
+  describe('doctor --fix --dry-run', () => {
+    it('previews fixable checks without writing changes', async () => {
+      setupSlopeDir(cwd);
+      const gitignorePath = join(cwd, '.gitignore');
+      const before = readFileSync(gitignorePath, 'utf8');
+      const logs: string[] = [];
+      const logSpy = vi.spyOn(console, 'log').mockImplementation((message = '') => {
+        logs.push(String(message));
+      });
+      const originalCwd = process.cwd();
+
+      try {
+        process.chdir(cwd);
+        await doctorCommand(['--fix', '--dry-run']);
+      } finally {
+        process.chdir(originalCwd);
+        logSpy.mockRestore();
+      }
+
+      expect(readFileSync(gitignorePath, 'utf8')).toBe(before);
+      expect(logs.join('\n')).toContain('[dry-run] Fixes that would be applied');
+      expect(logs.join('\n')).toContain('gitignore-noise');
+      expect(logs.join('\n')).not.toContain('Applying fixes');
+    });
   });
 
   // --- S65-1: version drift ---

--- a/tests/cli/guards/worktree-check.test.ts
+++ b/tests/cli/guards/worktree-check.test.ts
@@ -132,6 +132,17 @@ describe('worktreeCheckGuard', () => {
     expect(mockResolveStore).not.toHaveBeenCalled();
   });
 
+  it('allows git -C worktree add recovery commands', async () => {
+    const result = await worktreeCheckGuard({
+      ...makeInput(),
+      tool_name: 'Bash',
+      tool_input: { command: 'git -C /Users/sebastianbryers/Development/slope worktree add /tmp/slope-worktree HEAD' },
+    }, '/tmp/test');
+
+    expect(result).toEqual({});
+    expect(mockResolveStore).not.toHaveBeenCalled();
+  });
+
   it('allows when other session has worktree_path (isolated)', async () => {
     mockExecSync
       .mockReturnValueOnce('.git' as never)


### PR DESCRIPTION
## Summary
- incorporate PR #362 (`slope doctor --fix --dry-run` preview behavior)
- incorporate PR #363 (doctor state discovery from primary worktree)
- include the follow-up worktree guard recovery fix for `git -C <repo> worktree add ...`

## Validation
- `pnpm run typecheck`
- `pnpm vitest run tests/cli/commands/doctor.test.ts tests/cli/doctor.test.ts tests/cli/doctor-gitignore-noise.test.ts tests/cli/doctor-branch-hygiene.test.ts tests/cli/guards/worktree-check.test.ts`
- `pnpm test`

## Release intent
This prepares `main` for a GitHub Release of `v1.55.4`, which should trigger `.github/workflows/publish.yml` and publish `@slope-dev/slope@1.55.4` to npm.