### PR TITLE
chore: bump version to 1.55.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.55.5",
+  "version": "1.55.6",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Bump @slope-dev/slope from 1.55.5 to 1.55.6 for the Sprint 94 guard hardening release.

## Validation

- pnpm build
- pnpm test