### PR TITLE
[codex] harden guard enforcement workflow coverage

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"027cf01e-bc2d-42af-9189-68d16403a486","pid":37176,"procStart":"Thu May  7 17:52:58 2026","acquiredAt":1778201820882}

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -109,8 +109,16 @@
       "sprints": [
         93
       ],
-      "status": "planned",
+      "status": "complete",
       "note": "Recover Codex hook support after validating current Codex CLI hook docs and local 0.130 behavior."
+    },
+    {
+      "name": "Phase 23 \u2014 Guard Enforcement Hardening",
+      "sprints": [
+        94
+      ],
+      "status": "planned",
+      "note": "Close the remaining enforcement/diagnostic gaps exposed by #368: full dispatcher coverage, Codex matcher coverage, stale runtime detection, and configurable strictness for implementation writes outside sprint state."
     }
   ],
   "sprints": [
@@ -1268,7 +1276,7 @@
       "par": 4,
       "slope": 2,
       "type": "bug fix + dx",
-      "status": "planned",
+      "status": "complete",
       "depends_on": [
         92
       ],
@@ -1306,6 +1314,51 @@
           "depends_on": [
             "S93-2",
             "S93-3"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 94,
+      "theme": "Guard Enforcement Hardening \u2014 make workflow-control guards provable",
+      "par": 4,
+      "slope": 2,
+      "type": "hardening + dx",
+      "status": "planned",
+      "depends_on": [
+        93
+      ],
+      "note": "Follow-up to #368 and v1.55.5. The patch fixed the immediate no-sprint adhoc write gap; S94 expands coverage to the full dispatcher/runtime path and makes strictness/diagnostics explicit.",
+      "tickets": [
+        {
+          "key": "S94-1",
+          "title": "Dispatcher-level regression tests for adhoc claim-required and suppressed workflow guards",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 368
+        },
+        {
+          "key": "S94-2",
+          "title": "Codex matcher coverage for claim-required under apply_patch/Edit/Write installs",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 368
+        },
+        {
+          "key": "S94-3",
+          "title": "Doctor diagnostics for stale hook runtime resolution and local binary precedence",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 368
+        },
+        {
+          "key": "S94-4",
+          "title": "Configurable implementation-write strictness and non-implementing phase behavior",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 368,
+          "depends_on": [
+            "S94-1"
           ]
         }
       ]

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -1360,6 +1360,13 @@
           "depends_on": [
             "S94-1"
           ]
+        },
+        {
+          "key": "S94-5",
+          "title": "Transport-independent post-PR review workflow",
+          "club": "wedge",
+          "complexity": "small",
+          "note": "Close the connector-created PR gap where pr-review cannot fire because no Bash gh pr create hook event exists."
         }
       ]
     }

--- a/docs/backlog/sprint-94-plan.md
+++ b/docs/backlog/sprint-94-plan.md
@@ -111,6 +111,28 @@ This is enough for the emergency patch, but not enough for a mature workflow-con
 - Tests cover no sprint, planning/reviewing/scoring phases, and implementing phase.
 - Strict mode produces a block/deny output with actionable recovery commands.
 
+### S94-5: Transport-independent post-PR review workflow
+
+**Club:** wedge
+**Files:**
+- `src/cli/commands/pr.ts`
+- `src/cli/guards/pr-review.ts`
+- `src/cli/guards/docs.ts`
+- `tests/cli/pr-finalize.test.ts`
+- `tests/cli/guards/pr-review-recommend.test.ts`
+
+**Scope:**
+
+1. Add an explicit post-PR command agents can run after any PR creation transport, including GitHub MCP connector/API flows that do not trigger Bash hooks.
+2. Keep the existing `gh pr create` guard path, but have it point to the transport-independent command.
+3. Reuse the existing `slope review run` prompt generator so the new command does not fork review semantics.
+4. Compute recommendations from PR diff files plus sprint scorecard signals where available.
+
+**Acceptance:**
+- `slope pr review --pr=<N> --sprint=<N>` prints recommendations and review prompts.
+- `slope pr review --json` delegates to `slope review run --json` for agent consumption.
+- Tests cover the default review type and the `pr-review` guard handoff text.
+
 ---
 
 ## Verification

--- a/docs/backlog/sprint-94-plan.md
+++ b/docs/backlog/sprint-94-plan.md
@@ -1,0 +1,138 @@
+# Sprint 94 Plan - Guard Enforcement Hardening
+
+**Par:** 4 (4 tickets)
+**Slope:** 2 (guard dispatcher/runtime behavior, Codex hook coverage, doctor diagnostics, config semantics)
+**Theme:** Turn the #368 patch into a provable guard-enforcement contract.
+**Branch:** create `hardening/s94-guard-enforcement` before implementation.
+
+---
+
+## Context
+
+S93 restored Codex hook loading and v1.55.5 fixed the immediate #368 failure:
+
+- `claim-required` now runs in `adhoc` sessions for implementation writes with no active sprint.
+- The no-sprint implementation path returns `permissionDecision: "ask"` with sprint/claim guidance.
+- Most other sprint-workflow guards still suppress in `adhoc`, but now write `decision: "suppressed"` metrics.
+- Published package `@slope-dev/slope@1.55.5` verifies the global dispatcher path.
+
+This is enough for the emergency patch, but not enough for a mature workflow-control guard. S94 hardens the full path agents actually hit: matcher install, CLI dispatcher, metrics, doctor diagnostics, and configurable strictness.
+
+---
+
+## Tickets
+
+### S94-1: Dispatcher-level regression tests for adhoc claim-required and suppressed workflow guards
+
+**Club:** short_iron
+**Files:**
+- `src/cli/commands/guard.ts`
+- `tests/cli/commands/guard.test.ts`
+- `tests/cli/guards/claim-required.test.ts`
+
+**Scope:**
+
+1. Add tests that exercise the real `guardCommand()` path with hook-style JSON input, not only helper functions.
+2. Verify `claim-required` in `session_mode: "adhoc"` + no sprint + implementation path emits `permissionDecision: "ask"`.
+3. Verify a suppressed sprint-workflow guard records `decision: "suppressed"` with `reason: "adhoc-session"`.
+4. Cover batch execution if the active hook install groups multiple write guards into one invocation.
+5. Keep tests isolated from the developer's real `.slope/` state and global Codex config.
+
+**Acceptance:**
+- Focused tests prove the CLI dispatcher output shape and metrics JSONL.
+- `pnpm vitest run tests/cli/commands/guard.test.ts tests/cli/guards/claim-required.test.ts`
+- `pnpm typecheck`
+
+### S94-2: Codex matcher coverage for claim-required under apply_patch/Edit/Write installs
+
+**Club:** wedge
+**Files:**
+- `src/core/adapters/codex.ts`
+- `tests/core/adapters/codex.test.ts`
+- `tests/cli/commands/hook-codex.test.ts`
+
+**Scope:**
+
+1. Assert `claim-required` is installed under the Codex write matcher group.
+2. Assert that group includes `apply_patch`, `Edit`, and `Write`.
+3. Verify full/recommended hook install keeps `claim-required` in Codex project and user scopes.
+4. Add a regression around grouped write guards so future matcher edits cannot drop workflow enforcement silently.
+
+**Acceptance:**
+- `pnpm vitest run tests/core/adapters/codex.test.ts tests/cli/commands/hook-codex.test.ts`
+- Generated `~/.codex/hooks.json` equivalent contains `claim-required` under `apply_patch|Edit|Write`.
+
+### S94-3: Doctor diagnostics for stale hook runtime resolution and local binary precedence
+
+**Club:** short_iron
+**Files:**
+- `src/cli/commands/doctor.ts`
+- `src/core/adapters/codex.ts`
+- `tests/cli/commands/doctor.test.ts`
+
+**Scope:**
+
+1. Teach doctor to explain the actual Codex dispatcher resolution order: project `node_modules/.bin/slope`, SLOPE dev repo `dist/cli/index.js`, then global `slope`.
+2. Warn when a user-level Codex dispatcher will resolve a project-local `@slope-dev/slope` version older than the global/current package.
+3. Warn when the current repo is the SLOPE dev checkout and `dist/cli/index.js` is stale relative to source or package version.
+4. Keep diagnostics advisory by default, with clear next steps:
+   - update project dependency
+   - run `pnpm build` in the SLOPE dev repo
+   - reinstall hooks if dispatcher shape is stale
+5. Avoid network calls in doctor; use local package files and command resolution only.
+
+**Acceptance:**
+- Doctor tests cover stale project-local package and stale SLOPE dev `dist`.
+- `slope doctor` output makes it obvious why a hook can appear installed but execute old guard behavior.
+
+### S94-4: Configurable implementation-write strictness and non-implementing phase behavior
+
+**Club:** short_iron
+**Files:**
+- `src/core/config.ts`
+- `src/core/guard.ts`
+- `src/cli/guards/claim-required.ts`
+- `tests/cli/guards/claim-required.test.ts`
+- docs touched only if config is exposed publicly
+
+**Scope:**
+
+1. Add an explicit config knob for no-sprint implementation writes, e.g. `guidance.requireSprintForImplementationWrites`.
+2. Supported behavior should be clear and testable:
+   - `ask` default: current v1.55.5 behavior
+   - `deny`: strict teams/repos block implementation edits until sprint/claim state exists
+   - `off`: preserve true adhoc mode for repos that intentionally do not use sprint workflow
+3. Decide and encode behavior for active sprint phases that are not `implementing`.
+4. Preserve the existing active-implementing/no-claim advisory path unless strict mode intentionally upgrades it.
+5. Document migration/default behavior so existing users are not surprised.
+
+**Acceptance:**
+- Tests cover default, strict, and off modes.
+- Tests cover no sprint, planning/reviewing/scoring phases, and implementing phase.
+- Strict mode produces a block/deny output with actionable recovery commands.
+
+---
+
+## Verification
+
+Run before closing the sprint:
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm test
+slope validate
+```
+
+Manual hook smoke:
+
+```bash
+slope version
+npm view @slope-dev/slope version
+CODEX_PROJECT_DIR="$(pwd)" ~/.codex/hooks/slope-guard.sh claim-required <<'JSON'
+{"session_id":"manual-s94","cwd":"/tmp/unused","hook_event_name":"PreToolUse","tool_name":"apply_patch","tool_input":{"file_path":"src/manual-smoke.ts"}}
+JSON
+tail -n 5 .slope/guard-metrics.jsonl
+```
+
+If testing inside this SLOPE checkout, run `pnpm build` first because the user-level Codex dispatcher intentionally prefers local `dist/cli/index.js` for SLOPE's own development repo.

--- a/docs/retros/sprint-94-review.md
+++ b/docs/retros/sprint-94-review.md
@@ -4,16 +4,16 @@
 
 | Metric | Value |
 |---|---|
-| Par | 4 |
+| Par | 5 |
 | Slope | 2 |
-| Score | 4 |
+| Score | 5 |
 | Label | Par |
-| Fairway % | 100% (4/4) |
-| GIR % | 100% (4/4) |
+| Fairway % | 100% (5/5) |
+| GIR % | 100% (5/5) |
 | Putts | 0 |
 | Penalties | 0 |
 
-### Shot-by-Shot (Tickets Delivered: 4)
+### Shot-by-Shot (Tickets Delivered: 5)
 
 | Ticket | Club | Result | Hazards | Notes |
 |---|---|---|---|---|
@@ -21,6 +21,7 @@
 | S94-2 | Wedge | In the Hole | — | Commit 1c5acc5 locks claim-required into Codex write matcher coverage for generated configs, project installs, and user installs. |
 | S94-3 | Short Iron | Green | Rough: Codex hook behavior can look current while resolving a stale project-local package or stale dev dist output. | Commit e803279 adds codex-runtime diagnostics for project-local package precedence and stale SLOPE dev dist output. |
 | S94-4 | Short Iron | Green | Rough: [code review] claim-required strictness config was exposed without guard docs coverage, and guard metadata still described the guard as purely advisory despite deny mode | Commit e0262ff adds guidance.requireSprintForImplementationWrites with ask, deny, and off modes. Commits 2f0c0f1 and 8a91f97 handled sprint scoping and stale Claude lock cleanup. |
+| S94-5 | Wedge | Green | — | Added slope pr review so agents can run post-PR recommendations and review prompts after gh, MCP connector, or API PR creation paths. |
 
 ### Conditions
 
@@ -55,6 +56,7 @@
 
 - Default no-sprint implementation writes ask for permission; strict mode denies; off mode allows outside-sprint implementation writes.
 - Active implementing sprints still preserve the existing missing-claim advisory by default, with strict mode upgrading that path to deny.
+- After any connector/API-created PR, run slope pr review --pr=<N> --sprint=<N> to get the same recommendation and prompt flow as gh pr create.
 - Full test suite passed after implementation: 199 test files, 3341 tests.
 
 ### 19th Hole

--- a/docs/retros/sprint-94-review.md
+++ b/docs/retros/sprint-94-review.md
@@ -20,7 +20,7 @@
 | S94-1 | Short Iron | Green | — | Commit 289714d covers real guardCommand stdin/stdout behavior, adhoc claim-required asks, suppressed workflow guard metrics, and batched write guard behavior. |
 | S94-2 | Wedge | In the Hole | — | Commit 1c5acc5 locks claim-required into Codex write matcher coverage for generated configs, project installs, and user installs. |
 | S94-3 | Short Iron | Green | Rough: Codex hook behavior can look current while resolving a stale project-local package or stale dev dist output. | Commit e803279 adds codex-runtime diagnostics for project-local package precedence and stale SLOPE dev dist output. |
-| S94-4 | Short Iron | Green | — | Commit e0262ff adds guidance.requireSprintForImplementationWrites with ask, deny, and off modes. Commits 2f0c0f1 and 8a91f97 handled sprint scoping and stale Claude lock cleanup. |
+| S94-4 | Short Iron | Green | Rough: [code review] claim-required strictness config was exposed without guard docs coverage, and guard metadata still described the guard as purely advisory despite deny mode | Commit e0262ff adds guidance.requireSprintForImplementationWrites with ask, deny, and off modes. Commits 2f0c0f1 and 8a91f97 handled sprint scoping and stale Claude lock cleanup. |
 
 ### Conditions
 
@@ -34,6 +34,7 @@
 | Type | Ticket | Description |
 |---|---|---|
 | Rough | S94-3 | Codex hook behavior can look current while resolving a stale project-local package or stale dev dist output. |
+| Rough | S94-4 | [code review] claim-required strictness config was exposed without guard docs coverage, and guard metadata still described the guard as purely advisory despite deny mode |
 
 **Known hazards for future sprints:**
 - Codex runtime resolution can prefer project-local node_modules/.bin/slope or SLOPE dev dist/cli/index.js before the global package.

--- a/docs/retros/sprint-94-review.md
+++ b/docs/retros/sprint-94-review.md
@@ -1,0 +1,64 @@
+## Sprint 94 Review: Guard Enforcement Hardening
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 2 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (4/4) |
+| GIR % | 100% (4/4) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 4)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S94-1 | Short Iron | Green | — | Commit 289714d covers real guardCommand stdin/stdout behavior, adhoc claim-required asks, suppressed workflow guard metrics, and batched write guard behavior. |
+| S94-2 | Wedge | In the Hole | — | Commit 1c5acc5 locks claim-required into Codex write matcher coverage for generated configs, project installs, and user installs. |
+| S94-3 | Short Iron | Green | Rough: Codex hook behavior can look current while resolving a stale project-local package or stale dev dist output. | Commit e803279 adds codex-runtime diagnostics for project-local package precedence and stale SLOPE dev dist output. |
+| S94-4 | Short Iron | Green | — | Commit e0262ff adds guidance.requireSprintForImplementationWrites with ask, deny, and off modes. Commits 2f0c0f1 and 8a91f97 handled sprint scoping and stale Claude lock cleanup. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| Wind | moderate | The #368 emergency patch fixed the immediate no-sprint gap, but the larger guard contract needed coverage at the dispatcher, install, runtime, and config layers. |
+| Pin Position | minor | The default behavior had to stay advisory enough for adhoc work while allowing strict repos to deny implementation writes outside sprint or claim flow. |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Rough | S94-3 | Codex hook behavior can look current while resolving a stale project-local package or stale dev dist output. |
+
+**Known hazards for future sprints:**
+- Codex runtime resolution can prefer project-local node_modules/.bin/slope or SLOPE dev dist/cli/index.js before the global package.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Guard fixes need tests through the installed harness path, not only the guard helper function. | Added dispatcher-level and Codex install coverage so matcher or batch suppression regressions fail in tests. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| cleanup | healthy | Removed the stale .claude/scheduled_tasks.lock file requested at sprint start. |
+
+### Course Management Notes
+
+- Default no-sprint implementation writes ask for permission; strict mode denies; off mode allows outside-sprint implementation writes.
+- Active implementing sprints still preserve the existing missing-claim advisory by default, with strict mode upgrading that path to deny.
+- Full test suite passed after implementation: 199 test files, 3341 tests.
+
+### 19th Hole
+
+- **How did it feel?** A focused hardening sprint: small surface area, but the important path spans dispatcher output, installed matchers, runtime resolution, and config semantics.
+- **Advice for next player?** When changing a workflow-control guard, add coverage for helper behavior, CLI dispatcher output, installed hook matchers, and the runtime binary that the hook will actually execute.
+- **What surprised you?** The local auto-card path did not recognize the in-branch S94 roadmap entry and initially over-scanned history, so the reviewed scorecard needed manual correction.
+- **Excited about next?** Use the new strictness knob in a real repo and decide whether SLOPE itself should default to ask or deny for source writes without claims.

--- a/docs/retros/sprint-94.json
+++ b/docs/retros/sprint-94.json
@@ -1,0 +1,114 @@
+{
+  "sprint_number": 94,
+  "theme": "Guard Enforcement Hardening",
+  "type": "hardening + dx",
+  "player": "codex",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-16",
+  "shots": [
+    {
+      "ticket_key": "S94-1",
+      "title": "Dispatcher-level regression tests for adhoc claim-required and suppressed workflow guards",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Commit 289714d covers real guardCommand stdin/stdout behavior, adhoc claim-required asks, suppressed workflow guard metrics, and batched write guard behavior."
+    },
+    {
+      "ticket_key": "S94-2",
+      "title": "Codex matcher coverage for claim-required under apply_patch/Edit/Write installs",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Commit 1c5acc5 locks claim-required into Codex write matcher coverage for generated configs, project installs, and user installs."
+    },
+    {
+      "ticket_key": "S94-3",
+      "title": "Doctor diagnostics for stale hook runtime resolution and local binary precedence",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Codex hook behavior can look current while resolving a stale project-local package or stale dev dist output."
+        }
+      ],
+      "notes": "Commit e803279 adds codex-runtime diagnostics for project-local package precedence and stale SLOPE dev dist output."
+    },
+    {
+      "ticket_key": "S94-4",
+      "title": "Configurable implementation-write strictness and non-implementing phase behavior",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Commit e0262ff adds guidance.requireSprintForImplementationWrites with ask, deny, and off modes. Commits 2f0c0f1 and 8a91f97 handled sprint scoping and stale Claude lock cleanup."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "wind",
+      "description": "The #368 emergency patch fixed the immediate no-sprint gap, but the larger guard contract needed coverage at the dispatcher, install, runtime, and config layers.",
+      "impact": "moderate"
+    },
+    {
+      "type": "pin_position",
+      "description": "The default behavior had to stay advisory enough for adhoc work while allowing strict repos to deny implementation writes outside sprint or claim flow.",
+      "impact": "minor"
+    }
+  ],
+  "special_plays": [],
+  "bunker_locations": [
+    "Codex runtime resolution can prefer project-local node_modules/.bin/slope or SLOPE dev dist/cli/index.js before the global package."
+  ],
+  "yardage_book_updates": [
+    "tests/cli/commands/guard.test.ts now exercises the real guard dispatcher with hook-style JSON input and metrics assertions.",
+    "tests/core/adapters/codex.test.ts and tests/cli/commands/hook-codex.test.ts now lock claim-required under Codex apply_patch/Edit/Write matchers.",
+    "src/cli/commands/doctor.ts now reports codex-runtime resolution order and stale runtime warnings.",
+    "src/cli/guards/claim-required.ts now supports guidance.requireSprintForImplementationWrites policies."
+  ],
+  "course_management_notes": [
+    "Default no-sprint implementation writes ask for permission; strict mode denies; off mode allows outside-sprint implementation writes.",
+    "Active implementing sprints still preserve the existing missing-claim advisory by default, with strict mode upgrading that path to deny.",
+    "Full test suite passed after implementation: 199 test files, 3341 tests."
+  ],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Guard fixes need tests through the installed harness path, not only the guard helper function.",
+      "outcome": "Added dispatcher-level and Codex install coverage so matcher or batch suppression regressions fail in tests."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "cleanup",
+      "description": "Removed the stale .claude/scheduled_tasks.lock file requested at sprint start.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A focused hardening sprint: small surface area, but the important path spans dispatcher output, installed matchers, runtime resolution, and config semantics.",
+    "advice_for_next_player": "When changing a workflow-control guard, add coverage for helper behavior, CLI dispatcher output, installed hook matchers, and the runtime binary that the hook will actually execute.",
+    "what_surprised_you": "The local auto-card path did not recognize the in-branch S94 roadmap entry and initially over-scanned history, so the reviewed scorecard needed manual correction.",
+    "excited_about_next": "Use the new strictness knob in a real repo and decide whether SLOPE itself should default to ask or deny for source writes without claims."
+  }
+}

--- a/docs/retros/sprint-94.json
+++ b/docs/retros/sprint-94.json
@@ -2,9 +2,9 @@
   "sprint_number": 94,
   "player": "codex",
   "theme": "Guard Enforcement Hardening",
-  "par": 4,
+  "par": 5,
   "slope": 2,
-  "score": 4,
+  "score": 5,
   "score_label": "par",
   "date": "2026-05-16",
   "shots": [
@@ -52,13 +52,21 @@
         }
       ],
       "notes": "Commit e0262ff adds guidance.requireSprintForImplementationWrites with ask, deny, and off modes. Commits 2f0c0f1 and 8a91f97 handled sprint scoping and stale Claude lock cleanup."
+    },
+    {
+      "ticket_key": "S94-5",
+      "title": "Transport-independent post-PR review workflow",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [],
+      "notes": "Added slope pr review so agents can run post-PR recommendations and review prompts after gh, MCP connector, or API PR creation paths."
     }
   ],
   "stats": {
-    "fairways_hit": 4,
-    "fairways_total": 4,
-    "greens_in_regulation": 4,
-    "greens_total": 4,
+    "fairways_hit": 5,
+    "fairways_total": 5,
+    "greens_in_regulation": 5,
+    "greens_total": 5,
     "putts": 0,
     "penalties": 0,
     "hazards_hit": 2,
@@ -111,11 +119,13 @@
     "tests/cli/commands/guard.test.ts now exercises the real guard dispatcher with hook-style JSON input and metrics assertions.",
     "tests/core/adapters/codex.test.ts and tests/cli/commands/hook-codex.test.ts now lock claim-required under Codex apply_patch/Edit/Write matchers.",
     "src/cli/commands/doctor.ts now reports codex-runtime resolution order and stale runtime warnings.",
-    "src/cli/guards/claim-required.ts now supports guidance.requireSprintForImplementationWrites policies."
+    "src/cli/guards/claim-required.ts now supports guidance.requireSprintForImplementationWrites policies.",
+    "src/cli/commands/pr.ts now exposes slope pr review for connector/API PR creation paths that do not trigger the Bash pr-review guard."
   ],
   "course_management_notes": [
     "Default no-sprint implementation writes ask for permission; strict mode denies; off mode allows outside-sprint implementation writes.",
     "Active implementing sprints still preserve the existing missing-claim advisory by default, with strict mode upgrading that path to deny.",
+    "After any connector/API-created PR, run slope pr review --pr=<N> --sprint=<N> to get the same recommendation and prompt flow as gh pr create.",
     "Full test suite passed after implementation: 199 test files, 3341 tests."
   ]
 }

--- a/docs/retros/sprint-94.json
+++ b/docs/retros/sprint-94.json
@@ -1,8 +1,7 @@
 {
   "sprint_number": 94,
-  "theme": "Guard Enforcement Hardening",
-  "type": "hardening + dx",
   "player": "codex",
+  "theme": "Guard Enforcement Hardening",
   "par": 4,
   "slope": 2,
   "score": 4,
@@ -44,7 +43,14 @@
       "title": "Configurable implementation-write strictness and non-implementing phase behavior",
       "club": "short_iron",
       "result": "green",
-      "hazards": [],
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "[code review] claim-required strictness config was exposed without guard docs coverage, and guard metadata still described the guard as purely advisory despite deny mode",
+          "gotcha_id": "review:code"
+        }
+      ],
       "notes": "Commit e0262ff adds guidance.requireSprintForImplementationWrites with ask, deny, and off modes. Commits 2f0c0f1 and 8a91f97 handled sprint scoping and stale Claude lock cleanup."
     }
   ],
@@ -55,7 +61,7 @@
     "greens_total": 4,
     "putts": 0,
     "penalties": 0,
-    "hazards_hit": 1,
+    "hazards_hit": 2,
     "hazard_penalties": 0,
     "miss_directions": {
       "long": 0,
@@ -64,6 +70,7 @@
       "right": 0
     }
   },
+  "type": "hardening + dx",
   "conditions": [
     {
       "type": "wind",
@@ -77,20 +84,6 @@
     }
   ],
   "special_plays": [],
-  "bunker_locations": [
-    "Codex runtime resolution can prefer project-local node_modules/.bin/slope or SLOPE dev dist/cli/index.js before the global package."
-  ],
-  "yardage_book_updates": [
-    "tests/cli/commands/guard.test.ts now exercises the real guard dispatcher with hook-style JSON input and metrics assertions.",
-    "tests/core/adapters/codex.test.ts and tests/cli/commands/hook-codex.test.ts now lock claim-required under Codex apply_patch/Edit/Write matchers.",
-    "src/cli/commands/doctor.ts now reports codex-runtime resolution order and stale runtime warnings.",
-    "src/cli/guards/claim-required.ts now supports guidance.requireSprintForImplementationWrites policies."
-  ],
-  "course_management_notes": [
-    "Default no-sprint implementation writes ask for permission; strict mode denies; off mode allows outside-sprint implementation writes.",
-    "Active implementing sprints still preserve the existing missing-claim advisory by default, with strict mode upgrading that path to deny.",
-    "Full test suite passed after implementation: 199 test files, 3341 tests."
-  ],
   "training": [
     {
       "type": "lessons",
@@ -110,5 +103,19 @@
     "advice_for_next_player": "When changing a workflow-control guard, add coverage for helper behavior, CLI dispatcher output, installed hook matchers, and the runtime binary that the hook will actually execute.",
     "what_surprised_you": "The local auto-card path did not recognize the in-branch S94 roadmap entry and initially over-scanned history, so the reviewed scorecard needed manual correction.",
     "excited_about_next": "Use the new strictness knob in a real repo and decide whether SLOPE itself should default to ask or deny for source writes without claims."
-  }
+  },
+  "bunker_locations": [
+    "Codex runtime resolution can prefer project-local node_modules/.bin/slope or SLOPE dev dist/cli/index.js before the global package."
+  ],
+  "yardage_book_updates": [
+    "tests/cli/commands/guard.test.ts now exercises the real guard dispatcher with hook-style JSON input and metrics assertions.",
+    "tests/core/adapters/codex.test.ts and tests/cli/commands/hook-codex.test.ts now lock claim-required under Codex apply_patch/Edit/Write matchers.",
+    "src/cli/commands/doctor.ts now reports codex-runtime resolution order and stale runtime warnings.",
+    "src/cli/guards/claim-required.ts now supports guidance.requireSprintForImplementationWrites policies."
+  ],
+  "course_management_notes": [
+    "Default no-sprint implementation writes ask for permission; strict mode denies; off mode allows outside-sprint implementation writes.",
+    "Active implementing sprints still preserve the existing missing-claim advisory by default, with strict mode upgrading that path to deny.",
+    "Full test suite passed after implementation: 199 test files, 3341 tests."
+  ]
 }

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, readdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -473,11 +473,16 @@ function checkCodexHooks(cwd: string): DoctorCheck[] {
   const checks: DoctorCheck[] = [];
   const projectHooksPath = join(cwd, '.codex', 'hooks.json');
   const userHooksPath = join(homedir(), '.codex', 'hooks.json');
+  const hasProjectSlopeHooks = existsSync(projectHooksPath) && fileHasSlopeHooks(projectHooksPath);
+  const hasUserSlopeHooks = existsSync(userHooksPath) && fileHasSlopeHooks(userHooksPath);
 
   if (existsSync(projectHooksPath)) {
     checks.push(...checkCodexHooksFile(projectHooksPath, 'project'));
   }
-  if (existsSync(projectHooksPath) && existsSync(userHooksPath) && fileHasSlopeHooks(projectHooksPath) && fileHasSlopeHooks(userHooksPath)) {
+  if (hasProjectSlopeHooks || hasUserSlopeHooks || existsSync(join(cwd, '.codex'))) {
+    checks.push(...checkCodexRuntimeResolution(cwd));
+  }
+  if (hasProjectSlopeHooks && hasUserSlopeHooks) {
     checks.push({
       name: 'codex-hooks',
       status: 'warn',
@@ -487,6 +492,97 @@ function checkCodexHooks(cwd: string): DoctorCheck[] {
   }
 
   return checks;
+}
+
+function checkCodexRuntimeResolution(cwd: string): DoctorCheck[] {
+  const checks: DoctorCheck[] = [{
+    name: 'codex-runtime',
+    status: 'ok',
+    message: 'Codex dispatcher resolution: project node_modules/.bin/slope → SLOPE dev dist/cli/index.js → global slope',
+  }];
+
+  const currentVersion = getPackageVersion();
+  const localPackagePath = join(cwd, 'node_modules', '@slope-dev', 'slope', 'package.json');
+  if (existsSync(localPackagePath)) {
+    try {
+      const localPkg = JSON.parse(readFileSync(localPackagePath, 'utf8'));
+      const localVersion = typeof localPkg.version === 'string' ? localPkg.version : null;
+      if (localVersion && compareSemver(localVersion, currentVersion) < 0) {
+        checks.push({
+          name: 'codex-runtime',
+          status: 'warn',
+          message: `Codex hooks will prefer project-local @slope-dev/slope ${localVersion} before global/current ${currentVersion} — update the project dependency or remove the stale local install`,
+          fixable: false,
+        });
+      }
+    } catch {
+      checks.push({
+        name: 'codex-runtime',
+        status: 'warn',
+        message: 'Codex hooks will prefer project-local node_modules/.bin/slope, but node_modules/@slope-dev/slope/package.json is unreadable',
+        fixable: false,
+      });
+    }
+  }
+
+  const packagePath = join(cwd, 'package.json');
+  const distCliPath = join(cwd, 'dist', 'cli', 'index.js');
+  if (existsSync(packagePath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+      if (pkg.name === '@slope-dev/slope') {
+        if (!existsSync(distCliPath)) {
+          checks.push({
+            name: 'codex-runtime',
+            status: 'warn',
+            message: 'Codex hooks in the SLOPE dev repo prefer dist/cli/index.js, but it is missing — run `pnpm build`',
+            fixable: false,
+          });
+        } else {
+          const newestSourceMtime = newestMtime(join(cwd, 'src'));
+          const distMtime = statSync(distCliPath).mtimeMs;
+          if (newestSourceMtime > distMtime) {
+            checks.push({
+              name: 'codex-runtime',
+              status: 'warn',
+              message: 'Codex hooks in the SLOPE dev repo prefer dist/cli/index.js, but src/ is newer — run `pnpm build` before relying on hooks',
+              fixable: false,
+            });
+          }
+        }
+      }
+    } catch { /* package.json diagnostics are handled elsewhere */ }
+  }
+
+  return checks;
+}
+
+function compareSemver(a: string, b: string): number {
+  const aParts = a.split('.').map(part => Number.parseInt(part, 10) || 0);
+  const bParts = b.split('.').map(part => Number.parseInt(part, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const delta = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    if (delta !== 0) return delta;
+  }
+  return 0;
+}
+
+function newestMtime(path: string): number {
+  if (!existsSync(path)) return 0;
+  const stat = statSync(path);
+  if (!stat.isDirectory()) return stat.mtimeMs;
+
+  let newest = stat.mtimeMs;
+  for (const entry of readdirSync(path)) {
+    const childPath = join(path, entry);
+    const childStat = statSync(childPath);
+    if (childStat.isDirectory()) {
+      newest = Math.max(newest, newestMtime(childPath));
+    } else {
+      newest = Math.max(newest, childStat.mtimeMs);
+    }
+  }
+  return newest;
 }
 
 function checkCodexHooksFile(filePath: string, label: string): DoctorCheck[] {

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -1,4 +1,9 @@
 import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { detectLatestSprint, loadConfig, normalizeScorecard, recommendReviews } from '../../core/index.js';
+import type { ReviewRecommendation } from '../../core/index.js';
+import { reviewRunCommand } from './review-run.js';
 
 /**
  * `slope pr ...` — agent-friendly PR helpers.
@@ -8,6 +13,8 @@ import { execSync } from 'node:child_process';
  *                                            body for any issue refs in commit
  *                                            messages that GitHub's auto-close
  *                                            parser would otherwise miss (#321).
+ *   slope pr review [--pr=N] [--sprint=N]    Run the post-PR review workflow
+ *                                            for any PR creation transport.
  *   slope pr issues [--pr=N]                 Print extracted issue refs (helper).
  *
  * Background: commits like `fix: ... (GH #297, #299)` or `… closes #314` mix
@@ -22,6 +29,24 @@ interface FinalizeOptions {
   dryRun?: boolean;
 }
 
+interface PrReviewOptions {
+  pr?: number;
+  sprint?: number;
+  type?: 'architect' | 'code' | 'both';
+  json?: boolean;
+}
+
+interface PrReviewPlan {
+  pr: number;
+  sprint?: number;
+  ticketCount: number;
+  slope: number;
+  changedFiles: string[];
+  hasNewInfra: boolean;
+  recommendations: ReviewRecommendation[];
+  reviewType: 'architect' | 'code' | 'both';
+}
+
 export async function prCommand(args: string[]): Promise<void> {
   const sub = args[0];
 
@@ -32,6 +57,11 @@ export async function prCommand(args: string[]): Promise<void> {
 
   if (sub === 'finalize') {
     await finalizeSubcommand(args.slice(1));
+    return;
+  }
+
+  if (sub === 'review') {
+    await reviewSubcommand(args.slice(1));
     return;
   }
 
@@ -52,6 +82,9 @@ slope pr — Pull request helpers
 Usage:
   slope pr finalize [--pr=N] [--dry-run]   Inject Closes #N for issues referenced in commit
                                            messages but missing from PR body (#321).
+  slope pr review [--pr=N] [--sprint=N]    Run review recommendation + prompt generation
+                                           after PR creation, regardless of whether the
+                                           PR was created by gh, MCP, or another API.
   slope pr issues [--pr=N]                 Print extracted issue refs from the branch's
                                            commit messages.
 
@@ -69,12 +102,107 @@ function parseFlags(args: string[]): FinalizeOptions {
   return opts;
 }
 
+function parseReviewFlags(args: string[]): PrReviewOptions {
+  const opts: PrReviewOptions = {};
+  for (const a of args) {
+    if (a.startsWith('--pr=')) opts.pr = parseInt(a.slice('--pr='.length), 10);
+    else if (a.startsWith('--sprint=')) opts.sprint = parseInt(a.slice('--sprint='.length), 10);
+    else if (a.startsWith('--type=')) {
+      const type = a.slice('--type='.length);
+      if (type === 'architect' || type === 'code' || type === 'both') opts.type = type;
+    } else if (a === '--json') {
+      opts.json = true;
+    }
+  }
+  return opts;
+}
+
 function git(cmd: string): string {
   try {
     return execSync(`git ${cmd}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
   } catch {
     return '';
   }
+}
+
+function inferSprintNumber(explicit?: number): number | undefined {
+  if (explicit && !isNaN(explicit)) return explicit;
+  try {
+    const config = loadConfig();
+    return config.currentSprint ?? (detectLatestSprint(config, process.cwd()) || undefined);
+  } catch {
+    return undefined;
+  }
+}
+
+function loadSprintReviewSignals(sprint?: number): { ticketCount: number; slope: number } {
+  if (!sprint) return { ticketCount: 1, slope: 1 };
+  try {
+    const config = loadConfig();
+    const scorecardPath = join(process.cwd(), config.scorecardDir, `sprint-${sprint}.json`);
+    if (!existsSync(scorecardPath)) return { ticketCount: 1, slope: 1 };
+    const card = normalizeScorecard(JSON.parse(readFileSync(scorecardPath, 'utf8')));
+    return {
+      ticketCount: card.shots?.length ?? 1,
+      slope: card.slope ?? 1,
+    };
+  } catch {
+    return { ticketCount: 1, slope: 1 };
+  }
+}
+
+function changedFilesForPr(pr: number): string[] {
+  try {
+    const raw = gh(`pr diff ${pr} --name-only`);
+    return raw ? raw.split('\n').filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function defaultReviewType(_recommendations: ReviewRecommendation[]): 'architect' | 'code' | 'both' {
+  // Keep the transport-independent command aligned with `slope review run`,
+  // whose default is both. Recommendations are printed for prioritization,
+  // but the baseline code review remains useful for AI-authored diffs.
+  return 'both';
+}
+
+export function formatReviewRecommendations(recommendations: ReviewRecommendation[]): string {
+  if (recommendations.length === 0) return '  (none)';
+  return recommendations
+    .map((rec) => {
+      const type = rec.review_type.padEnd(14);
+      const priority = rec.priority.padEnd(13);
+      return `  ${type} ${priority} ${rec.reason}`;
+    })
+    .join('\n');
+}
+
+export async function planPrReview(opts: PrReviewOptions): Promise<PrReviewPlan | null> {
+  const pr = resolvePrNumber(opts);
+  if (!pr) return null;
+
+  const sprint = inferSprintNumber(opts.sprint);
+  const { ticketCount, slope } = loadSprintReviewSignals(sprint);
+  const changedFiles = changedFilesForPr(pr);
+  const hasNewInfra = changedFiles.some(p => /(\.sql|migration|schema|infra|terraform|k8s|deploy)/i.test(p));
+  const recommendations = recommendReviews({
+    ticketCount,
+    slope,
+    filePatterns: changedFiles,
+    hasNewInfra,
+  });
+
+  return {
+    pr,
+    sprint,
+    ticketCount,
+    slope,
+    changedFiles,
+    hasNewInfra,
+    recommendations,
+    reviewType: opts.type ?? defaultReviewType(recommendations),
+  };
 }
 
 /** Wrapper around `gh` CLI invocations. Throws a contextual error when gh
@@ -247,6 +375,34 @@ async function finalizeSubcommand(args: string[]): Promise<void> {
   // gh expects the body via --body — pass through stdin to avoid shell quoting hazards
   execSync(`gh pr edit ${plan.pr} --body-file -`, { input: newBody, encoding: 'utf8' });
   console.log(`\n  Updated PR #${plan.pr} body with ${plan.toAdd.length} Closes line(s).\n`);
+}
+
+async function reviewSubcommand(args: string[]): Promise<void> {
+  const opts = parseReviewFlags(args);
+  const plan = await planPrReview(opts);
+
+  if (!plan) {
+    console.error('\nCould not resolve PR — pass --pr=N or run from a branch with an open PR.\n');
+    process.exit(1);
+  }
+
+  const reviewArgs = [`--pr=${plan.pr}`, `--type=${plan.reviewType}`];
+  if (plan.sprint) reviewArgs.push(`--sprint=${plan.sprint}`);
+  if (opts.json) {
+    reviewArgs.push('--json');
+    await reviewRunCommand(reviewArgs);
+    return;
+  }
+
+  console.log(`\nPR #${plan.pr} review workflow${plan.sprint ? ` for Sprint ${plan.sprint}` : ''}`);
+  console.log(`Files changed: ${plan.changedFiles.length}`);
+  console.log(`Signals: ${plan.ticketCount} ticket${plan.ticketCount !== 1 ? 's' : ''}, slope ${plan.slope}${plan.hasNewInfra ? ', infrastructure/schema paths' : ''}`);
+  console.log('\nRecommended reviews:\n');
+  console.log('  Type           Priority      Reason');
+  console.log(formatReviewRecommendations(plan.recommendations));
+  console.log('\nReview prompts:\n');
+
+  await reviewRunCommand(reviewArgs);
 }
 
 async function issuesSubcommand(args: string[]): Promise<void> {

--- a/src/cli/guards/claim-required.ts
+++ b/src/cli/guards/claim-required.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import type { HookInput, GuardResult } from '../../core/index.js';
+import { loadConfig } from '../config.js';
 import { loadSprintState } from '../sprint-state.js';
 import { loadSessionState, updateSessionState } from '../session-state.js';
 import { resolveStore } from '../store.js';
@@ -72,6 +73,8 @@ const IMPLEMENTATION_EXTENSIONS = new Set([
   '.yml',
 ]);
 
+type ImplementationWritePolicy = 'ask' | 'deny' | 'off';
+
 /**
  * Claim-required guard: fires PreToolUse on Edit|Write.
  * Warns (not blocks) when editing code without an active sprint claim.
@@ -82,12 +85,16 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
   const sessionId = input.session_id;
   if (!sessionId) return {};
 
+  const policy = getImplementationWritePolicy(cwd);
+
   // Check if there's an active sprint with claims
   const sprintState = loadSprintState(cwd);
   if (sprintState && sprintState.phase === 'implementing') {
     // Session dedup for the advisory missing-claim warning only.
-    const sessionState = loadSessionState(cwd);
-    if (sessionState.claim_warned_session_id === sessionId) return {};
+    if (policy !== 'deny') {
+      const sessionState = loadSessionState(cwd);
+      if (sessionState.claim_warned_session_id === sessionId) return {};
+    }
 
     // Active sprint in implementing phase — check for claims
     try {
@@ -107,17 +114,31 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
     const relativePath = normalizeHookPath(filePath, cwd);
     if (!relativePath || !isImplementationWritePath(relativePath)) return {};
 
+    return implementationWritePolicyResult(policy, [
+      `SLOPE claim-required: ${relativePath} looks like an implementation edit, but there is no active sprint state.`,
+      'Start or resume a sprint and claim the work before editing, or get explicit user approval to continue as adhoc work.',
+      'Suggested commands: `slope sprint start --number=<N> --phase=implementing` then `slope claim --target=<path> --ticket=<ticket>`.',
+    ]);
+  } else {
+    const filePath = input.tool_input?.file_path as string | undefined;
+    const relativePath = normalizeHookPath(filePath, cwd);
+    if (!relativePath || !isImplementationWritePath(relativePath)) return {};
+
+    return implementationWritePolicyResult(policy, [
+      `SLOPE claim-required: ${relativePath} looks like an implementation edit, but sprint ${sprintState.sprint} is in ${sprintState.phase} phase.`,
+      'Implementation edits should happen during the implementing phase with a claim, or with explicit user approval to continue outside the sprint workflow.',
+      'Suggested command: `slope sprint start --number=<N> --phase=implementing` or update the current sprint phase before editing.',
+    ]);
+  }
+
+  if (policy === 'deny') {
     return {
-      decision: 'ask',
-      context: [
-        `SLOPE claim-required: ${relativePath} looks like an implementation edit, but there is no active sprint state.`,
-        'Start or resume a sprint and claim the work before editing, or get explicit user approval to continue as adhoc work.',
-        'Suggested commands: `slope sprint start --number=<N> --phase=implementing` then `slope claim --target=<path> --ticket=<ticket>`.',
+      decision: 'deny',
+      blockReason: [
+        'SLOPE claim-required: No active sprint claim for this implementation edit.',
+        'Run `slope claim --target=<path> --ticket=<ticket>` before editing, or set `guidance.requireSprintForImplementationWrites` to "ask" or "off".',
       ].join('\n'),
     };
-  } else {
-    // Sprint exists but not in implementing phase — passthrough
-    return {};
   }
 
   // Mark as warned
@@ -125,6 +146,28 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
 
   return {
     context: 'SLOPE: No active sprint claim. Consider running `slope claim` to track this work.',
+  };
+}
+
+function getImplementationWritePolicy(cwd: string): ImplementationWritePolicy {
+  const value = loadConfig(cwd).guidance?.requireSprintForImplementationWrites;
+  return value === 'deny' || value === 'off' || value === 'ask' ? value : 'ask';
+}
+
+function implementationWritePolicyResult(policy: ImplementationWritePolicy, lines: string[]): GuardResult {
+  if (policy === 'off') return {};
+  if (policy === 'deny') {
+    return {
+      decision: 'deny',
+      blockReason: [
+        ...lines,
+        'Strict mode is enabled by `guidance.requireSprintForImplementationWrites: "deny"`.',
+      ].join('\n'),
+    };
+  }
+  return {
+    decision: 'ask',
+    context: lines.join('\n'),
   };
 }
 

--- a/src/cli/guards/docs.ts
+++ b/src/cli/guards/docs.ts
@@ -108,7 +108,7 @@ export const GUARD_DOCS: Record<string, GuardDoc> = {
   'pr-review': {
     purpose: 'Prompts for the review workflow after PR creation. Ensures sprint review artifacts are created.',
     triggers: 'PostToolUse on Bash. Fires after a shell command completes (checks for `gh pr create`).',
-    behavior: 'Advisory — if the command created a PR, injects a reminder to run `slope review recommend` and create review artifacts.',
+    behavior: 'Advisory — if the command created a PR, injects a reminder to run `slope pr review --pr=<N>` and create review artifacts. For connector/API-created PRs where this Bash guard cannot fire, run the same command manually.',
     configuration: 'Disable: add "pr-review" to guidance.disabled.',
     level: 'full',
   },

--- a/src/cli/guards/docs.ts
+++ b/src/cli/guards/docs.ts
@@ -133,6 +133,13 @@ export const GUARD_DOCS: Record<string, GuardDoc> = {
     configuration: 'Disable: add "worktree-check" to guidance.disabled.',
     level: 'full',
   },
+  'claim-required': {
+    purpose: 'Keeps implementation edits connected to the sprint workflow. It catches code changes made with no active sprint state, outside the implementing phase, or without a matching claim.',
+    triggers: 'PreToolUse on Edit, Write, and Codex apply_patch. Fires when a file modification is attempted.',
+    behavior: 'Mixed — asks for permission by default on no-sprint or non-implementing implementation writes, warns by default for missing claims during implementing, and denies when strict mode is enabled.',
+    configuration: 'guidance.requireSprintForImplementationWrites controls implementation writes outside active sprint/claim flow: "ask" (default), "deny" (strict), or "off". Disable entirely: add "claim-required" to guidance.disabled.',
+    level: 'full',
+  },
   'sprint-completion': {
     purpose: 'Enforces sprint lifecycle gates. Blocks PR creation and session end when required gates (build, test, scorecard) are incomplete.',
     triggers: 'PreToolUse on Bash (blocks `gh pr create`), PostToolUse on Bash (auto-detects test pass), Stop (blocks session end).',

--- a/src/cli/guards/pr-review.ts
+++ b/src/cli/guards/pr-review.ts
@@ -22,9 +22,10 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
   // source of truth: it requires `https://github.com/` literally followed by
   // a path containing `/pull/<digits>`. If it matches, treat it as a real
   // PR URL; if not, the guard skips.
-  const urlMatch = response.match(/(https:\/\/github\.com\/[^\s]+\/pull\/\d+)/);
+  const urlMatch = response.match(/(https:\/\/github\.com\/[^\s]+\/pull\/(\d+))/);
   if (!urlMatch) return {};
   const prUrl = urlMatch[1];
+  const prNumber = urlMatch[2];
 
   const recs = computeRecommendations(cwd);
   const recLine = formatRecommendations(recs);
@@ -35,6 +36,7 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
     context: [
       `A pull request was just created (${prUrl}).`,
       ...(recLine ? [`Recommended reviews based on diff: ${recLine}`] : []),
+      `Run \`slope pr review --pr=${prNumber}\` to generate the transport-independent review workflow.`,
       `After the review, capture findings with \`slope review findings add\`, then \`slope review amend\` to apply to scorecard.`,
       'Tip: also run `slope pr finalize` to add Closes #N for any issues referenced in commits.',
     ].join(' '),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -476,6 +476,7 @@ Usage:
   slope review recommend                    Recommend review types for current sprint
   slope review findings add|list|clear      Manage implementation review findings
   slope review amend [--sprint=N]           Amend scorecard with review findings
+  slope pr review [--pr=N] [--sprint=N]     Run post-PR review workflow
   slope briefing [--sprint=N] [options]      Pre-round briefing
   slope plan --complexity=<level>           Pre-shot advisor (club + training + hazards)
   slope classify --scope=... ...            Classify a shot from execution trace

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -38,6 +38,7 @@ export interface SlopeConfig {
     protectedBranches?: string[];
     mapStaleWarnAt?: number;
     mapStaleBlockAt?: number;
+    requireSprintForImplementationWrites?: 'ask' | 'deny' | 'off';
   };
   orchestration?: {
     escalation?: EscalationConfig;

--- a/src/core/guard.ts
+++ b/src/core/guard.ts
@@ -372,12 +372,12 @@ export const GUARD_DEFINITIONS: GuardDefinition[] = [
   },
   {
     name: 'claim-required',
-    description: 'Warn when editing code without an active sprint claim',
+    description: 'Require sprint/claim workflow for implementation writes',
     hookEvent: 'PreToolUse',
     toolCategories: ['write_file'],
     matcher: 'Edit|Write',
     level: 'full',
-    guardType: 'advisory',
+    guardType: 'mixed',
   },
   {
     name: 'post-push',

--- a/src/core/guard.ts
+++ b/src/core/guard.ts
@@ -156,6 +156,8 @@ export interface GuidanceConfig {
   mapStaleWarnAt?: number;
   /** Commits behind before explore guard blocks Edit/Write (default 31) */
   mapStaleBlockAt?: number;
+  /** How claim-required handles implementation writes outside active sprint/claim flow (default ask) */
+  requireSprintForImplementationWrites?: 'ask' | 'deny' | 'off';
 }
 
 /** All guard definitions */

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { chmodSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, writeFileSync, rmSync, readFileSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
@@ -237,6 +237,71 @@ describe('doctor checks', () => {
       expect(config.custom).toBe(true);
       expect(config.hooks.PreToolUse).toHaveLength(1);
       expect(config.PreToolUse).toBeUndefined();
+    });
+
+    it('warns when Codex hooks will resolve a stale project-local slope package', () => {
+      setupSlopeDir(cwd);
+      mkdirSync(join(cwd, '.codex'), { recursive: true });
+      writeFileSync(join(cwd, '.codex', 'hooks.json'), JSON.stringify({
+        hooks: {
+          PreToolUse: [{
+            matcher: 'apply_patch',
+            hooks: [{ type: 'command', command: '"./.codex/hooks/slope-guard.sh" claim-required' }],
+          }],
+        },
+      }));
+      mkdirSync(join(cwd, 'node_modules', '@slope-dev', 'slope'), { recursive: true });
+      writeFileSync(join(cwd, 'node_modules', '@slope-dev', 'slope', 'package.json'), JSON.stringify({
+        name: '@slope-dev/slope',
+        version: '0.0.1',
+      }));
+
+      const checks = runDoctorChecks(cwd);
+      const runtimeCheck = checks.find(c =>
+        c.name === 'codex-runtime' &&
+        c.status === 'warn' &&
+        c.message.includes('project-local @slope-dev/slope 0.0.1'),
+      );
+
+      expect(runtimeCheck).toBeDefined();
+      expect(runtimeCheck!.message).toContain('before global/current');
+    });
+
+    it('warns when Codex hooks in the SLOPE dev repo would use stale dist output', () => {
+      setupSlopeDir(cwd);
+      mkdirSync(join(cwd, '.codex'), { recursive: true });
+      writeFileSync(join(cwd, '.codex', 'hooks.json'), JSON.stringify({
+        hooks: {
+          PreToolUse: [{
+            matcher: 'apply_patch',
+            hooks: [{ type: 'command', command: '"./.codex/hooks/slope-guard.sh" claim-required' }],
+          }],
+        },
+      }));
+      writeFileSync(join(cwd, 'package.json'), JSON.stringify({
+        name: '@slope-dev/slope',
+        version: '9.9.9',
+      }));
+      mkdirSync(join(cwd, 'src', 'cli', 'guards'), { recursive: true });
+      mkdirSync(join(cwd, 'dist', 'cli'), { recursive: true });
+      const distPath = join(cwd, 'dist', 'cli', 'index.js');
+      const sourcePath = join(cwd, 'src', 'cli', 'guards', 'claim-required.ts');
+      writeFileSync(distPath, '// old build\n');
+      writeFileSync(sourcePath, '// new source\n');
+      const oldDate = new Date('2024-01-01T00:00:00Z');
+      const newDate = new Date('2026-01-01T00:00:00Z');
+      utimesSync(distPath, oldDate, oldDate);
+      utimesSync(sourcePath, newDate, newDate);
+
+      const checks = runDoctorChecks(cwd);
+      const runtimeCheck = checks.find(c =>
+        c.name === 'codex-runtime' &&
+        c.status === 'warn' &&
+        c.message.includes('src/ is newer'),
+      );
+
+      expect(runtimeCheck).toBeDefined();
+      expect(runtimeCheck!.message).toContain('pnpm build');
     });
 
     it('detects non-executable Codex hook scripts', () => {

--- a/tests/cli/commands/guard.test.ts
+++ b/tests/cli/commands/guard.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { PassThrough } from 'node:stream';
+import type { HookInput } from '../../../src/core/index.js';
 
 // Ensure adapters are registered
 import '../../../src/core/adapters/claude-code.js';
@@ -9,13 +11,53 @@ import '../../../src/core/adapters/cursor.js';
 import '../../../src/core/adapters/windsurf.js';
 import '../../../src/core/adapters/generic.js';
 
-import { guardManageCommand, shouldSuppressGuardInAdhoc } from '../../../src/cli/commands/guard.js';
+import { guardCommand, guardManageCommand, shouldSuppressGuardInAdhoc } from '../../../src/cli/commands/guard.js';
 import { setSessionMode } from '../../../src/cli/session-state.js';
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `slope-guard-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(dir, { recursive: true });
   return dir;
+}
+
+function writeMinimalSlopeConfig(cwd: string): void {
+  mkdirSync(join(cwd, '.slope'), { recursive: true });
+  writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({
+    scorecardDir: 'docs/retros',
+    metaphor: 'golf',
+  }));
+}
+
+function makeHookInput(cwd: string, overrides: Partial<HookInput> = {}): HookInput {
+  return {
+    session_id: 'test-session',
+    cwd,
+    hook_event_name: 'PreToolUse',
+    tool_name: 'apply_patch',
+    tool_input: { file_path: join(cwd, 'src/example.ts') },
+    ...overrides,
+  };
+}
+
+async function runGuardCommandWithInput(args: string[], input: HookInput): Promise<string> {
+  const stdin = new PassThrough();
+  const originalStdin = process.stdin;
+  let output = '';
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    output += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  });
+
+  Object.defineProperty(process, 'stdin', { value: stdin, configurable: true });
+  try {
+    const command = guardCommand(args);
+    stdin.end(JSON.stringify(input));
+    await command;
+    return output;
+  } finally {
+    writeSpy.mockRestore();
+    Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
+  }
 }
 
 describe('slope guard recommend (S65-3)', () => {
@@ -30,12 +72,7 @@ describe('slope guard recommend (S65-3)', () => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    // Minimal .slope setup
-    mkdirSync(join(cwd, '.slope'), { recursive: true });
-    writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({
-      scorecardDir: 'docs/retros',
-      metaphor: 'golf',
-    }));
+    writeMinimalSlopeConfig(cwd);
     writeFileSync(join(cwd, '.slope', 'hooks.json'), JSON.stringify({ installed: {} }));
   });
 
@@ -88,12 +125,71 @@ describe('slope guard recommend (S65-3)', () => {
   });
 });
 
+describe('guardCommand dispatcher path', () => {
+  let cwd: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    cwd = makeTmpDir();
+    origCwd = process.cwd();
+    process.chdir(cwd);
+    writeMinimalSlopeConfig(cwd);
+    setSessionMode(cwd, 'test-session', 'adhoc');
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    rmSync(cwd, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('emits ask output for claim-required on adhoc implementation writes with no sprint state', async () => {
+    const output = await runGuardCommandWithInput(['claim-required'], makeHookInput(cwd));
+    const parsed = JSON.parse(output);
+
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('PreToolUse');
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('ask');
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('no active sprint state');
+
+    const metrics = readFileSync(join(cwd, '.slope', 'guard-metrics.jsonl'), 'utf8');
+    expect(metrics).toContain('"guard":"claim-required"');
+    expect(metrics).toContain('"decision":"ask"');
+  });
+
+  it('records suppressed metrics for adhoc workflow guards that do not run', async () => {
+    const output = await runGuardCommandWithInput(['workflow-step-gate'], makeHookInput(cwd));
+
+    expect(output).toBe('');
+    const metrics = readFileSync(join(cwd, '.slope', 'guard-metrics.jsonl'), 'utf8');
+    expect(metrics).toContain('"guard":"workflow-step-gate"');
+    expect(metrics).toContain('"decision":"suppressed"');
+    expect(metrics).toContain('"reason":"adhoc-session"');
+  });
+
+  it('keeps claim-required effective when batched with suppressed write guards', async () => {
+    const output = await runGuardCommandWithInput(
+      ['__batch', 'workflow-step-gate', 'claim-required'],
+      makeHookInput(cwd),
+    );
+    const parsed = JSON.parse(output);
+
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('ask');
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('slope claim');
+
+    const metrics = readFileSync(join(cwd, '.slope', 'guard-metrics.jsonl'), 'utf8');
+    expect(metrics).toContain('"guard":"workflow-step-gate"');
+    expect(metrics).toContain('"decision":"suppressed"');
+    expect(metrics).toContain('"guard":"claim-required"');
+    expect(metrics).toContain('"decision":"ask"');
+  });
+});
+
 describe('adhoc guard suppression', () => {
   let cwd: string;
 
   beforeEach(() => {
     cwd = makeTmpDir();
-    mkdirSync(join(cwd, '.slope'), { recursive: true });
+    writeMinimalSlopeConfig(cwd);
     setSessionMode(cwd, 'test-session', 'adhoc');
   });
 

--- a/tests/cli/commands/hook-codex.test.ts
+++ b/tests/cli/commands/hook-codex.test.ts
@@ -10,6 +10,12 @@ function makeTmpDir(): string {
   return dir;
 }
 
+type CodexHookEntry = { matcher?: string; hooks: Array<{ command: string }> };
+
+function findHookGroupForCommand(groups: CodexHookEntry[] | undefined, commandPart: string): CodexHookEntry | undefined {
+  return groups?.find(group => group.hooks.some(hook => hook.command.includes(commandPart)));
+}
+
 describe('slope hook add --harness=codex', () => {
   let cwd: string;
   let origCwd: string;
@@ -59,5 +65,15 @@ describe('slope hook add --harness=codex', () => {
     expect(output).toContain('Installed 30 of 31 guard hooks (level: full)');
     expect(output).toContain('compaction');
     expect(output).toContain('unsupported by harness');
+  });
+
+  it('installs claim-required under the Codex write matcher for project-local full installs', async () => {
+    await hookCommand(['add', '--level=full', '--harness=codex']);
+
+    const codexConfig = JSON.parse(readFileSync(join(cwd, '.codex', 'hooks.json'), 'utf8'));
+    const group = findHookGroupForCommand(codexConfig.hooks.PreToolUse, 'claim-required');
+
+    expect(group).toBeDefined();
+    expect(group?.matcher?.split('|')).toEqual(expect.arrayContaining(['apply_patch', 'Edit', 'Write']));
   });
 });

--- a/tests/cli/guards/claim-required.test.ts
+++ b/tests/cli/guards/claim-required.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -17,6 +17,32 @@ function makeInput(cwd: string, filePath: string): HookInput {
     tool_name: 'apply_patch',
     tool_input: { file_path: filePath },
   };
+}
+
+function writeConfig(cwd: string, guidance: Record<string, unknown> = {}): void {
+  mkdirSync(join(cwd, '.slope'), { recursive: true });
+  writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({
+    scorecardDir: 'docs/retros',
+    metaphor: 'golf',
+    guidance,
+  }));
+}
+
+function writeSprintState(cwd: string, phase: string): void {
+  mkdirSync(join(cwd, '.slope'), { recursive: true });
+  writeFileSync(join(cwd, '.slope', 'sprint-state.json'), JSON.stringify({
+    sprint: 94,
+    phase,
+    gates: {
+      tests: false,
+      code_review: false,
+      architect_review: false,
+      scorecard: false,
+      review_md: false,
+    },
+    started_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }));
 }
 
 describe('claimOverlapsPath', () => {
@@ -87,6 +113,7 @@ describe('claimRequiredGuard', () => {
   it('asks before implementation writes when no sprint state is active', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
     try {
+      writeConfig(cwd);
       const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
 
       expect(result.decision).toBe('ask');
@@ -101,8 +128,90 @@ describe('claimRequiredGuard', () => {
   it('does not interrupt non-implementation writes when no sprint state is active', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
     try {
+      writeConfig(cwd);
       const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'README.md')), cwd);
       expect(result).toEqual({});
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies no-sprint implementation writes in strict mode', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
+    try {
+      writeConfig(cwd, { requireSprintForImplementationWrites: 'deny' });
+      const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+
+      expect(result.decision).toBe('deny');
+      expect(result.blockReason).toContain('Strict mode');
+      expect(result.blockReason).toContain('no active sprint state');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('allows no-sprint implementation writes when the policy is off', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
+    try {
+      writeConfig(cwd, { requireSprintForImplementationWrites: 'off' });
+      const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+      expect(result).toEqual({});
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('asks before implementation writes when sprint is not in implementing phase', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
+    try {
+      writeConfig(cwd);
+      writeSprintState(cwd, 'planning');
+      const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+
+      expect(result.decision).toBe('ask');
+      expect(result.context).toContain('planning phase');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('denies implementation writes outside implementing phase in strict mode', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
+    try {
+      writeConfig(cwd, { requireSprintForImplementationWrites: 'deny' });
+      writeSprintState(cwd, 'reviewing');
+      const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+
+      expect(result.decision).toBe('deny');
+      expect(result.blockReason).toContain('reviewing phase');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves the implementing phase missing-claim advisory by default', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
+    try {
+      writeConfig(cwd);
+      writeSprintState(cwd, 'implementing');
+      const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+
+      expect(result.decision).toBeUndefined();
+      expect(result.context).toContain('No active sprint claim');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('upgrades implementing phase missing-claim edits to deny in strict mode', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
+    try {
+      writeConfig(cwd, { requireSprintForImplementationWrites: 'deny' });
+      writeSprintState(cwd, 'implementing');
+      const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+
+      expect(result.decision).toBe('deny');
+      expect(result.blockReason).toContain('No active sprint claim');
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/cli/guards/pr-review-recommend.test.ts
+++ b/tests/cli/guards/pr-review-recommend.test.ts
@@ -81,6 +81,14 @@ describe('prReviewGuard recommendations (GH #302)', () => {
     );
     expect(result.suggestion?.context).toContain('slope pr finalize');
   });
+
+  it('points agents to the transport-independent PR review command', async () => {
+    const result = await prReviewGuard(
+      makeInput('https://github.com/x/y/pull/42'),
+      cwd,
+    );
+    expect(result.suggestion?.context).toContain('slope pr review --pr=42');
+  });
 });
 
 describe('prReviewGuard internals', () => {

--- a/tests/cli/pr-finalize.test.ts
+++ b/tests/cli/pr-finalize.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { extractIssueRefs, existingAutoCloseRefs } from '../../src/cli/commands/pr.js';
+import {
+  defaultReviewType,
+  extractIssueRefs,
+  existingAutoCloseRefs,
+  formatReviewRecommendations,
+} from '../../src/cli/commands/pr.js';
 
 describe('extractIssueRefs (GH #321)', () => {
   it('extracts a single issue ref', () => {
@@ -60,5 +65,25 @@ describe('existingAutoCloseRefs (GH #321)', () => {
   it('matches "fixed" / "closed" past tense', () => {
     expect(existingAutoCloseRefs('Fixed #42')).toEqual(new Set([42]));
     expect(existingAutoCloseRefs('Closed #43')).toEqual(new Set([43]));
+  });
+});
+
+describe('pr review workflow helpers (S94-5)', () => {
+  it('defaults transport-independent PR review to both architect and code prompts', () => {
+    expect(defaultReviewType([
+      { review_type: 'architect', priority: 'required', reason: '4 tickets warrants architectural review' },
+      { review_type: 'code', priority: 'optional', reason: 'Baseline code review' },
+    ])).toBe('both');
+  });
+
+  it('formats review recommendations for command output', () => {
+    const output = formatReviewRecommendations([
+      { review_type: 'architect', priority: 'required', reason: '4 tickets warrants architectural review' },
+      { review_type: 'code', priority: 'optional', reason: 'Baseline code review' },
+    ]);
+
+    expect(output).toContain('architect');
+    expect(output).toContain('required');
+    expect(output).toContain('Baseline code review');
   });
 });

--- a/tests/core/adapters/codex.test.ts
+++ b/tests/core/adapters/codex.test.ts
@@ -6,6 +6,12 @@ import { CodexAdapter } from '../../../src/core/adapters/codex.js';
 import { GUARD_DEFINITIONS } from '../../../src/core/guard.js';
 import type { GuardResult } from '../../../src/core/guard.js';
 
+type CodexHookEntry = { matcher?: string; hooks: Array<{ command: string; statusMessage?: string }> };
+
+function findHookGroupForCommand(groups: CodexHookEntry[] | undefined, commandPart: string): CodexHookEntry | undefined {
+  return groups?.find(group => group.hooks.some(hook => hook.command.includes(commandPart)));
+}
+
 describe('CodexAdapter', () => {
   let adapter: CodexAdapter;
 
@@ -159,6 +165,16 @@ describe('CodexAdapter', () => {
       );
     });
 
+    it('keeps claim-required in the Codex write matcher group', () => {
+      const guards = GUARD_DEFINITIONS.filter(g => g.name === 'claim-required');
+      const config = adapter.generateHooksConfig(guards, '/path/to/slope-guard.sh');
+
+      const group = findHookGroupForCommand(config.hooks.PreToolUse, 'claim-required');
+      expect(group).toBeDefined();
+      expect(group?.matcher?.split('|')).toEqual(expect.arrayContaining(['apply_patch', 'Edit', 'Write']));
+      expect(group?.hooks[0]?.statusMessage).toBe('SLOPE claim-required');
+    });
+
     it('groups guards by event and matcher for Codex review ergonomics', () => {
       const guards = GUARD_DEFINITIONS.filter(g => g.hookEvent === 'PreToolUse' && g.matcher === 'Bash').slice(0, 2);
       expect(guards).toHaveLength(2);
@@ -232,6 +248,19 @@ describe('CodexAdapter', () => {
         entry.hooks.map(h => h.command),
       );
       expect(commands.filter((cmd: string) => cmd.includes('branch-before-commit'))).toHaveLength(1);
+    });
+
+    it('installs claim-required under apply_patch/Edit/Write for user-level full installs', () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'slope-codex-user-full-cwd-'));
+      const homeDir = mkdtempSync(join(tmpdir(), 'slope-codex-user-full-home-'));
+      const guards = GUARD_DEFINITIONS.filter(g => g.level === 'full');
+
+      adapter.installGuards(cwd, guards, { scope: 'user', homeDir });
+
+      const config = JSON.parse(readFileSync(join(homeDir, '.codex', 'hooks.json'), 'utf8'));
+      const group = findHookGroupForCommand(config.hooks.PreToolUse, 'claim-required');
+      expect(group).toBeDefined();
+      expect(group?.matcher?.split('|')).toEqual(expect.arrayContaining(['apply_patch', 'Edit', 'Write']));
     });
 
     it('preserves non-SLOPE hooks and does not duplicate managed entries', () => {


### PR DESCRIPTION
## Summary

This PR closes Sprint 94 by hardening the guard-enforcement contract that followed issue #368 and the v1.55.5 emergency patch.

Changes include:
- dispatcher-level regression coverage for adhoc `claim-required`, suppressed workflow guards, and batched guard execution
- Codex matcher coverage proving `claim-required` remains installed under `apply_patch|Edit|Write` for project and user installs
- `slope doctor` diagnostics for Codex runtime resolution, stale project-local `@slope-dev/slope`, and stale SLOPE dev `dist/cli/index.js`
- `guidance.requireSprintForImplementationWrites` with `ask`, `deny`, and `off` policies
- `slope pr review --pr=<N> --sprint=<N>` for post-PR review workflow after gh, MCP connector, or API-created PRs
- S94 scorecard and sprint review artifacts
- removal of stale `.claude/scheduled_tasks.lock`

## Why

The immediate bug fix made no-sprint implementation writes ask for approval, but the higher-risk path spans hook installation, CLI dispatch, runtime resolution, config semantics, and post-PR review handoff. This PR makes those assumptions explicit and covered by tests.

## Validation

- `pnpm build`
- `pnpm exec tsc --noEmit`
- focused PR-review tests — 28 passed
- `node dist/cli/index.js pr review --pr=370 --sprint=94 --type=code`
- `pnpm test` — 199 files passed, 3344 tests passed
- `slope validate` — Sprint 94 valid with no warnings
- `slope doctor` — no new Codex runtime warning; existing repo hygiene warnings remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `slope pr review` subcommand for transport-independent PR review workflow
  * Made `claim-required` guard configurable with strictness modes (ask/warn/deny)

* **Bug Fixes**
  * Enhanced `slope doctor` with runtime resolution diagnostics for Codex hook conflicts and stale dependencies

* **Documentation**
  * Added Sprint 94 plan and review documentation for guard enforcement improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->