### PR TITLE
docs(95): scope inserted sprint recovery

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -117,8 +117,16 @@
       "sprints": [
         94
       ],
+      "status": "complete",
+      "note": "Closed the remaining enforcement/diagnostic gaps exposed by #368: full dispatcher coverage, Codex matcher coverage, stale runtime detection, configurable strictness for implementation writes outside sprint state, and transport-independent PR review handoff. Shipped in v1.55.6."
+    },
+    {
+      "name": "Phase 24 \u2014 Sprint State Inference",
+      "sprints": [
+        95
+      ],
       "status": "planned",
-      "note": "Close the remaining enforcement/diagnostic gaps exposed by #368: full dispatcher coverage, Codex matcher coverage, stale runtime detection, and configurable strictness for implementation writes outside sprint state."
+      "note": "Resolve #364 by making roadmap-inserted sub-sprints and missing active state explicit in next/status/briefing and guard guidance."
     }
   ],
   "sprints": [
@@ -1324,11 +1332,13 @@
       "par": 4,
       "slope": 2,
       "type": "hardening + dx",
-      "status": "planned",
+      "status": "complete",
       "depends_on": [
         93
       ],
-      "note": "Follow-up to #368 and v1.55.5. The patch fixed the immediate no-sprint adhoc write gap; S94 expands coverage to the full dispatcher/runtime path and makes strictness/diagnostics explicit.",
+      "score": 5,
+      "score_label": "par",
+      "note": "Follow-up to #368 and v1.55.5. Shipped in v1.55.6 with dispatcher/runtime coverage, configurable strictness, diagnostics, and explicit post-PR review handoff.",
       "tickets": [
         {
           "key": "S94-1",
@@ -1367,6 +1377,58 @@
           "club": "wedge",
           "complexity": "small",
           "note": "Close the connector-created PR gap where pr-review cannot fire because no Bash gh pr create hook event exists."
+        }
+      ]
+    },
+    {
+      "id": 95,
+      "theme": "Inserted Sprint Recovery \u2014 make next/status respect sub-sprints",
+      "par": 4,
+      "slope": 2,
+      "type": "bug fix + dx",
+      "status": "planned",
+      "depends_on": [
+        94
+      ],
+      "note": "Scope for #364. Prevent agents from falling through to scorecard+1 when a pending inserted roadmap sprint like id 435 / S43.5 is the real work context but no active sprint state exists.",
+      "tickets": [
+        {
+          "key": "S95-1",
+          "title": "Normalize and display inserted sprint identifiers like roadmap id 435 as S43.5 (#364)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 364
+        },
+        {
+          "key": "S95-2",
+          "title": "Teach slope next/status/briefing to prefer pending inserted roadmap sprints over scorecard+1 fallback (#364)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 364,
+          "depends_on": [
+            "S95-1"
+          ]
+        },
+        {
+          "key": "S95-3",
+          "title": "Warn when branch/roadmap/commit context implies a sprint but no active sprint state exists (#364)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 364,
+          "depends_on": [
+            "S95-1"
+          ]
+        },
+        {
+          "key": "S95-4",
+          "title": "Document and test starting, claiming, and scorecarding inserted sub-sprints (#364)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 364,
+          "depends_on": [
+            "S95-1",
+            "S95-2"
+          ]
         }
       ]
     }

--- a/docs/backlog/sprint-95-plan.md
+++ b/docs/backlog/sprint-95-plan.md
@@ -1,0 +1,126 @@
+# Sprint 95 Plan - Inserted Sprint Recovery
+
+**Par:** 4 (4 tickets)
+**Slope:** 2 (roadmap ID semantics, sprint inference, guard/status UX)
+**Theme:** Make `slope next`, status, briefing, and guards respect inserted sub-sprints.
+**GitHub issue:** #364
+**Branch:** create `fix/s95-inserted-sprint-state` before implementation.
+
+---
+
+## Context
+
+Issue #364 came from `fathoms-art`: a branch and commit history clearly referred to an inserted sprint `S43.5`, represented in `roadmap.json` as id `435`, but no active sprint state existed. SLOPE then fell back to scorecards and reported `S100`, because existing sprint inference is mostly:
+
+1. explicit `config.currentSprint`
+2. latest scorecard number + 1
+
+That is too weak for repositories that insert sub-sprints between canonical sprint numbers. The next session can be steered toward the wrong sprint unless the user manually correlates branch name, commits, and roadmap entries.
+
+---
+
+## Tickets
+
+### S95-1: Normalize and display inserted sprint identifiers like roadmap id 435 as S43.5
+
+**Club:** short_iron
+**Files:**
+- `src/core/roadmap.ts`
+- `src/core/loader.ts`
+- focused tests near roadmap/loader helpers
+
+**Scope:**
+
+1. Add a single helper for sprint display labels so roadmap id `435` can be shown as `S43.5` without ad hoc formatting.
+2. Keep numeric ids stable internally unless the implementation proves a richer type is needed.
+3. Define ordering rules for canonical ids and inserted ids.
+4. Cover edge cases explicitly: `43`, `435`, `95`, and ambiguous ids that should remain canonical.
+
+**Acceptance:**
+- Tests prove inserted sprint labels and ordering.
+- Existing canonical sprint labels stay unchanged.
+
+### S95-2: Teach next/status/briefing to prefer pending inserted roadmap sprints over scorecard+1 fallback
+
+**Club:** short_iron
+**Files:**
+- `src/cli/commands/next.ts`
+- `src/cli/commands/agent.ts`
+- briefing/status code paths as needed
+- command tests
+
+**Scope:**
+
+1. Load `docs/backlog/roadmap.json` before falling back to scorecard+1.
+2. If a pending inserted sprint is the lowest ready roadmap candidate, surface it explicitly.
+3. Make output explain when scorecard inference is being overridden by roadmap state.
+4. Avoid mutating active sprint state from read-only commands.
+
+**Acceptance:**
+- `slope next` reports the pending inserted sprint instead of the next canonical scorecard number.
+- `slope status` / agent status do not silently imply the wrong sprint when no active state exists.
+
+### S95-3: Warn when branch/roadmap/commit context implies a sprint but no active sprint state exists
+
+**Club:** short_iron
+**Files:**
+- `src/cli/guards/claim-required.ts`
+- session/status helpers as needed
+- guard tests
+
+**Scope:**
+
+1. Detect likely sprint context from branch names, recent commits, and pending roadmap entries.
+2. When no active sprint state exists, warn with the inferred sprint and the command to start or resume it.
+3. Keep implementation-write enforcement from S94 intact.
+4. Do not block pure inspection/read-only work.
+
+**Acceptance:**
+- Guard output warns about the inferred inserted sprint instead of generic no-state guidance.
+- Tests cover branch/commit hints and no false positive for unrelated branches.
+
+### S95-4: Document and test starting, claiming, and scorecarding inserted sub-sprints
+
+**Club:** wedge
+**Files:**
+- `docs/getting-started.md` or a focused guide
+- `docs/backlog/sprint-95-plan.md`
+- command tests for any accepted CLI input shape
+
+**Scope:**
+
+1. Document the supported representation for inserted sprints.
+2. Decide whether users should type `--number=435`, `--number=43.5`, or both.
+3. Ensure claim, sprint start, and scorecard commands have clear behavior for inserted sprints.
+4. Add regression coverage for the chosen input/display shape.
+
+**Acceptance:**
+- Docs explain the inserted sprint workflow without relying on tribal knowledge.
+- Tests prove the selected CLI input shape works end to end.
+
+---
+
+## Verification
+
+Run before closing the sprint:
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm test
+slope validate
+```
+
+Manual scenario:
+
+```bash
+# In a fixture or temporary repo:
+# - scorecards end at S99
+# - roadmap has pending id 435 / S43.5
+# - no active .slope/sprint-state.json
+slope next
+slope status
+slope briefing
+```
+
+Expected: commands point at the inserted sprint context or warn explicitly before falling back to `S100`.


### PR DESCRIPTION
## Summary

Scope Sprint 95 around #364: inserted sub-sprint inference and missing active-state warnings.

Changes:
- mark S94 / Phase 23 complete after v1.55.6
- add Phase 24 for sprint-state inference
- add S95 roadmap entry and sprint plan

## Validation

- roadmap JSON parses
- git diff --check
- slope validate docs/retros/sprint-94.json

Note: slope roadmap validate still reports the existing S75.5 numbering-gap errors; S95 did not introduce those.