### PR TITLE
fix(368): enforce claim guard for adhoc writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.55.4",
+  "version": "1.55.5",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -206,9 +206,11 @@ async function runGuardByName(
     input.hook_event_name = def.hookEvent;
   }
 
-  // Skip sprint-workflow guards in adhoc sessions
-  const relevance = GUARD_RELEVANCE[name];
-  if (relevance?.when === 'sprint-workflow' && input.session_id && isAdhocSession(cwd, input.session_id)) {
+  // Skip most sprint-workflow guards in adhoc sessions. Guards with
+  // suppressInAdhoc=false still run to steer implementation writes back into
+  // an explicit sprint/claim flow.
+  if (shouldSuppressGuardInAdhoc(name, cwd, input.session_id)) {
+    recordGuardSuppression(cwd, name, input, 'adhoc-session');
     return null;
   }
 
@@ -571,7 +573,13 @@ export async function guardManageCommand(args: string[]): Promise<void> {
 }
 
 /** Guard relevance metadata: when each guard is useful and why */
-const GUARD_RELEVANCE: Record<string, { when: string; why: string }> = {
+interface GuardRelevance {
+  when: string;
+  why: string;
+  suppressInAdhoc?: boolean;
+}
+
+const GUARD_RELEVANCE: Record<string, GuardRelevance> = {
   'explore': { when: 'always', why: 'Prevents unnecessary codebase exploration when map is available' },
   'hazard': { when: 'always', why: 'Warns about known issues before editing affected files' },
   'commit-nudge': { when: 'always', why: 'Prevents lost work from uncommitted changes' },
@@ -595,10 +603,20 @@ const GUARD_RELEVANCE: Record<string, { when: string; why: string }> = {
   'session-briefing': { when: 'always', why: 'Injects sprint context on session start for continuity' },
   'post-push': { when: 'sprint-workflow', why: 'Suggests next workflow step after pushing' },
   'phase-boundary': { when: 'sprint-workflow', why: 'Prevents starting new phase without cleanup' },
-  'claim-required': { when: 'sprint-workflow', why: 'Warns when editing without sprint claim' },
+  'claim-required': { when: 'sprint-workflow', why: 'Warns when editing without sprint claim', suppressInAdhoc: false },
   'review-stale': { when: 'sprint-workflow', why: 'Catches scored sprints missing reviews' },
   'workflow-step-gate': { when: 'sprint-workflow', why: 'Blocks file edits outside agent_work workflow steps' },
 };
+
+export function shouldSuppressGuardInAdhoc(name: string, cwd: string, sessionId: string): boolean {
+  const relevance = GUARD_RELEVANCE[name];
+  return Boolean(
+    relevance?.when === 'sprint-workflow' &&
+    relevance.suppressInAdhoc !== false &&
+    sessionId &&
+    isAdhocSession(cwd, sessionId),
+  );
+}
 
 /** Detect which workflow profiles apply to this repo */
 function detectWorkflowProfiles(cwd: string): Set<string> {
@@ -722,6 +740,21 @@ function recordGuardExecution(cwd: string, guardName: string, input: HookInput, 
       event: input.hook_event_name,
       tool: input.tool_name ?? '',
       decision,
+    });
+    appendFileSync(metricsPath, line + '\n');
+  } catch { /* never block guard execution */ }
+}
+
+function recordGuardSuppression(cwd: string, guardName: string, input: HookInput, reason: string): void {
+  try {
+    const metricsPath = join(cwd, '.slope', 'guard-metrics.jsonl');
+    const line = JSON.stringify({
+      ts: new Date().toISOString(),
+      guard: guardName,
+      event: input.hook_event_name,
+      tool: input.tool_name ?? '',
+      decision: 'suppressed',
+      reason,
     });
     appendFileSync(metricsPath, line + '\n');
   } catch { /* never block guard execution */ }

--- a/src/cli/guards/claim-required.ts
+++ b/src/cli/guards/claim-required.ts
@@ -5,6 +5,73 @@ import { loadSprintState } from '../sprint-state.js';
 import { loadSessionState, updateSessionState } from '../session-state.js';
 import { resolveStore } from '../store.js';
 
+const IMPLEMENTATION_DIRS = [
+  'app/',
+  'client/',
+  'components/',
+  'lib/',
+  'packages/',
+  'scripts/',
+  'server/',
+  'src/',
+  'templates/',
+  'tests/',
+  'workers/',
+];
+
+const NON_IMPLEMENTATION_DIRS = [
+  '.git/',
+  '.slope/',
+  'docs/retros/',
+  'node_modules/',
+];
+
+const IMPLEMENTATION_FILES = new Set([
+  'astro.config.mjs',
+  'package-lock.json',
+  'package.json',
+  'pnpm-lock.yaml',
+  'rollup.config.js',
+  'tsconfig.json',
+  'vite.config.ts',
+  'vitest.config.ts',
+  'webpack.config.js',
+  'yarn.lock',
+]);
+
+const IMPLEMENTATION_EXTENSIONS = new Set([
+  '.astro',
+  '.c',
+  '.cjs',
+  '.cpp',
+  '.cs',
+  '.css',
+  '.go',
+  '.h',
+  '.hpp',
+  '.html',
+  '.java',
+  '.js',
+  '.json',
+  '.jsx',
+  '.kt',
+  '.mjs',
+  '.php',
+  '.py',
+  '.rb',
+  '.rs',
+  '.scss',
+  '.sh',
+  '.svelte',
+  '.swift',
+  '.toml',
+  '.ts',
+  '.tsx',
+  '.vue',
+  '.yaml',
+  '.yml',
+]);
+
 /**
  * Claim-required guard: fires PreToolUse on Edit|Write.
  * Warns (not blocks) when editing code without an active sprint claim.
@@ -15,13 +82,13 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
   const sessionId = input.session_id;
   if (!sessionId) return {};
 
-  // Session dedup: warn once only
-  const sessionState = loadSessionState(cwd);
-  if (sessionState.claim_warned_session_id === sessionId) return {};
-
   // Check if there's an active sprint with claims
   const sprintState = loadSprintState(cwd);
   if (sprintState && sprintState.phase === 'implementing') {
+    // Session dedup for the advisory missing-claim warning only.
+    const sessionState = loadSessionState(cwd);
+    if (sessionState.claim_warned_session_id === sessionId) return {};
+
     // Active sprint in implementing phase — check for claims
     try {
       const claimsPath = join(cwd, '.slope', 'claims.json');
@@ -36,8 +103,18 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
       }
     } catch { /* claims unavailable */ }
   } else if (!sprintState) {
-    // No sprint state — adhoc work, no warning needed (#263)
-    return {};
+    const filePath = input.tool_input?.file_path as string | undefined;
+    const relativePath = normalizeHookPath(filePath, cwd);
+    if (!relativePath || !isImplementationWritePath(relativePath)) return {};
+
+    return {
+      decision: 'ask',
+      context: [
+        `SLOPE claim-required: ${relativePath} looks like an implementation edit, but there is no active sprint state.`,
+        'Start or resume a sprint and claim the work before editing, or get explicit user approval to continue as adhoc work.',
+        'Suggested commands: `slope sprint start --number=<N> --phase=implementing` then `slope claim --target=<path> --ticket=<ticket>`.',
+      ].join('\n'),
+    };
   } else {
     // Sprint exists but not in implementing phase — passthrough
     return {};
@@ -49,6 +126,31 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
   return {
     context: 'SLOPE: No active sprint claim. Consider running `slope claim` to track this work.',
   };
+}
+
+function normalizeHookPath(filePath: string | undefined, cwd: string): string | null {
+  if (!filePath) return null;
+  const normalizedCwd = cwd.replace(/\\/g, '/').replace(/\/$/, '');
+  const normalizedPath = filePath.replace(/\\/g, '/');
+  const relativePath = normalizedPath.startsWith(`${normalizedCwd}/`)
+    ? normalizedPath.slice(normalizedCwd.length + 1)
+    : normalizedPath;
+  return relativePath.replace(/^\.\//, '');
+}
+
+export function isImplementationWritePath(relativePath: string): boolean {
+  const path = relativePath.replace(/\\/g, '/').replace(/^\.\//, '');
+  if (!path || path.endsWith('/')) return false;
+  if (NON_IMPLEMENTATION_DIRS.some(dir => path.startsWith(dir))) return false;
+  if (path === 'README.md' || path.endsWith('.md')) return false;
+
+  const fileName = path.split('/').at(-1) ?? path;
+  if (IMPLEMENTATION_FILES.has(fileName)) return true;
+  if (IMPLEMENTATION_DIRS.some(dir => path.startsWith(dir))) return true;
+
+  const dotIndex = fileName.lastIndexOf('.');
+  if (dotIndex === -1) return false;
+  return IMPLEMENTATION_EXTENSIONS.has(fileName.slice(dotIndex));
 }
 
 /**

--- a/tests/cli/commands/guard.test.ts
+++ b/tests/cli/commands/guard.test.ts
@@ -9,7 +9,8 @@ import '../../../src/core/adapters/cursor.js';
 import '../../../src/core/adapters/windsurf.js';
 import '../../../src/core/adapters/generic.js';
 
-import { guardManageCommand } from '../../../src/cli/commands/guard.js';
+import { guardManageCommand, shouldSuppressGuardInAdhoc } from '../../../src/cli/commands/guard.js';
+import { setSessionMode } from '../../../src/cli/session-state.js';
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `slope-guard-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -84,5 +85,27 @@ describe('slope guard recommend (S65-3)', () => {
     const output = logSpy.mock.calls.map(c => c[0]).join('\n');
     // Guards with when:'always' should show YES
     expect(output).toContain('YES');
+  });
+});
+
+describe('adhoc guard suppression', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = makeTmpDir();
+    mkdirSync(join(cwd, '.slope'), { recursive: true });
+    setSessionMode(cwd, 'test-session', 'adhoc');
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('keeps most sprint workflow guards suppressed in adhoc sessions', () => {
+    expect(shouldSuppressGuardInAdhoc('workflow-step-gate', cwd, 'test-session')).toBe(true);
+  });
+
+  it('allows claim-required to run in adhoc sessions', () => {
+    expect(shouldSuppressGuardInAdhoc('claim-required', cwd, 'test-session')).toBe(false);
   });
 });

--- a/tests/cli/guards/claim-required.test.ts
+++ b/tests/cli/guards/claim-required.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from 'vitest';
-import { claimOverlapsPath } from '../../../src/cli/guards/claim-required.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  claimOverlapsPath,
+  claimRequiredGuard,
+  isImplementationWritePath,
+} from '../../../src/cli/guards/claim-required.js';
+import type { HookInput } from '../../../src/core/index.js';
+
+function makeInput(cwd: string, filePath: string): HookInput {
+  return {
+    session_id: 'test-session',
+    cwd,
+    hook_event_name: 'PreToolUse',
+    tool_name: 'apply_patch',
+    tool_input: { file_path: filePath },
+  };
+}
 
 describe('claimOverlapsPath', () => {
   describe('area scope', () => {
@@ -46,5 +64,47 @@ describe('claimOverlapsPath', () => {
     it('does NOT match a prefix-only path', () => {
       expect(claimOverlapsPath('file', 'src/core/mem', 'src/core/memory.ts', 'src/core')).toBe(false);
     });
+  });
+});
+
+describe('isImplementationWritePath', () => {
+  it('matches common implementation paths', () => {
+    expect(isImplementationWritePath('src/core/index.ts')).toBe(true);
+    expect(isImplementationWritePath('packages/app/config.json')).toBe(true);
+    expect(isImplementationWritePath('data/recipes.json')).toBe(true);
+    expect(isImplementationWritePath('package.json')).toBe(true);
+  });
+
+  it('ignores docs, SLOPE state, and dependency directories', () => {
+    expect(isImplementationWritePath('README.md')).toBe(false);
+    expect(isImplementationWritePath('docs/retros/sprint-1.json')).toBe(false);
+    expect(isImplementationWritePath('.slope/sprint-state.json')).toBe(false);
+    expect(isImplementationWritePath('node_modules/pkg/index.js')).toBe(false);
+  });
+});
+
+describe('claimRequiredGuard', () => {
+  it('asks before implementation writes when no sprint state is active', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
+    try {
+      const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+
+      expect(result.decision).toBe('ask');
+      expect(result.context).toContain('no active sprint state');
+      expect(result.context).toContain('slope sprint start');
+      expect(result.context).toContain('slope claim');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not interrupt non-implementation writes when no sprint state is active', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
+    try {
+      const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'README.md')), cwd);
+      expect(result).toEqual({});
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- let claim-required run in adhoc sessions for implementation writes with no active sprint
- record suppressed adhoc workflow guards in metrics
- bump package version to 1.55.5 for patch release

Fixes #368

## Verification
- pnpm vitest run tests/cli/guards/claim-required.test.ts tests/cli/commands/guard.test.ts
- pnpm exec tsc --noEmit
- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sprint-workflow guards are now suppressed during adhoc sessions with detailed logging for enhanced visibility.

* **Bug Fixes**
  * Enhanced claim-required guard to provide better guidance when implementation edits occur outside active sprints.
  * Improved decision logic for sprint phase detection and cross-session validation.

* **Chores**
  * Version bumped to 1.55.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->