### PR TITLE
fix(95): infer inserted sprint state from roadmap

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -1386,7 +1386,7 @@
       "par": 4,
       "slope": 2,
       "type": "bug fix + dx",
-      "status": "planned",
+      "status": "complete",
       "depends_on": [
         94
       ],

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -185,6 +185,23 @@ slope release --target=<ticket>          # Release a claim when done
 slope session end                       # End the session
 ```
 
+### Inserted Sub-Sprints
+
+Use a decimal sprint label when work is inserted between two existing sprints, for example `S43.5` between `S43` and `S44`.
+
+SLOPE supports two roadmap representations:
+
+- natural decimal ids: `"id": 43.5` with ticket keys like `S43.5-1`
+- encoded half-sprint integer ids: `"id": 435` displayed as `S43.5`, also with ticket keys like `S43.5-1`
+
+When no active sprint state exists, `slope next`, `slope status`, `slope briefing`, and `slope agent status` prefer pending roadmap sub-sprints over the plain scorecard `+1` fallback. Start the inserted sprint with the roadmap id SLOPE reports:
+
+```bash
+slope next
+slope sprint start --number=435 --phase=implementing
+slope claim --sprint=435 --target=S43.5-1
+```
+
 ### After a Sprint
 
 ```bash

--- a/docs/retros/sprint-95-review.md
+++ b/docs/retros/sprint-95-review.md
@@ -1,0 +1,66 @@
+
+## Sprint 95 Review: Inserted Sprint Recovery — make next/status respect sub-sprints
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 2 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (4/4) |
+| GIR % | 100% (4/4) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 4)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S95-1 | Short Iron | Green | Rough: The initial encoded-id rule was too broad and would have displayed future canonical three-digit sprints ending in a non-zero digit as inserted sub-sprints. | Added roadmap helpers for encoded half-sprint ids, natural decimal ids, human labels, and ordering. Architect review narrowed encoded integer support to half-sprints ending in 5 so S101 and S203 remain canonical. |
+| S95-2 | Short Iron | In the Hole | — | Added shared sprint inference and wired next, status, briefing, agent status, and claim defaults to pending roadmap context before scorecard+1 fallback. |
+| S95-3 | Short Iron | Green | — | Claim-required now includes an inferred sprint hint when implementation edits happen without active sprint state, preferring pending roadmap context and falling back to branch or commit references. |
+| S95-4 | Wedge | In the Hole | — | Added core, loader, next, agent, guard, and ticket-done tests plus getting-started docs for decimal labels and encoded half-sprint ids. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| rough | moderate | A pending inserted roadmap sprint can be older than the latest scorecard, so scorecard+1 was the wrong fallback for no-state recovery. |
+| Pin Position | minor | The roadmap currently needs encoded integer ids for state/store compatibility, but user-facing labels still need to read as S43.5. |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Rough | S95-1 | The initial encoded-id rule was too broad and would have displayed future canonical three-digit sprints ending in a non-zero digit as inserted sub-sprints. |
+
+**Known hazards for future sprints:**
+- Encoded inserted ids must stay narrow; broad three-digit decoding mislabels future canonical sprints.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Inserted sprint support needs both ordering tests and user-facing command tests. | Added regression coverage for roadmap validation, scorecard filename loading, next/status inference, guard hints, and ticket completion. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| review | healthy | SLOPE PR review flow was run after PR creation and again after the amended fix. |
+
+### Course Management Notes
+
+- Use natural decimal roadmap ids when possible; use encoded half-sprint integer ids like 435 when integer storage compatibility is required.
+- Start encoded inserted sprints with the roadmap id, for example slope sprint start --number=435 --phase=implementing.
+- Full local suite passed after the implementation and after the architect-review fix: 200 test files, 3355 tests.
+
+### 19th Hole
+
+- **How did it feel?** A compact recovery sprint with one real architectural edge: keeping encoded inserted ids useful without corrupting future three-digit canonical sprint labels.
+- **Advice for next player?** When adding new sprint-number semantics, test canonical boundary values as well as the special case. S100, S101, and S203 are just as important as S43.5.
+- **What surprised you?** The no-state inference needed to avoid older incomplete canonical roadmap entries while still recovering inserted sub-sprints that sort before the latest scorecard.
+- **Excited about next?** Release this so agents recovering in repos with inserted work get the right sprint context from the roadmap instead of silently drifting to scorecard+1.
+

--- a/docs/retros/sprint-95.json
+++ b/docs/retros/sprint-95.json
@@ -1,0 +1,115 @@
+{
+  "sprint_number": 95,
+  "player": "codex",
+  "theme": "Inserted Sprint Recovery — make next/status respect sub-sprints",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-17",
+  "shots": [
+    {
+      "ticket_key": "S95-1",
+      "title": "Normalize and display inserted sprint identifiers like roadmap id 435 as S43.5 (#364)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The initial encoded-id rule was too broad and would have displayed future canonical three-digit sprints ending in a non-zero digit as inserted sub-sprints."
+        }
+      ],
+      "notes": "Added roadmap helpers for encoded half-sprint ids, natural decimal ids, human labels, and ordering. Architect review narrowed encoded integer support to half-sprints ending in 5 so S101 and S203 remain canonical."
+    },
+    {
+      "ticket_key": "S95-2",
+      "title": "Teach slope next/status/briefing to prefer pending inserted roadmap sprints over scorecard+1 fallback (#364)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added shared sprint inference and wired next, status, briefing, agent status, and claim defaults to pending roadmap context before scorecard+1 fallback."
+    },
+    {
+      "ticket_key": "S95-3",
+      "title": "Warn when branch/roadmap/commit context implies a sprint but no active sprint state exists (#364)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Claim-required now includes an inferred sprint hint when implementation edits happen without active sprint state, preferring pending roadmap context and falling back to branch or commit references."
+    },
+    {
+      "ticket_key": "S95-4",
+      "title": "Document and test starting, claiming, and scorecarding inserted sub-sprints (#364)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added core, loader, next, agent, guard, and ticket-done tests plus getting-started docs for decimal labels and encoded half-sprint ids."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "bug fix + dx",
+  "conditions": [
+    {
+      "type": "rough",
+      "description": "A pending inserted roadmap sprint can be older than the latest scorecard, so scorecard+1 was the wrong fallback for no-state recovery.",
+      "impact": "moderate"
+    },
+    {
+      "type": "pin_position",
+      "description": "The roadmap currently needs encoded integer ids for state/store compatibility, but user-facing labels still need to read as S43.5.",
+      "impact": "minor"
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Inserted sprint support needs both ordering tests and user-facing command tests.",
+      "outcome": "Added regression coverage for roadmap validation, scorecard filename loading, next/status inference, guard hints, and ticket completion."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "review",
+      "description": "SLOPE PR review flow was run after PR creation and again after the amended fix.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A compact recovery sprint with one real architectural edge: keeping encoded inserted ids useful without corrupting future three-digit canonical sprint labels.",
+    "advice_for_next_player": "When adding new sprint-number semantics, test canonical boundary values as well as the special case. S100, S101, and S203 are just as important as S43.5.",
+    "what_surprised_you": "The no-state inference needed to avoid older incomplete canonical roadmap entries while still recovering inserted sub-sprints that sort before the latest scorecard.",
+    "excited_about_next": "Release this so agents recovering in repos with inserted work get the right sprint context from the roadmap instead of silently drifting to scorecard+1."
+  },
+  "bunker_locations": [
+    "Encoded inserted ids must stay narrow; broad three-digit decoding mislabels future canonical sprints."
+  ],
+  "yardage_book_updates": [
+    "src/core/roadmap.ts now formats and orders inserted half-sprint ids and natural decimal ids.",
+    "src/cli/sprint-inference.ts centralizes config, roadmap, scorecard, and initial sprint fallback logic.",
+    "src/cli/commands/next.ts, status.ts, briefing.ts, claim.ts, and agent.ts now use shared sprint inference.",
+    "src/cli/guards/claim-required.ts now surfaces inferred sprint context when active sprint state is missing.",
+    "src/cli/commands/ticket.ts resolves decimal ticket labels like S43.5-1 back to encoded roadmap ids like 435."
+  ],
+  "course_management_notes": [
+    "Use natural decimal roadmap ids when possible; use encoded half-sprint integer ids like 435 when integer storage compatibility is required.",
+    "Start encoded inserted sprints with the roadmap id, for example slope sprint start --number=435 --phase=implementing.",
+    "Full local suite passed after the implementation and after the architect-review fix: 200 test files, 3355 tests."
+  ]
+}

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -2,11 +2,12 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   parseRoadmap,
-  detectLatestSprint,
   loadScorecards,
+  formatSprintLabel,
 } from '../../core/index.js';
 import type { RoadmapDefinition, RoadmapSprint } from '../../core/index.js';
 import { loadConfig } from '../config.js';
+import { inferSprintContext } from '../sprint-inference.js';
 import { loadSprintState } from '../sprint-state.js';
 import { resolveStore } from '../store.js';
 
@@ -123,13 +124,14 @@ export async function collectAgentStatus(cwd: string): Promise<AgentStatus> {
     }
   }
 
-  // Current sprint — sprint-state.json wins; otherwise fall back to detectLatestSprint
+  // Current sprint — sprint-state.json wins; otherwise infer from roadmap
+  // pending work before falling back to scorecards (#364).
   const sprintState = loadSprintState(cwd);
   let currentSprint: number | null = sprintState?.sprint ?? null;
   if (currentSprint == null) {
     try {
-      const latest = detectLatestSprint(config, cwd);
-      currentSprint = latest > 0 ? latest : null;
+      const inferred = inferSprintContext(cwd, config);
+      currentSprint = inferred.source === 'initial' && !roadmap ? null : inferred.sprint;
     } catch {
       // best-effort
     }
@@ -281,7 +283,7 @@ function recommendCommands(state: {
   // No active sprint state
   if (state.sprintState == null) {
     if (state.currentSprint != null) {
-      cmds.push(`slope sprint start --sprint=${state.currentSprint}`);
+      cmds.push(`slope sprint start --number=${state.currentSprint}`);
     } else {
       cmds.push('slope briefing');
     }
@@ -371,7 +373,7 @@ export function renderAgentMarkdown(
 ): string {
   const lines: string[] = [];
   const sprintLabel = s.currentSprint != null
-    ? `S${s.currentSprint}${opts.sprintTheme ? ` ${opts.sprintTheme}` : ''}`
+    ? `${formatSprintLabel(s.currentSprint)}${opts.sprintTheme ? ` ${opts.sprintTheme}` : ''}`
     : '—';
 
   lines.push('# Agent Next');
@@ -388,7 +390,7 @@ export function renderAgentMarkdown(
   if (s.blockedBy.length > 0) {
     lines.push('## Blocked');
     lines.push('');
-    lines.push(`This sprint is blocked by: ${s.blockedBy.map(id => `S${id}`).join(', ')}`);
+    lines.push(`This sprint is blocked by: ${s.blockedBy.map(formatSprintLabel).join(', ')}`);
     lines.push('');
     lines.push('Resolve those before proceeding here.');
     lines.push('');
@@ -430,12 +432,12 @@ function printHumanStatus(s: AgentStatus): void {
   lines.push('═'.repeat(50));
   lines.push(`  Vision:        ${s.vision}`);
   lines.push(`  Roadmap:       ${s.roadmap}`);
-  lines.push(`  Sprint:        ${s.currentSprint ?? '—'}`);
+  lines.push(`  Sprint:        ${s.currentSprint != null ? formatSprintLabel(s.currentSprint) : '—'}`);
   lines.push(`  Phase:         ${s.phase}`);
   lines.push(`  Claims:        ${s.activeClaims.length > 0 ? s.activeClaims.join(', ') : 'none'}`);
   lines.push(`  Next ticket:   ${s.nextTicket ?? '—'}`);
   if (s.blockedBy.length > 0) {
-    lines.push(`  Blocked by:    ${s.blockedBy.map(id => `S${id}`).join(', ')}`);
+    lines.push(`  Blocked by:    ${s.blockedBy.map(formatSprintLabel).join(', ')}`);
   }
   if (s.requiredGates.length > 0) {
     lines.push(`  Pending gates: ${s.requiredGates.join(', ')}`);

--- a/src/cli/commands/briefing.ts
+++ b/src/cli/commands/briefing.ts
@@ -4,6 +4,7 @@ import { formatBriefing, parseRoadmap, castRoadmapStructure, getRole, hasRole, l
 import type { CommonIssuesFile, SessionEntry, SprintClaim, RoadmapDefinition, SlopeEvent, RoleDefinition } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { loadScorecards } from '../loader.js';
+import { inferSprintContext } from '../sprint-inference.js';
 import { resolveStore } from '../store.js';
 import { resolveMetaphor } from '../metaphor.js';
 
@@ -75,13 +76,8 @@ export async function briefingCommand(args: string[]): Promise<void> {
   let sprintNumber: number;
   if (sprintFlag) {
     sprintNumber = sprintFlag;
-  } else if (config.currentSprint) {
-    sprintNumber = config.currentSprint;
-  } else if (scorecards.length > 0) {
-    const maxSprint = Math.max(...scorecards.map(s => s.sprint_number));
-    sprintNumber = maxSprint + 1;
   } else {
-    sprintNumber = 1;
+    sprintNumber = inferSprintContext(cwd, config).sprint;
   }
 
   // Load claims and events from store

--- a/src/cli/commands/claim.ts
+++ b/src/cli/commands/claim.ts
@@ -1,6 +1,6 @@
 import { checkConflicts } from '../../core/index.js';
 import { loadConfig } from '../config.js';
-import { loadScorecards } from '../loader.js';
+import { inferSprintContext } from '../sprint-inference.js';
 import { resolveStore } from '../store.js';
 import type { ClaimScope, SprintClaim } from '../../core/index.js';
 
@@ -16,11 +16,7 @@ function parseArgs(args: string[]): Record<string, string> {
 function resolveSprint(flags: Record<string, string>, cwd: string): number {
   if (flags.sprint) return parseInt(flags.sprint, 10);
   const config = loadConfig(cwd);
-  if (config.currentSprint) return config.currentSprint;
-  const scorecards = loadScorecards(config, cwd);
-  if (scorecards.length === 0) return 1;
-  const maxSprint = Math.max(...scorecards.map(s => s.sprint_number));
-  return maxSprint + 1;
+  return inferSprintContext(cwd, config).sprint;
 }
 
 export async function claimCommand(args: string[]): Promise<void> {

--- a/src/cli/commands/next.ts
+++ b/src/cli/commands/next.ts
@@ -1,29 +1,33 @@
 import { loadConfig } from '../config.js';
-import { resolveCurrentSprint, detectLatestSprint } from '../loader.js';
+import { inferSprintContext } from '../sprint-inference.js';
 
 export function nextCommand(): void {
   const config = loadConfig();
   const cwd = process.cwd();
-  const latest = detectLatestSprint(config, cwd);
-  const next = resolveCurrentSprint(config, cwd);
+  const context = inferSprintContext(cwd, config);
 
   console.log('');
-  if (latest === 0) {
-    console.log('  No scorecards found. Next sprint: S1');
+  if (context.latestScorecard === 0) {
+    console.log(`  No scorecards found. Next sprint: ${context.label}`);
   } else {
-    console.log(`  Latest scorecard: S${latest}`);
-    console.log(`  Next sprint: S${next}`);
+    console.log(`  Latest scorecard: S${context.latestScorecard}`);
+    console.log(`  Next sprint: ${context.label}`);
   }
 
-  if (config.currentSprint) {
+  if (context.source === 'config') {
     console.log(`  (set explicitly in .slope/config.json)`);
+  } else if (context.source === 'roadmap') {
+    console.log(`  (selected from pending roadmap sprint${context.roadmapSprint?.theme ? `: ${context.roadmapSprint.theme}` : ''})`);
+    if (context.latestScorecard > 0 && context.sprint !== context.latestScorecard + 1) {
+      console.log(`  (roadmap state overrides scorecard fallback to S${context.latestScorecard + 1})`);
+    }
   } else {
     console.log(`  (auto-detected from scorecards)`);
   }
 
   console.log('');
   console.log('  Quick start:');
-  console.log(`    slope briefing --sprint=${next}`);
-  console.log(`    slope auto-card --sprint=${next} --since="$(date -d yesterday +%Y-%m-%d)"`);
+  console.log(`    slope briefing --sprint=${context.sprint}`);
+  console.log(`    slope auto-card --sprint=${context.sprint} --since="$(date -d yesterday +%Y-%m-%d)"`);
   console.log('');
 }

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,9 +1,9 @@
-import { checkConflicts, findShippedSprintsOnMain } from '../../core/index.js';
+import { checkConflicts, findShippedSprintsOnMain, formatSprintLabel } from '../../core/index.js';
 import type { SprintClaim, SlopeSession } from '../../core/index.js';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { loadConfig } from '../config.js';
-import { loadScorecards } from '../loader.js';
+import { inferSprintContext } from '../sprint-inference.js';
 import { resolveStore } from '../store.js';
 
 function parseArgs(args: string[]): Record<string, string> {
@@ -18,11 +18,7 @@ function parseArgs(args: string[]): Record<string, string> {
 function resolveSprint(flags: Record<string, string>, cwd: string): number {
   if (flags.sprint) return parseInt(flags.sprint, 10);
   const config = loadConfig(cwd);
-  if (config.currentSprint) return config.currentSprint;
-  const scorecards = loadScorecards(config, cwd);
-  if (scorecards.length === 0) return 1;
-  const maxSprint = Math.max(...scorecards.map(s => s.sprint_number));
-  return maxSprint + 1;
+  return inferSprintContext(cwd, config).sprint;
 }
 
 export async function statusCommand(args: string[]): Promise<void> {
@@ -47,7 +43,7 @@ export async function statusCommand(args: string[]): Promise<void> {
 async function showSprintStatus(store: { list: (n: number) => Promise<SprintClaim[]>; close: () => void }, sprintNumber: number): Promise<void> {
   const claims = await store.list(sprintNumber);
 
-  console.log(`\nSprint ${sprintNumber} — Course Status`);
+  console.log(`\n${formatSprintLabel(sprintNumber)} — Course Status`);
   console.log('═'.repeat(40));
 
   if (claims.length === 0) {

--- a/src/cli/commands/ticket.ts
+++ b/src/cli/commands/ticket.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { parseRoadmap } from '../../core/index.js';
+import { formatSprintLabel, parseRoadmap } from '../../core/index.js';
 import type { RoadmapDefinition } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { loadSprintState } from '../sprint-state.js';
@@ -66,12 +66,19 @@ async function doneSubcommand(args: string[]): Promise<void> {
   const flags = parseFlags(args);
   const cwd = process.cwd();
 
-  // Resolve current sprint — sprint state wins; otherwise infer from ticket key (S{N}-...)
+  const roadmap = loadRoadmap(cwd);
+
+  // Resolve current sprint — sprint state wins; otherwise match the roadmap
+  // ticket before falling back to the display label in S{N}-... keys.
   const state = loadSprintState(cwd);
   let sprintNumber: number | null = state?.sprint ?? null;
+  if (sprintNumber == null && roadmap) {
+    const roadmapSprint = roadmap.sprints.find(s => s.tickets.some(t => t.key === ticketKey));
+    if (roadmapSprint) sprintNumber = roadmapSprint.id;
+  }
   if (sprintNumber == null) {
-    const m = ticketKey.match(/^S(\d+)-/i);
-    if (m) sprintNumber = parseInt(m[1], 10);
+    const m = ticketKey.match(/^S(\d+(?:\.\d+)?)-/i);
+    if (m) sprintNumber = parseFloat(m[1]);
   }
   if (sprintNumber == null) {
     console.error(`Could not resolve sprint for ticket ${ticketKey}.`);
@@ -80,12 +87,11 @@ async function doneSubcommand(args: string[]): Promise<void> {
   }
 
   // 1. Verify ticket exists in roadmap (best-effort — warn but don't block)
-  const roadmap = loadRoadmap(cwd);
   if (roadmap) {
     const sprint = roadmap.sprints.find(s => s.id === sprintNumber);
     const ticketDefined = sprint?.tickets.some(t => t.key === ticketKey);
     if (!ticketDefined) {
-      console.warn(`Warning: ticket ${ticketKey} not found in roadmap S${sprintNumber}. Continuing anyway.`);
+      console.warn(`Warning: ticket ${ticketKey} not found in roadmap ${formatSprintLabel(sprintNumber)}. Continuing anyway.`);
     }
   }
 
@@ -97,7 +103,7 @@ async function doneSubcommand(args: string[]): Promise<void> {
     const existing = await store.list(sprintNumber);
     const ownClaim = existing.find(c => c.target === ticketKey && c.player === player);
     if (!ownClaim) {
-      console.error(`No active claim for ${ticketKey} by ${player} on S${sprintNumber}.`);
+      console.error(`No active claim for ${ticketKey} by ${player} on ${formatSprintLabel(sprintNumber)}.`);
       console.error('Run `slope claim --target=' + ticketKey + ' --sprint=' + sprintNumber + '` first.');
       process.exit(1);
     }
@@ -129,7 +135,7 @@ async function doneSubcommand(args: string[]): Promise<void> {
     }
 
     console.log(`\nTicket ${ticketKey}: done.`);
-    console.log(`  Sprint:  S${sprintNumber}`);
+    console.log(`  Sprint:  ${formatSprintLabel(sprintNumber)}`);
     console.log(`  Player:  ${player}`);
     if (sha) console.log(`  Commit:  ${sha}`);
     if (flags.notes) console.log(`  Notes:   ${flags.notes}`);

--- a/src/cli/guards/claim-required.ts
+++ b/src/cli/guards/claim-required.ts
@@ -1,7 +1,10 @@
+import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { formatSprintLabel } from '../../core/index.js';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { loadConfig } from '../config.js';
+import { inferSprintContext } from '../sprint-inference.js';
 import { loadSprintState } from '../sprint-state.js';
 import { loadSessionState, updateSessionState } from '../session-state.js';
 import { resolveStore } from '../store.js';
@@ -114,10 +117,14 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
     const relativePath = normalizeHookPath(filePath, cwd);
     if (!relativePath || !isImplementationWritePath(relativePath)) return {};
 
+    const hint = inferMissingSprintHint(cwd);
     return implementationWritePolicyResult(policy, [
       `SLOPE claim-required: ${relativePath} looks like an implementation edit, but there is no active sprint state.`,
+      ...(hint ? [`Detected likely sprint context: ${hint.label} (${hint.source}).`] : []),
       'Start or resume a sprint and claim the work before editing, or get explicit user approval to continue as adhoc work.',
-      'Suggested commands: `slope sprint start --number=<N> --phase=implementing` then `slope claim --target=<path> --ticket=<ticket>`.',
+      hint
+        ? `Suggested commands: \`slope sprint start --number=${hint.sprint} --phase=implementing\` then \`slope claim --target=<path> --ticket=<ticket>\`.`
+        : 'Suggested commands: `slope sprint start --number=<N> --phase=implementing` then `slope claim --target=<path> --ticket=<ticket>`.',
     ]);
   } else {
     const filePath = input.tool_input?.file_path as string | undefined;
@@ -147,6 +154,44 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
   return {
     context: 'SLOPE: No active sprint claim. Consider running `slope claim` to track this work.',
   };
+}
+
+function inferMissingSprintHint(cwd: string): { sprint: number; label: string; source: string } | null {
+  try {
+    const inferred = inferSprintContext(cwd);
+    if (inferred.source === 'roadmap') {
+      return { sprint: inferred.sprint, label: inferred.label, source: 'pending roadmap sprint' };
+    }
+  } catch { /* fall through */ }
+
+  const branch = readGit(cwd, 'rev-parse --abbrev-ref HEAD');
+  const branchSprint = parseSprintReference(branch);
+  if (branchSprint != null) {
+    return { sprint: branchSprint, label: formatSprintLabel(branchSprint), source: `branch ${branch}` };
+  }
+
+  const subject = readGit(cwd, 'log -1 --format=%s');
+  const commitSprint = parseSprintReference(subject);
+  if (commitSprint != null) {
+    return { sprint: commitSprint, label: formatSprintLabel(commitSprint), source: 'latest commit' };
+  }
+
+  return null;
+}
+
+function readGit(cwd: string, command: string): string {
+  try {
+    return execSync(`git ${command}`, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function parseSprintReference(text: string): number | null {
+  const match = text.match(/\bS(\d+(?:\.\d+)?)\b/i);
+  if (!match) return null;
+  const sprint = Number.parseFloat(match[1]);
+  return Number.isFinite(sprint) && sprint > 0 ? sprint : null;
 }
 
 function getImplementationWritePolicy(cwd: string): ImplementationWritePolicy {

--- a/src/cli/sprint-inference.ts
+++ b/src/cli/sprint-inference.ts
@@ -1,0 +1,114 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  castRoadmapStructure,
+  compareSprintIds,
+  detectLatestSprint,
+  formatSprintLabel,
+  isEncodedInsertedSprintId,
+  loadScorecards,
+  parseRoadmap,
+  sprintOrderValue,
+} from '../core/index.js';
+import type { RoadmapDefinition, RoadmapSprint, SlopeConfig } from '../core/index.js';
+import { loadConfig } from './config.js';
+
+export interface InferredSprintContext {
+  sprint: number;
+  label: string;
+  source: 'config' | 'roadmap' | 'scorecards' | 'initial';
+  latestScorecard: number;
+  roadmapSprint?: RoadmapSprint;
+}
+
+export function loadRoadmapForInference(cwd: string, config: SlopeConfig): RoadmapDefinition | null {
+  const roadmapPath = join(cwd, config.roadmapPath);
+  if (!existsSync(roadmapPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(roadmapPath, 'utf8'));
+    const parsed = parseRoadmap(raw);
+    return parsed.roadmap ?? castRoadmapStructure(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function inferSprintContext(cwd: string = process.cwd(), config: SlopeConfig = loadConfig(cwd)): InferredSprintContext {
+  const latestScorecard = detectLatestSprint(config, cwd);
+  if (config.currentSprint) {
+    return {
+      sprint: config.currentSprint,
+      label: formatSprintLabel(config.currentSprint),
+      source: 'config',
+      latestScorecard,
+    };
+  }
+
+  const roadmap = loadRoadmapForInference(cwd, config);
+  const scorecards = loadScorecards(config, cwd);
+  const completedIds = new Set<number>(scorecards.map(card => card.sprint_number));
+  const pendingSprints = roadmap?.sprints
+    .filter(sprint => {
+      const status = (sprint as RoadmapSprint & { status?: string }).status;
+      return status !== 'complete' && !completedIds.has(sprint.id);
+    })
+    .sort((a, b) => compareSprintIds(a.id, b.id)) ?? [];
+
+  const scorecardNext = latestScorecard > 0 ? latestScorecard + 1 : 1;
+  const pending = choosePendingSprint(pendingSprints, latestScorecard, scorecardNext);
+
+  if (pending) {
+    return {
+      sprint: pending.id,
+      label: formatSprintLabel(pending.id),
+      source: 'roadmap',
+      latestScorecard,
+      roadmapSprint: pending,
+    };
+  }
+
+  if (latestScorecard > 0) {
+    const sprint = scorecardNext;
+    return {
+      sprint,
+      label: formatSprintLabel(sprint),
+      source: 'scorecards',
+      latestScorecard,
+    };
+  }
+
+  return {
+    sprint: 1,
+    label: 'S1',
+    source: 'initial',
+    latestScorecard: 0,
+  };
+}
+
+function choosePendingSprint(
+  pendingSprints: RoadmapSprint[],
+  latestScorecard: number,
+  scorecardNext: number,
+): RoadmapSprint | undefined {
+  if (pendingSprints.length === 0) return undefined;
+  if (latestScorecard === 0) return pendingSprints[0];
+
+  const exactNext = pendingSprints.find(sprint => sprint.id === scorecardNext);
+  if (exactNext) return exactNext;
+
+  const nextOrder = sprintOrderValue(scorecardNext);
+  const insertedRecovery = pendingSprints.find(sprint =>
+    isInsertedSprintId(sprint.id) && sprintOrderValue(sprint.id) <= nextOrder,
+  );
+  if (insertedRecovery) return insertedRecovery;
+
+  return pendingSprints.find(sprint => sprintOrderValue(sprint.id) > sprintOrderValue(latestScorecard));
+}
+
+function isInsertedSprintId(id: number): boolean {
+  return !Number.isInteger(id) || isEncodedInsertedSprintId(id);
+}
+
+export function maxSprintByOrder(ids: number[]): number {
+  return ids.reduce((max, id) => sprintOrderValue(id) > sprintOrderValue(max) ? id : max, 0);
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -169,7 +169,12 @@ export {
   castRoadmapStructure,
   formatRoadmapSummary,
   formatStrategicContext,
+  formatSprintLabel,
+  formatSprintNumber,
   findNextPlannedSprint,
+  isEncodedInsertedSprintId,
+  sprintOrderValue,
+  compareSprintIds,
 } from './roadmap.js';
 export { extractSprintReferences, findShippedSprintsOnMain } from './analyzers/git.js';
 export type {

--- a/src/core/loader.ts
+++ b/src/core/loader.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import type { GolfScorecard } from './types.js';
 import type { SlopeConfig } from './config.js';
 import { normalizeStats } from './builder.js';
+import { compareSprintIds } from './roadmap.js';
 
 /**
  * Load SLOPE scorecards from the configured directory.
@@ -14,18 +15,18 @@ export function loadScorecards(config: SlopeConfig, cwd: string = process.cwd())
     return [];
   }
 
-  // Build regex from pattern (e.g. "sprint-*.json" → /^sprint-(\d+)\.json$/)
+  // Build regex from pattern (e.g. "sprint-*.json" → /^sprint-(\d+(?:\.\d+)?)\.json$/)
   const patternParts = config.scorecardPattern.split('*');
   const prefix = patternParts[0] ?? '';
   const suffix = patternParts[1] ?? '';
-  const regex = new RegExp(`^${escapeRegex(prefix)}(\\d+)${escapeRegex(suffix)}$`);
+  const regex = new RegExp(`^${escapeRegex(prefix)}(\\d+(?:\\.\\d+)?)${escapeRegex(suffix)}$`);
 
   const files = readdirSync(dir)
     .filter((f: string) => regex.test(f))
     .sort((a, b) => {
-      const na = parseInt(a.match(regex)?.[1] ?? '0', 10);
-      const nb = parseInt(b.match(regex)?.[1] ?? '0', 10);
-      return na - nb;
+      const na = parseFloat(a.match(regex)?.[1] ?? '0');
+      const nb = parseFloat(b.match(regex)?.[1] ?? '0');
+      return compareSprintIds(na, nb);
     });
 
   const scorecards: GolfScorecard[] = [];
@@ -33,7 +34,7 @@ export function loadScorecards(config: SlopeConfig, cwd: string = process.cwd())
   for (const file of files) {
     const match = file.match(regex);
     if (!match) continue;
-    const num = parseInt(match[1], 10);
+    const num = parseFloat(match[1]);
     if (num < config.minSprint) continue;
 
     try {
@@ -55,7 +56,10 @@ export function loadScorecards(config: SlopeConfig, cwd: string = process.cwd())
 export function detectLatestSprint(config: SlopeConfig, cwd: string = process.cwd()): number {
   const cards = loadScorecards(config, cwd);
   if (cards.length === 0) return 0;
-  return Math.max(...cards.map((c) => c.sprint_number));
+  return cards
+    .map((c) => c.sprint_number)
+    .sort(compareSprintIds)
+    .at(-1) ?? 0;
 }
 
 /**

--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -62,6 +62,42 @@ export interface RoadmapValidationResult {
   warnings: RoadmapValidationWarning[];
 }
 
+/** Return true for encoded inserted half-sprint ids like 435 => S43.5.
+ *  Decimal roadmap ids such as 75.5 are already explicit and are left as-is.
+ *  The encoding is intentionally limited to three-digit ids ending in 5 so
+ *  ordinary ids like 95, 100, 101, and 203 stay canonical.
+ */
+export function isEncodedInsertedSprintId(id: number): boolean {
+  return Number.isInteger(id) && id >= 100 && id < 1000 && id % 10 === 5;
+}
+
+/** Numeric value used for ordering sprint ids. Encoded inserted ids sort
+ *  between their surrounding canonical sprints: 435 sorts as 43.5.
+ */
+export function sprintOrderValue(id: number): number {
+  if (isEncodedInsertedSprintId(id)) {
+    return Math.floor(id / 10) + (id % 10) / 10;
+  }
+  return id;
+}
+
+/** Format the numeric portion of a sprint id for human-facing output. */
+export function formatSprintNumber(id: number): string {
+  if (isEncodedInsertedSprintId(id)) {
+    return `${Math.floor(id / 10)}.${id % 10}`;
+  }
+  return Number.isInteger(id) ? String(id) : String(id);
+}
+
+/** Format a full sprint label, e.g. S95 or S43.5. */
+export function formatSprintLabel(id: number): string {
+  return `S${formatSprintNumber(id)}`;
+}
+
+export function compareSprintIds(a: number, b: number): number {
+  return sprintOrderValue(a) - sprintOrderValue(b);
+}
+
 /** Validate a roadmap definition for structural correctness.
  *  Optionally cross-check sprint status against scorecards and/or shipped
  *  sprint commits on main when provided. Caller is responsible for collecting
@@ -83,12 +119,15 @@ export function validateRoadmap(
   }
 
   // Check: sprint numbering continuity
-  const sortedIds = [...sprintIds].sort((a, b) => a - b);
+  const sortedIds = [...sprintIds].sort(compareSprintIds);
   for (let i = 1; i < sortedIds.length; i++) {
-    if (sortedIds[i] !== sortedIds[i - 1] + 1) {
+    const prev = sprintOrderValue(sortedIds[i - 1]);
+    const current = sprintOrderValue(sortedIds[i]);
+    const allowedInsertedStep = current > prev && current <= Math.floor(prev) + 1;
+    if (!allowedInsertedStep && current !== prev + 1) {
       errors.push({
         type: 'error',
-        message: `Sprint numbering gap: S${sortedIds[i - 1]} → S${sortedIds[i]}`,
+        message: `Sprint numbering gap: ${formatSprintLabel(sortedIds[i - 1])} → ${formatSprintLabel(sortedIds[i])}`,
       });
     }
   }
@@ -107,26 +146,26 @@ export function validateRoadmap(
       warnings.push({
         type: 'warning',
         sprint: sprint.id,
-        message: `S${sprint.id} has ${sprint.tickets.length} tickets (recommended 3-4)`,
+        message: `${formatSprintLabel(sprint.id)} has ${sprint.tickets.length} tickets (recommended 3-4)`,
       });
     }
     if (sprint.tickets.length > 4) {
       warnings.push({
         type: 'warning',
         sprint: sprint.id,
-        message: `S${sprint.id} has ${sprint.tickets.length} tickets (recommended 3-4)`,
+        message: `${formatSprintLabel(sprint.id)} has ${sprint.tickets.length} tickets (recommended 3-4)`,
       });
     }
 
     // Check: ticket key format matches sprint
     for (const ticket of sprint.tickets) {
-      const expected = `S${sprint.id}-`;
+      const expected = `${formatSprintLabel(sprint.id)}-`;
       if (!ticket.key.startsWith(expected)) {
         errors.push({
           type: 'error',
           sprint: sprint.id,
           ticket: ticket.key,
-          message: `Ticket ${ticket.key} does not match sprint S${sprint.id} (expected prefix ${expected})`,
+          message: `Ticket ${ticket.key} does not match sprint ${formatSprintLabel(sprint.id)} (expected prefix ${expected})`,
         });
       }
     }
@@ -151,7 +190,7 @@ export function validateRoadmap(
         errors.push({
           type: 'error',
           sprint: sprint.id,
-          message: `S${sprint.id} depends on S${dep} which does not exist in the roadmap`,
+          message: `${formatSprintLabel(sprint.id)} depends on ${formatSprintLabel(dep)} which does not exist in the roadmap`,
         });
       }
     }
@@ -161,7 +200,7 @@ export function validateRoadmap(
       errors.push({
         type: 'error',
         sprint: sprint.id,
-        message: `S${sprint.id} has invalid par ${sprint.par} (must be 3, 4, or 5)`,
+        message: `${formatSprintLabel(sprint.id)} has invalid par ${sprint.par} (must be 3, 4, or 5)`,
       });
     }
   }
@@ -171,7 +210,7 @@ export function validateRoadmap(
   if (cycle) {
     errors.push({
       type: 'error',
-      message: `Dependency cycle detected: ${cycle.map(id => `S${id}`).join(' → ')}`,
+      message: `Dependency cycle detected: ${cycle.map(formatSprintLabel).join(' → ')}`,
     });
   }
 
@@ -181,7 +220,7 @@ export function validateRoadmap(
       if (!sprintIds.has(sid)) {
         errors.push({
           type: 'error',
-          message: `Phase "${phase.name}" references S${sid} which does not exist`,
+          message: `Phase "${phase.name}" references ${formatSprintLabel(sid)} which does not exist`,
         });
       }
     }
@@ -199,7 +238,7 @@ export function validateRoadmap(
         warnings.push({
           type: 'warning',
           sprint: sprint.id,
-          message: `S${sprint.id} has a scorecard but roadmap status is "${status ?? 'planned'}" — expected "complete"`,
+          message: `${formatSprintLabel(sprint.id)} has a scorecard but roadmap status is "${status ?? 'planned'}" — expected "complete"`,
         });
       }
 
@@ -207,7 +246,7 @@ export function validateRoadmap(
         warnings.push({
           type: 'warning',
           sprint: sprint.id,
-          message: `S${sprint.id} is marked "complete" in roadmap but no scorecard exists (phantom sprint)`,
+          message: `${formatSprintLabel(sprint.id)} is marked "complete" in roadmap but no scorecard exists (phantom sprint)`,
         });
       }
     }
@@ -223,7 +262,7 @@ export function validateRoadmap(
         errors.push({
           type: 'error',
           sprint: sprint.id,
-          message: `S${sprint.id} has shipped commits on main but status is "${status ?? 'planned'}" — expected "complete"`,
+          message: `${formatSprintLabel(sprint.id)} has shipped commits on main but status is "${status ?? 'planned'}" — expected "complete"`,
         });
       }
 
@@ -231,7 +270,7 @@ export function validateRoadmap(
         warnings.push({
           type: 'warning',
           sprint: sprint.id,
-          message: `S${sprint.id} is marked "complete" but no shipped commits found on main`,
+          message: `${formatSprintLabel(sprint.id)} is marked "complete" but no shipped commits found on main`,
         });
       }
     }
@@ -501,9 +540,9 @@ export function formatRoadmapSummary(roadmap: RoadmapDefinition): string {
     lines.push('');
     for (const sprint of phaseSprints) {
       const deps = sprint.depends_on?.length
-        ? ` (depends on: ${sprint.depends_on.map(d => `S${d}`).join(', ')})`
+        ? ` (depends on: ${sprint.depends_on.map(formatSprintLabel).join(', ')})`
         : ' (no dependencies)';
-      lines.push(`- **S${sprint.id}** — ${sprint.theme} | Par ${sprint.par} | ${sprint.tickets.length} tickets${deps}`);
+      lines.push(`- **${formatSprintLabel(sprint.id)}** — ${sprint.theme} | Par ${sprint.par} | ${sprint.tickets.length} tickets${deps}`);
     }
     lines.push('');
   }
@@ -511,7 +550,7 @@ export function formatRoadmapSummary(roadmap: RoadmapDefinition): string {
   // Critical path
   lines.push('## Critical Path');
   lines.push('');
-  lines.push(`${criticalPath.path.map(id => `S${id}`).join(' → ')} (${criticalPath.length} sprints, par ${criticalPath.totalPar})`);
+  lines.push(`${criticalPath.path.map(formatSprintLabel).join(' → ')} (${criticalPath.length} sprints, par ${criticalPath.totalPar})`);
   lines.push('');
 
   // Parallel opportunities
@@ -519,7 +558,7 @@ export function formatRoadmapSummary(roadmap: RoadmapDefinition): string {
     lines.push('## Parallel Opportunities');
     lines.push('');
     for (const group of parallelGroups) {
-      lines.push(`- ${group.sprints.map(id => `S${id}`).join(', ')}: ${group.reason}`);
+      lines.push(`- ${group.sprints.map(formatSprintLabel).join(', ')}: ${group.reason}`);
     }
     lines.push('');
   }
@@ -554,17 +593,17 @@ export function formatStrategicContext(
   // Find what depends on this sprint
   const dependents = roadmap.sprints
     .filter(s => s.depends_on?.includes(currentSprint))
-    .map(s => `S${s.id}`);
+    .map(s => formatSprintLabel(s.id));
 
   const lines: string[] = [];
-  lines.push(`Sprint ${sprintIndex} of ${totalSprints} — S${currentSprint}: ${sprint.theme}`);
+  lines.push(`Sprint ${sprintIndex} of ${totalSprints} — ${formatSprintLabel(currentSprint)}: ${sprint.theme}`);
 
   if (phase) {
     lines.push(`Phase: ${phase.name}`);
   }
 
   if (onCriticalPath) {
-    lines.push(`On critical path: ${criticalPath.path.map(id => `S${id}`).join(' → ')}`);
+    lines.push(`On critical path: ${criticalPath.path.map(formatSprintLabel).join(' → ')}`);
   }
 
   if (dependents.length > 0) {
@@ -581,8 +620,8 @@ export function formatStrategicContext(
       });
     const status = blockers.length === 0
       ? 'ready'
-      : `blocked by ${blockers.map(b => `S${b}`).join(', ')}`;
-    lines.push(`Next: S${next.id}: ${next.theme} (${status})`);
+      : `blocked by ${blockers.map(formatSprintLabel).join(', ')}`;
+    lines.push(`Next: ${formatSprintLabel(next.id)}: ${next.theme} (${status})`);
   }
 
   return lines.join('\n');
@@ -597,12 +636,13 @@ export function findNextPlannedSprint(
   roadmap: RoadmapDefinition,
   currentSprint: number,
 ): RoadmapSprint | null {
+  const currentOrder = sprintOrderValue(currentSprint);
   const candidates = roadmap.sprints
     .filter(s => {
       const status = (s as RoadmapSprint & { status?: string }).status;
-      return status !== 'complete' && s.id > currentSprint;
+      return status !== 'complete' && sprintOrderValue(s.id) > currentOrder;
     })
-    .sort((a, b) => a.id - b.id);
+    .sort((a, b) => compareSprintIds(a.id, b.id));
 
   if (candidates.length === 0) return null;
 

--- a/tests/cli/commands/agent.test.ts
+++ b/tests/cli/commands/agent.test.ts
@@ -92,6 +92,43 @@ describe('agent status (GH #310)', () => {
     expect(status.recommendedCommands).toContain('slope briefing');
   });
 
+  it('uses pending inserted roadmap sprint when no active sprint state exists (#364)', async () => {
+    writeVision(cwd);
+    writeRoadmap(cwd, [
+      { id: 43, theme: 'Done', par: 4, slope: 1, type: 'feature', status: 'complete', tickets: [
+        { key: 'S43-1', title: 't1', club: 'wedge', complexity: 'small' },
+        { key: 'S43-2', title: 't2', club: 'wedge', complexity: 'small' },
+        { key: 'S43-3', title: 't3', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 435, theme: 'Inserted', par: 4, slope: 1, type: 'bug fix', status: 'planned', tickets: [
+        { key: 'S43.5-1', title: 't1', club: 'wedge', complexity: 'small' },
+        { key: 'S43.5-2', title: 't2', club: 'wedge', complexity: 'small' },
+        { key: 'S43.5-3', title: 't3', club: 'wedge', complexity: 'small' },
+      ] },
+    ]);
+    writeFileSync(join(cwd, 'docs', 'retros', 'sprint-99.json'), JSON.stringify({
+      sprint_number: 99,
+      theme: 'Latest',
+      par: 4,
+      slope: 1,
+      score: 4,
+      score_label: 'par',
+      shots: [],
+      stats: { fairways_hit: 0, fairways_total: 0, greens_in_regulation: 0, greens_total: 0, putts: 0, penalties: 0, hazards_hit: 0, hazard_penalties: 0, miss_directions: { long: 0, short: 0, left: 0, right: 0 } },
+      conditions: [],
+      special_plays: [],
+      bunker_locations: [],
+      yardage_book_updates: [],
+      course_management_notes: [],
+    }));
+
+    const status = await collectAgentStatus(cwd);
+    expect(status.currentSprint).toBe(435);
+    expect(status.phase).toBe('unknown');
+    expect(status.nextTicket).toBe('S43.5-1');
+    expect(status.recommendedCommands).toContain('slope sprint start --number=435');
+  });
+
   it('clears blockedBy when upstream sprint has a scorecard but no roadmap status field (#356)', async () => {
     writeVision(cwd);
     writeRoadmap(cwd, [

--- a/tests/cli/commands/next.test.ts
+++ b/tests/cli/commands/next.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { nextCommand } from '../../../src/cli/commands/next.js';
+
+function makeRepo(): string {
+  const cwd = mkdtempSync(join(tmpdir(), 'slope-next-'));
+  mkdirSync(join(cwd, '.slope'), { recursive: true });
+  mkdirSync(join(cwd, 'docs', 'backlog'), { recursive: true });
+  mkdirSync(join(cwd, 'docs', 'retros'), { recursive: true });
+  writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({
+    roadmapPath: 'docs/backlog/roadmap.json',
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+  }));
+  return cwd;
+}
+
+function writeScorecard(cwd: string, sprint: number): void {
+  writeFileSync(join(cwd, 'docs', 'retros', `sprint-${sprint}.json`), JSON.stringify({
+    sprint_number: sprint,
+    theme: `Sprint ${sprint}`,
+    par: 4,
+    slope: 1,
+    score: 4,
+    score_label: 'par',
+    shots: [],
+    stats: { fairways_hit: 0, fairways_total: 0, greens_in_regulation: 0, greens_total: 0, putts: 0, penalties: 0, hazards_hit: 0, hazard_penalties: 0, miss_directions: { long: 0, short: 0, left: 0, right: 0 } },
+    conditions: [],
+    special_plays: [],
+    bunker_locations: [],
+    yardage_book_updates: [],
+    course_management_notes: [],
+  }));
+}
+
+function writeRoadmap(cwd: string): void {
+  writeFileSync(join(cwd, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+    name: 'Test',
+    phases: [{ name: 'P1', sprints: [43, 435, 44] }],
+    sprints: [
+      { id: 43, theme: 'Done', par: 4, slope: 1, type: 'feature', status: 'complete', tickets: [
+        { key: 'S43-1', title: 'done', club: 'wedge', complexity: 'small' },
+        { key: 'S43-2', title: 'done', club: 'wedge', complexity: 'small' },
+        { key: 'S43-3', title: 'done', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 435, theme: 'Inserted work', par: 4, slope: 1, type: 'bug fix', status: 'planned', tickets: [
+        { key: 'S43.5-1', title: 'inserted', club: 'wedge', complexity: 'small' },
+        { key: 'S43.5-2', title: 'inserted', club: 'wedge', complexity: 'small' },
+        { key: 'S43.5-3', title: 'inserted', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 44, theme: 'Later', par: 4, slope: 1, type: 'feature', status: 'planned', tickets: [
+        { key: 'S44-1', title: 'later', club: 'wedge', complexity: 'small' },
+        { key: 'S44-2', title: 'later', club: 'wedge', complexity: 'small' },
+        { key: 'S44-3', title: 'later', club: 'wedge', complexity: 'small' },
+      ] },
+    ],
+  }));
+}
+
+describe('slope next', () => {
+  const repos: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const repo of repos.splice(0)) rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('prefers a pending inserted roadmap sprint over scorecard+1 fallback', () => {
+    const cwd = makeRepo();
+    repos.push(cwd);
+    writeScorecard(cwd, 99);
+    writeRoadmap(cwd);
+    const originalCwd = process.cwd();
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg = '') => logs.push(String(msg)));
+
+    try {
+      process.chdir(cwd);
+      nextCommand();
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const output = logs.join('\n');
+    expect(output).toContain('Latest scorecard: S99');
+    expect(output).toContain('Next sprint: S43.5');
+    expect(output).toContain('roadmap state overrides scorecard fallback to S100');
+    expect(output).toContain('slope briefing --sprint=435');
+  });
+});

--- a/tests/cli/commands/ticket-done.test.ts
+++ b/tests/cli/commands/ticket-done.test.ts
@@ -46,6 +46,42 @@ function setupRepoWithClaim(): string {
   return dir;
 }
 
+function setupInsertedRepoWithClaim(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'slope-done-inserted-'));
+  mkdirSync(join(dir, '.slope'), { recursive: true });
+  mkdirSync(join(dir, 'docs', 'backlog'), { recursive: true });
+  mkdirSync(join(dir, 'docs', 'retros'), { recursive: true });
+  writeFileSync(join(dir, '.slope', 'config.json'), JSON.stringify({
+    roadmapPath: 'docs/backlog/roadmap.json',
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+  }));
+  writeFileSync(join(dir, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+    name: 'Test',
+    phases: [{ name: 'P1', sprints: [435] }],
+    sprints: [{
+      id: 435,
+      theme: 'Inserted',
+      par: 4,
+      slope: 1,
+      type: 'bugfix',
+      tickets: [
+        { key: 'S43.5-1', title: 'a', club: 'wedge', complexity: 'small' },
+        { key: 'S43.5-2', title: 'b', club: 'wedge', complexity: 'small' },
+        { key: 'S43.5-3', title: 'c', club: 'wedge', complexity: 'small' },
+      ],
+    }],
+  }));
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email t@t', { cwd: dir });
+  execSync('git config user.name t', { cwd: dir });
+  execSync('git commit -q --allow-empty -m init', { cwd: dir });
+  execSync(`node ${SLOPE_BIN} claim --sprint=435 --target=S43.5-1`, {
+    cwd: dir, stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return dir;
+}
+
 describe('slope ticket done (GH #316)', () => {
   beforeAll(() => {
     if (!existsSync(SLOPE_BIN)) {
@@ -87,6 +123,20 @@ describe('slope ticket done (GH #316)', () => {
         cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
       });
       expect(out).toContain('Notes:   all green');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves inserted roadmap ticket labels to the encoded sprint id', () => {
+    const cwd = setupInsertedRepoWithClaim();
+    try {
+      const out = execSync(`node ${SLOPE_BIN} ticket done S43.5-1`, {
+        cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      expect(out).toContain('Ticket S43.5-1: done.');
+      expect(out).toContain('Sprint:  S43.5');
+      expect(out).toContain('Claim:   released');
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/cli/guards/claim-required.test.ts
+++ b/tests/cli/guards/claim-required.test.ts
@@ -22,9 +22,31 @@ function makeInput(cwd: string, filePath: string): HookInput {
 function writeConfig(cwd: string, guidance: Record<string, unknown> = {}): void {
   mkdirSync(join(cwd, '.slope'), { recursive: true });
   writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({
+    roadmapPath: 'docs/backlog/roadmap.json',
     scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
     metaphor: 'golf',
     guidance,
+  }));
+}
+
+function writeInsertedRoadmap(cwd: string): void {
+  mkdirSync(join(cwd, 'docs', 'backlog'), { recursive: true });
+  writeFileSync(join(cwd, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+    name: 'Test',
+    phases: [{ name: 'P1', sprints: [43, 435] }],
+    sprints: [
+      { id: 43, theme: 'Done', par: 4, slope: 1, type: 'feature', status: 'complete', tickets: [
+        { key: 'S43-1', title: 'done', club: 'wedge', complexity: 'small' },
+        { key: 'S43-2', title: 'done', club: 'wedge', complexity: 'small' },
+        { key: 'S43-3', title: 'done', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 435, theme: 'Inserted', par: 4, slope: 1, type: 'bug fix', status: 'planned', tickets: [
+        { key: 'S43.5-1', title: 'inserted', club: 'wedge', complexity: 'small' },
+        { key: 'S43.5-2', title: 'inserted', club: 'wedge', complexity: 'small' },
+        { key: 'S43.5-3', title: 'inserted', club: 'wedge', complexity: 'small' },
+      ] },
+    ],
   }));
 }
 
@@ -131,6 +153,21 @@ describe('claimRequiredGuard', () => {
       writeConfig(cwd);
       const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'README.md')), cwd);
       expect(result).toEqual({});
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('includes pending inserted sprint context when no sprint state is active', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
+    try {
+      writeConfig(cwd);
+      writeInsertedRoadmap(cwd);
+      const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+
+      expect(result.decision).toBe('ask');
+      expect(result.context).toContain('Detected likely sprint context: S43.5');
+      expect(result.context).toContain('slope sprint start --number=435 --phase=implementing');
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/core/loader.test.ts
+++ b/tests/core/loader.test.ts
@@ -84,6 +84,14 @@ describe('loadScorecards — numeric sort', () => {
     const numbers = cards.map(c => c.sprint_number);
     expect(numbers).toEqual([5, 10]);
   });
+
+  it('loads and sorts decimal scorecard filenames for inserted sub-sprints', () => {
+    writeCard(retrosDir, 'sprint-44.json', 44);
+    writeCard(retrosDir, 'sprint-43.5.json', 43.5);
+
+    const cards = loadScorecards(baseConfig, TMP);
+    expect(cards.map(c => c.sprint_number)).toEqual([43.5, 44]);
+  });
 });
 
 describe('detectLatestSprint', () => {
@@ -104,6 +112,14 @@ describe('detectLatestSprint', () => {
 
     const latest = detectLatestSprint(baseConfig, TMP);
     expect(latest).toBe(20);
+  });
+
+  it('orders decimal inserted scorecards before the next canonical sprint', () => {
+    writeCard(retrosDir, 'sprint-43.5.json', 43.5);
+    writeCard(retrosDir, 'sprint-44.json', 44);
+
+    const latest = detectLatestSprint(baseConfig, TMP);
+    expect(latest).toBe(44);
   });
 
   it('returns 0 for no scorecards', () => {

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -6,6 +6,8 @@ import {
   parseRoadmap,
   formatRoadmapSummary,
   formatStrategicContext,
+  formatSprintLabel,
+  sprintOrderValue,
   findNextPlannedSprint,
 } from '../../src/core/roadmap.js';
 import type { RoadmapDefinition, RoadmapSprint, RoadmapTicket } from '../../src/core/roadmap.js';
@@ -43,6 +45,23 @@ function makeRoadmap(overrides: Partial<RoadmapDefinition> = {}): RoadmapDefinit
   };
 }
 
+describe('sprint id formatting', () => {
+  it('formats canonical, decimal, and encoded inserted sprint ids', () => {
+    expect(formatSprintLabel(43)).toBe('S43');
+    expect(formatSprintLabel(43.5)).toBe('S43.5');
+    expect(formatSprintLabel(435)).toBe('S43.5');
+    expect(formatSprintLabel(95)).toBe('S95');
+    expect(formatSprintLabel(100)).toBe('S100');
+    expect(formatSprintLabel(101)).toBe('S101');
+    expect(formatSprintLabel(203)).toBe('S203');
+  });
+
+  it('sorts encoded inserted ids between surrounding canonical sprints', () => {
+    expect(sprintOrderValue(435)).toBe(43.5);
+    expect([44, 435, 43].sort((a, b) => sprintOrderValue(a) - sprintOrderValue(b))).toEqual([43, 435, 44]);
+  });
+});
+
 // --- validateRoadmap ---
 
 describe('validateRoadmap', () => {
@@ -66,6 +85,34 @@ describe('validateRoadmap', () => {
     const result = validateRoadmap(roadmap);
     expect(result.valid).toBe(false);
     expect(result.errors.some(e => e.message.includes('gap'))).toBe(true);
+  });
+
+  it('allows inserted decimal sprint ids between canonical sprints', () => {
+    const roadmap = makeRoadmap({
+      sprints: [makeSprint(75), makeSprint(75.5), makeSprint(76)],
+      phases: [{ name: 'P1', sprints: [75, 75.5, 76] }],
+    });
+    const result = validateRoadmap(roadmap);
+    expect(result.errors.some(e => e.message.includes('gap'))).toBe(false);
+  });
+
+  it('accepts encoded inserted sprint ids with decimal ticket prefixes', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        makeSprint(43),
+        makeSprint(435, {
+          tickets: [
+            { ...makeTicket(435, 1), key: 'S43.5-1' },
+            { ...makeTicket(435, 2), key: 'S43.5-2' },
+            { ...makeTicket(435, 3), key: 'S43.5-3' },
+          ],
+        }),
+        makeSprint(44),
+      ],
+      phases: [{ name: 'P1', sprints: [43, 435, 44] }],
+    });
+    const result = validateRoadmap(roadmap);
+    expect(result.errors).toEqual([]);
   });
 
   it('detects duplicate sprint IDs', () => {
@@ -527,6 +574,25 @@ describe('findNextPlannedSprint', () => {
     });
     const next = findNextPlannedSprint(roadmap, 8);
     expect(next?.id).toBe(9);
+  });
+
+  it('orders encoded inserted sprints before the next canonical sprint', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        { ...makeSprint(43), status: 'complete' } as any,
+        makeSprint(435, {
+          tickets: [
+            { ...makeTicket(435, 1), key: 'S43.5-1' },
+            { ...makeTicket(435, 2), key: 'S43.5-2' },
+            { ...makeTicket(435, 3), key: 'S43.5-3' },
+          ],
+        }),
+        makeSprint(44),
+      ],
+      phases: [{ name: 'P1', sprints: [43, 435, 44] }],
+    });
+    const next = findNextPlannedSprint(roadmap, 43);
+    expect(next?.id).toBe(435);
   });
 
   it('skips complete sprints', () => {


### PR DESCRIPTION
## Summary

Implements S95 / #364 inserted sprint recovery.

- Adds sprint id formatting and ordering helpers so encoded inserted ids like `435` display and sort as `S43.5`.
- Makes `next`, `status`, `briefing`, `agent status`, claim defaults, and the claim-required guard infer pending roadmap sprint context before falling back to scorecard + 1.
- Allows decimal scorecard filenames and decimal ticket labels, and resolves `ticket done S43.5-*` back to encoded roadmap sprint ids.
- Documents inserted sub-sprint usage in getting started.

Fixes #364.

## Validation

- `pnpm build`
- `pnpm exec tsc --noEmit`
- `pnpm vitest run tests/cli/commands/ticket-done.test.ts tests/core/roadmap.test.ts tests/core/loader.test.ts tests/cli/commands/next.test.ts tests/cli/commands/agent.test.ts tests/cli/guards/claim-required.test.ts`
- `pnpm test`
- `node dist/cli/index.js next`
- `node dist/cli/index.js status`
- `node dist/cli/index.js agent status --json`
- `node dist/cli/index.js roadmap validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inserted sub-sprints using decimal identifiers (e.g., S43.5) for work scheduled between existing sprints.
  * Enhanced sprint context inference to automatically detect the next active sprint.

* **Bug Fixes**
  * Improved sprint detection when no active sprint state exists.

* **Documentation**
  * Added comprehensive guide for managing inserted sub-sprints in your workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->