### PR TITLE
fix(next): ignore superseded roadmap sprints

### DIFF
--- a/src/cli/sprint-inference.ts
+++ b/src/cli/sprint-inference.ts
@@ -6,6 +6,7 @@ import {
   detectLatestSprint,
   formatSprintLabel,
   isEncodedInsertedSprintId,
+  isRoadmapSprintPending,
   loadScorecards,
   parseRoadmap,
   sprintOrderValue,
@@ -49,8 +50,7 @@ export function inferSprintContext(cwd: string = process.cwd(), config: SlopeCon
   const completedIds = new Set<number>(scorecards.map(card => card.sprint_number));
   const pendingSprints = roadmap?.sprints
     .filter(sprint => {
-      const status = (sprint as RoadmapSprint & { status?: string }).status;
-      return status !== 'complete' && !completedIds.has(sprint.id);
+      return isRoadmapSprintPending(sprint) && !completedIds.has(sprint.id);
     })
     .sort((a, b) => compareSprintIds(a.id, b.id)) ?? [];
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -173,6 +173,7 @@ export {
   formatSprintNumber,
   findNextPlannedSprint,
   isEncodedInsertedSprintId,
+  isRoadmapSprintPending,
   sprintOrderValue,
   compareSprintIds,
 } from './roadmap.js';

--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -98,6 +98,12 @@ export function compareSprintIds(a: number, b: number): number {
   return sprintOrderValue(a) - sprintOrderValue(b);
 }
 
+/** Return true when a roadmap sprint should still be considered selectable work. */
+export function isRoadmapSprintPending(sprint: RoadmapSprint): boolean {
+  const status = (sprint as RoadmapSprint & { status?: string }).status;
+  return status !== 'complete' && status !== 'superseded';
+}
+
 /** Validate a roadmap definition for structural correctness.
  *  Optionally cross-check sprint status against scorecards and/or shipped
  *  sprint commits on main when provided. Caller is responsible for collecting
@@ -639,8 +645,7 @@ export function findNextPlannedSprint(
   const currentOrder = sprintOrderValue(currentSprint);
   const candidates = roadmap.sprints
     .filter(s => {
-      const status = (s as RoadmapSprint & { status?: string }).status;
-      return status !== 'complete' && sprintOrderValue(s.id) > currentOrder;
+      return isRoadmapSprintPending(s) && sprintOrderValue(s.id) > currentOrder;
     })
     .sort((a, b) => compareSprintIds(a.id, b.id));
 

--- a/tests/cli/commands/next.test.ts
+++ b/tests/cli/commands/next.test.ts
@@ -59,6 +59,25 @@ function writeRoadmap(cwd: string): void {
   }));
 }
 
+function writeSupersededRoadmap(cwd: string): void {
+  writeFileSync(join(cwd, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+    name: 'Test',
+    phases: [{ name: 'P1', sprints: [75.5, 96] }],
+    sprints: [
+      { id: 75.5, theme: 'Old inserted work', par: 4, slope: 1, type: 'bug fix', status: 'superseded', tickets: [
+        { key: 'S75.5-1', title: 'old', club: 'wedge', complexity: 'small' },
+        { key: 'S75.5-2', title: 'old', club: 'wedge', complexity: 'small' },
+        { key: 'S75.5-3', title: 'old', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 96, theme: 'Current work', par: 4, slope: 1, type: 'feature', status: 'planned', tickets: [
+        { key: 'S96-1', title: 'current', club: 'wedge', complexity: 'small' },
+        { key: 'S96-2', title: 'current', club: 'wedge', complexity: 'small' },
+        { key: 'S96-3', title: 'current', club: 'wedge', complexity: 'small' },
+      ] },
+    ],
+  }));
+}
+
 describe('slope next', () => {
   const repos: string[] = [];
 
@@ -88,5 +107,27 @@ describe('slope next', () => {
     expect(output).toContain('Next sprint: S43.5');
     expect(output).toContain('roadmap state overrides scorecard fallback to S100');
     expect(output).toContain('slope briefing --sprint=435');
+  });
+
+  it('ignores superseded roadmap sprints when selecting the next sprint', () => {
+    const cwd = makeRepo();
+    repos.push(cwd);
+    writeScorecard(cwd, 95);
+    writeSupersededRoadmap(cwd);
+    const originalCwd = process.cwd();
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg = '') => logs.push(String(msg)));
+
+    try {
+      process.chdir(cwd);
+      nextCommand();
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const output = logs.join('\n');
+    expect(output).toContain('Latest scorecard: S95');
+    expect(output).toContain('Next sprint: S96');
+    expect(output).not.toContain('S75.5');
   });
 });

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -607,6 +607,18 @@ describe('findNextPlannedSprint', () => {
     expect(next?.id).toBe(9);
   });
 
+  it('skips superseded sprints', () => {
+    const roadmap = makeRoadmap({
+      sprints: [
+        { ...makeSprint(7), status: 'complete' } as any,
+        { ...makeSprint(8), status: 'superseded' } as any,
+        { ...makeSprint(9), status: 'planned' } as any,
+      ],
+    });
+    const next = findNextPlannedSprint(roadmap, 7);
+    expect(next?.id).toBe(9);
+  });
+
   it('returns null when no later sprints exist', () => {
     const roadmap = makeRoadmap({
       sprints: [


### PR DESCRIPTION
## Summary

Fixes `slope next` selecting roadmap sprints marked `superseded` as pending work.

- Adds `isRoadmapSprintPending` as the shared roadmap status predicate.
- Uses it in sprint inference and `findNextPlannedSprint`.
- Adds regression coverage for `slope next` and roadmap next-sprint selection.

## Validation

- `pnpm vitest run tests/cli/commands/next.test.ts tests/core/roadmap.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm test`
- `node dist/cli/index.js next` -> `S96` instead of superseded `S75.5`
- `node dist/cli/index.js roadmap validate`