### PR TITLE
chore: bump version to 1.55.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.55.6",
+  "version": "1.55.7",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Bumps `@slope-dev/slope` from `1.55.6` to `1.55.7` for the S95 inserted sprint recovery release.

## Validation

Already run on `main` before this bump commit:

- `pnpm build`
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `node dist/cli/index.js version` -> `@slope-dev/slope v1.55.7`