### PR TITLE
fix: repair vision parsing and roadmap generation

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -125,8 +125,16 @@
       "sprints": [
         95
       ],
-      "status": "planned",
+      "status": "complete",
       "note": "Resolve #364 by making roadmap-inserted sub-sprints and missing active state explicit in next/status/briefing and guard guidance."
+    },
+    {
+      "name": "Phase 25 \u2014 Vision & Roadmap Generation Repair",
+      "sprints": [
+        96
+      ],
+      "status": "planned",
+      "note": "Close #376/#377 by preserving natural-language vision priorities and making roadmap generation refuse shallow placeholder output when backlog analysis yields no concrete work."
     }
   ],
   "sprints": [
@@ -1428,6 +1436,54 @@
           "depends_on": [
             "S95-1",
             "S95-2"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 96,
+      "theme": "Vision & Roadmap Generation Repair",
+      "par": 4,
+      "slope": 2,
+      "type": "bug fix + dx",
+      "status": "planned",
+      "depends_on": [
+        95
+      ],
+      "note": "Address newly filed generator issues before Codex plugin work: preserve commas inside parenthesized vision list items and stop roadmap generation from emitting thin planning stubs while claiming backlog analysis.",
+      "tickets": [
+        {
+          "key": "S96-1",
+          "title": "Make vision priorities and non-goals split only on top-level commas (#376)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 376
+        },
+        {
+          "key": "S96-2",
+          "title": "Add vision create/update regression coverage for parenthesized commas (#376)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 376,
+          "depends_on": [
+            "S96-1"
+          ]
+        },
+        {
+          "key": "S96-3",
+          "title": "Remove shallow Investigate-and-plan roadmap stubs and fail loudly with no concrete backlog (#377)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 377
+        },
+        {
+          "key": "S96-4",
+          "title": "Update roadmap generate CLI messaging and tests for concrete backlog requirements (#377)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 377,
+          "depends_on": [
+            "S96-3"
           ]
         }
       ]

--- a/docs/retros/sprint-96.json
+++ b/docs/retros/sprint-96.json
@@ -1,0 +1,112 @@
+{
+  "sprint_number": 96,
+  "player": "sebastianbryers",
+  "theme": "Vision & Roadmap Generation Repair",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-17",
+  "shots": [
+    {
+      "ticket_key": "S96-1",
+      "title": "Make vision priorities and non-goals split only on top-level commas (#376)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added top-level comma parser for vision priorities/non-goals, preserving commas inside (), [], {}, and quoted strings."
+    },
+    {
+      "ticket_key": "S96-2",
+      "title": "Add vision create/update regression coverage for parenthesized commas (#376)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Covered direct parser behavior plus create/update command writes for priorities and non-goals."
+    },
+    {
+      "ticket_key": "S96-3",
+      "title": "Remove shallow Investigate-and-plan roadmap stubs and fail loudly with no concrete backlog (#377)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Removed placeholder sprint fallback and added RoadmapGenerationError for empty/no-signal generation."
+    },
+    {
+      "ticket_key": "S96-4",
+      "title": "Update roadmap generate CLI messaging and tests for concrete backlog requirements (#377)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "auto-card could not match fix(96) commit subjects to explicit S96-N ticket keys, requiring include-untracked and manual scorecard correction."
+        }
+      ],
+      "notes": "CLI now says concrete backlog signals are required and prints a clear failure path instead of writing placeholders."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "rough",
+      "impact": "minor",
+      "description": "Commit subjects used sprint-level fix(96)/docs(96) scopes rather than explicit S96-N ticket keys, so auto-card could not assign all roadmap tickets automatically."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "When fixing generated output quality, delete misleading fallbacks before adding richer generation paths.",
+      "outcome": "roadmap generate now fails loudly with no concrete backlog instead of producing unusable planning stubs."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "review",
+      "description": "Local review recommendation was probed; it requires architect review for a four-ticket sprint, but the command undercounted table-form sprint plans and should be fixed separately.",
+      "status": "watch"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Small surface area, but worth being strict because the old generator looked successful while producing work no one should use.",
+    "advice_for_next_player": "Keep roadmap generation honest: either mine real backlog signals or stop with an actionable error.",
+    "what_surprised_you": "review recommend still reads H3-style plans, while slope sprint plan now emits a ticket table.",
+    "excited_about_next": "Release this with the superseded-sprint fix so global slope has the current planning behavior."
+  },
+  "bunker_locations": [
+    "auto-card could not match fix(96) commit subjects to explicit S96-N ticket keys, requiring include-untracked and manual scorecard correction."
+  ],
+  "yardage_book_updates": [
+    "Use explicit S{N}-{M} ticket keys in commit subjects when auto-card should map commits to planned roadmap tickets without manual correction."
+  ],
+  "course_management_notes": [
+    "roadmap generate now refuses no-signal output; this is intentionally narrower than building full CODEBASE/GitHub issue mining in the same sprint."
+  ],
+  "slope_factors": [
+    "cli_parser",
+    "generation_failure_mode"
+  ],
+  "_auto_generated": true,
+  "_commits": 3,
+  "_ci_signal": null,
+  "_pr_signal": null,
+  "_note": "Auto-generated from git only (no CI). Shots default to green. Provide --test-output for better scoring."
+}

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -16,6 +16,7 @@ import {
   runAnalyzers,
   estimateComplexity,
   generateRoadmapFromVision,
+  RoadmapGenerationError,
 } from '../../core/index.js';
 import type { RoadmapDefinition, RoadmapSprint, RoadmapTicket, RoadmapClub, GolfScorecard } from '../../core/index.js';
 import { loadConfig } from '../config.js';
@@ -437,7 +438,7 @@ async function generateSubcommand(flags: Record<string, string>, cwd: string): P
     process.exit(1);
   }
 
-  console.log('\nGenerating roadmap from vision + backlog...');
+  console.log('\nGenerating roadmap from vision + concrete backlog signals...');
 
   const localBacklog = await analyzeBacklog(cwd);
   const backlog = mergeBacklogs(localBacklog);
@@ -450,7 +451,20 @@ async function generateSubcommand(flags: Record<string, string>, cwd: string): P
     console.log('  Warning: Could not estimate complexity, using defaults.');
   }
 
-  const roadmap = generateRoadmapFromVision(vision, backlog, complexity);
+  let roadmap: ReturnType<typeof generateRoadmapFromVision>;
+  try {
+    roadmap = generateRoadmapFromVision(vision, backlog, complexity);
+  } catch (err) {
+    if (err instanceof RoadmapGenerationError) {
+      console.error(`\nError: ${err.message}`);
+      console.error('\nTo generate a useful roadmap, provide at least one concrete backlog signal:');
+      console.error('  - add TODO/FIXME/HACK comments in source files');
+      console.error('  - sync or provide issue data before generation');
+      console.error('  - write the roadmap manually when the vision is intentionally high-level\n');
+      process.exit(1);
+    }
+    throw err;
+  }
 
   const validation = validateRoadmap(roadmap);
   if (!validation.valid) {
@@ -535,12 +549,16 @@ Usage:
   slope roadmap status [--path=<file>] [--sprint=N]  Current progress
   slope roadmap show [--path=<file>]         Render summary (critical path, parallel tracks)
   slope roadmap sync [--path=<file>] [--dry-run]     Sync scorecards into roadmap
-  slope roadmap generate [--path=<file>] [--dry-run] Generate from vision + backlog analysis
+  slope roadmap generate [--path=<file>] [--dry-run] Generate from vision + concrete backlog signals
 
 Options:
   --path=<file>    Path to roadmap JSON (default: docs/backlog/roadmap.json)
   --sprint=N       Override current sprint number (for status)
   --dry-run        Show what would change without writing (for sync and generate)
+
+Generate requires concrete backlog signals from source TODO/FIXME/HACK comments
+or synced issue data. It fails instead of creating placeholder planning tickets
+when there is nothing concrete to mine.
 `);
       if (sub) process.exit(1);
   }

--- a/src/cli/commands/vision.ts
+++ b/src/cli/commands/vision.ts
@@ -10,6 +10,62 @@ function parseArgs(args: string[]): Record<string, string> {
   return result;
 }
 
+export function splitTopLevelCommaList(input: string): string[] {
+  const items: string[] = [];
+  let current = '';
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  for (const char of input) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      current += char;
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      current += char;
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+
+    if (char === '(') parenDepth++;
+    if (char === ')' && parenDepth > 0) parenDepth--;
+    if (char === '[') bracketDepth++;
+    if (char === ']' && bracketDepth > 0) bracketDepth--;
+    if (char === '{') braceDepth++;
+    if (char === '}' && braceDepth > 0) braceDepth--;
+
+    if (char === ',' && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      const trimmed = current.trim();
+      if (trimmed) items.push(trimmed);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  const trimmed = current.trim();
+  if (trimmed) items.push(trimmed);
+  return items;
+}
+
 function createSubcommand(flags: Record<string, string>): void {
   if (!flags.purpose) {
     console.error('Error: --purpose is required.');
@@ -17,9 +73,7 @@ function createSubcommand(flags: Record<string, string>): void {
     process.exit(1);
   }
 
-  const priorities = flags.priorities
-    ? flags.priorities.split(',').map(s => s.trim()).filter(Boolean)
-    : [];
+  const priorities = flags.priorities ? splitTopLevelCommaList(flags.priorities) : [];
 
   if (priorities.length === 0) {
     console.error('Error: --priorities is required (comma-separated list).');
@@ -32,9 +86,7 @@ function createSubcommand(flags: Record<string, string>): void {
       priorities,
       audience: flags.audience,
       techDirection: flags['tech-direction'],
-      nonGoals: flags['non-goals']
-        ? flags['non-goals'].split(',').map(s => s.trim()).filter(Boolean)
-        : undefined,
+      nonGoals: flags['non-goals'] ? splitTopLevelCommaList(flags['non-goals']) : undefined,
     });
     console.log('\nVision created successfully.\n');
     console.log(`  Purpose:    ${vision.purpose}`);
@@ -59,10 +111,10 @@ function createSubcommand(flags: Record<string, string>): void {
 function updateSubcommand(flags: Record<string, string>): void {
   const fields: Record<string, unknown> = {};
   if (flags.purpose) fields.purpose = flags.purpose;
-  if (flags.priorities) fields.priorities = flags.priorities.split(',').map(s => s.trim()).filter(Boolean);
+  if (flags.priorities) fields.priorities = splitTopLevelCommaList(flags.priorities);
   if (flags.audience) fields.audience = flags.audience;
   if (flags['tech-direction']) fields.techDirection = flags['tech-direction'];
-  if (flags['non-goals']) fields.nonGoals = flags['non-goals'].split(',').map(s => s.trim()).filter(Boolean);
+  if (flags['non-goals']) fields.nonGoals = splitTopLevelCommaList(flags['non-goals']);
 
   if (Object.keys(fields).length === 0) {
     console.error('Error: provide at least one field to update.');
@@ -108,10 +160,10 @@ Usage:
 
 Create options:
   --purpose="..."             Project purpose (required)
-  --priorities="a,b,c"        Comma-separated priorities (required)
+  --priorities="a,b,c"        Comma-separated priorities; commas inside (), [], {} are preserved (required)
   --audience="..."            Target audience
   --tech-direction="..."      Technical direction
-  --non-goals="a,b"           Comma-separated non-goals
+  --non-goals="a,b"           Comma-separated non-goals; commas inside (), [], {} are preserved
   --write-md[=<path>]         Also write tracked Markdown (default: docs/vision.md)
 
 Update options:

--- a/src/core/generators/roadmap.ts
+++ b/src/core/generators/roadmap.ts
@@ -10,6 +10,13 @@ import type { TodoEntry } from '../analyzers/backlog.js';
 
 const ISSUE_REF_PATTERN = /(?:depends\s+on\s+#(\d+)|blocked\s+by\s+#(\d+)|requires\s+#(\d+)|after\s+#(\d+))/gi;
 
+export class RoadmapGenerationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RoadmapGenerationError';
+  }
+}
+
 /**
  * Generate a roadmap from repo analysis data.
  *
@@ -331,14 +338,7 @@ export function generateRoadmapFromVision(
       });
     }
 
-    if (tickets.length === 0) {
-      tickets.push({
-        key: `S${sprintNum}-1`,
-        title: `Investigate and plan ${priority} improvements`,
-        club: 'short_iron' as RoadmapClub,
-        complexity: 'standard',
-      });
-    }
+    if (tickets.length === 0) continue;
 
     sprints.push({
       id: sprintNum,
@@ -390,6 +390,12 @@ export function generateRoadmapFromVision(
       name: `Phase ${phases.length + 1} — General`,
       sprints: [sprintNum],
     });
+  }
+
+  if (sprints.length === 0) {
+    throw new RoadmapGenerationError(
+      'vision is too abstract for auto-generation. Roadmap generation needs concrete backlog signals from source TODO/FIXME/HACK comments or synced issue data; no placeholder planning tickets were created.',
+    );
   }
 
   return {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -629,7 +629,7 @@ export type { MergedBacklog } from './analyzers/backlog-merged.js';
 export { generateConfig } from './generators/config.js';
 export { generateFirstSprint } from './generators/first-sprint.js';
 export { generateCommonIssues } from './generators/common-issues.js';
-export { generateRoadmap, generateRoadmapFromVision } from './generators/roadmap.js';
+export { generateRoadmap, generateRoadmapFromVision, RoadmapGenerationError } from './generators/roadmap.js';
 export type { GeneratedConfig } from './generators/config.js';
 export type { GeneratedSprint } from './generators/first-sprint.js';
 

--- a/tests/cli/commands/roadmap-generate-dry-run.test.ts
+++ b/tests/cli/commands/roadmap-generate-dry-run.test.ts
@@ -63,5 +63,26 @@ describe('slope roadmap generate --dry-run (GH #304)', () => {
     const out = execSync(`node ${SLOPE_BIN} roadmap`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
     expect(out).toMatch(/generate\s+\[--path=<file>\]\s+\[--dry-run\]/);
     expect(out).toContain('sync and generate');
+    expect(out).toContain('concrete backlog signals');
+  });
+
+  it('fails loudly instead of writing placeholders when no backlog can be mined', () => {
+    const cwd = setupRepo();
+    const roadmapPath = join(cwd, 'docs', 'backlog', 'roadmap.json');
+    try {
+      execSync(`node ${SLOPE_BIN} roadmap generate --dry-run`, {
+        cwd,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      throw new Error('Expected roadmap generate to fail without concrete backlog signals');
+    } catch (err) {
+      const error = err as { stderr?: string };
+      expect(error.stderr).toContain('vision is too abstract');
+      expect(error.stderr).toContain('no placeholder planning tickets were created');
+      expect(existsSync(roadmapPath)).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/cli/commands/vision-list-parser.test.ts
+++ b/tests/cli/commands/vision-list-parser.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { splitTopLevelCommaList, visionCommand } from '../../../src/cli/commands/vision.js';
+
+let cwd: string;
+let previousCwd: string;
+
+function readVision(): { priorities: string[]; nonGoals?: string[] } {
+  return JSON.parse(readFileSync(join(cwd, '.slope', 'vision.json'), 'utf8')) as {
+    priorities: string[];
+    nonGoals?: string[];
+  };
+}
+
+describe('vision list parsing', () => {
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    cwd = mkdtempSync(join(tmpdir(), 'slope-vision-list-'));
+    process.chdir(cwd);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    rmSync(cwd, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('splits only on top-level commas', () => {
+    expect(splitTopLevelCommaList('Guests (find info, share moments live), Admin (manage X, Y, Z)')).toEqual([
+      'Guests (find info, share moments live)',
+      'Admin (manage X, Y, Z)',
+    ]);
+  });
+
+  it('preserves parenthesized commas in vision create priorities and non-goals', async () => {
+    await visionCommand([
+      'create',
+      '--purpose=Test vision',
+      '--priorities=Guests on the day-of (find info, share moments live),Us as admin (manage X, Y, Z)',
+      '--non-goals=Reports (CSV, PDF),Billing',
+    ]);
+
+    expect(readVision()).toMatchObject({
+      priorities: [
+        'Guests on the day-of (find info, share moments live)',
+        'Us as admin (manage X, Y, Z)',
+      ],
+      nonGoals: ['Reports (CSV, PDF)', 'Billing'],
+    });
+  });
+
+  it('preserves parenthesized commas in vision update priorities and non-goals', async () => {
+    await visionCommand([
+      'create',
+      '--purpose=Test vision',
+      '--priorities=Initial',
+    ]);
+
+    await visionCommand([
+      'update',
+      '--priorities=Guests (find info, share moments live),Admins (manage X, Y, Z)',
+      '--non-goals=Exports (CSV, PDF),Billing',
+    ]);
+
+    expect(readVision()).toMatchObject({
+      priorities: [
+        'Guests (find info, share moments live)',
+        'Admins (manage X, Y, Z)',
+      ],
+      nonGoals: ['Exports (CSV, PDF)', 'Billing'],
+    });
+  });
+});

--- a/tests/core/generators/roadmap-from-vision.test.ts
+++ b/tests/core/generators/roadmap-from-vision.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateRoadmapFromVision } from '../../../src/core/generators/roadmap.js';
+import { RoadmapGenerationError, generateRoadmapFromVision } from '../../../src/core/generators/roadmap.js';
 import { validateRoadmap } from '../../../src/core/roadmap.js';
 import type { VisionDocument } from '../../../src/core/analyzers/types.js';
 import type { ComplexityProfile } from '../../../src/core/analyzers/complexity.js';
@@ -56,18 +56,15 @@ function makeRemoteBacklog(issues: GitHubIssue[]): GitHubBacklogAnalysis {
 }
 
 describe('generateRoadmapFromVision', () => {
-  it('creates sprints from vision priorities with empty backlog', () => {
-    const roadmap = generateRoadmapFromVision(makeVision(), makeEmptyBacklog());
-    expect(roadmap.sprints).toHaveLength(2);
-    expect(roadmap.phases).toHaveLength(2);
-    expect(roadmap.sprints[0].theme).toBe('reliability');
-    expect(roadmap.sprints[0].tickets).toHaveLength(1);
-    expect(roadmap.sprints[0].tickets[0].title).toContain('reliability');
-    expect(roadmap.sprints[1].theme).toBe('speed');
+  it('fails loudly instead of creating placeholder sprints with empty backlog', () => {
+    expect(() => generateRoadmapFromVision(makeVision(), makeEmptyBacklog())).toThrow(RoadmapGenerationError);
+    expect(() => generateRoadmapFromVision(makeVision(), makeEmptyBacklog())).toThrow('vision is too abstract');
   });
 
-  it('passes validateRoadmap', () => {
-    const result = validateRoadmap(generateRoadmapFromVision(makeVision(), makeEmptyBacklog()));
+  it('passes validateRoadmap when concrete backlog exists', () => {
+    const todos = [makeTodo({ text: 'Add retry test coverage', file: 'src/reliability.ts', line: 5 })];
+    const backlog: MergedBacklog = { local: makeLocalBacklog(todos), totalItems: 1 };
+    const result = validateRoadmap(generateRoadmapFromVision(makeVision({ priorities: ['reliability'] }), backlog));
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
   });
@@ -112,13 +109,17 @@ describe('generateRoadmapFromVision', () => {
   });
 
   it('uses complexity profile for par/slope', () => {
-    const roadmap = generateRoadmapFromVision(makeVision({ priorities: ['reliability'] }), makeEmptyBacklog(), makeComplexity());
+    const todos = [makeTodo({ text: 'Add retry test coverage', file: 'src/reliability.ts', line: 5 })];
+    const backlog: MergedBacklog = { local: makeLocalBacklog(todos), totalItems: 1 };
+    const roadmap = generateRoadmapFromVision(makeVision({ priorities: ['reliability'] }), backlog, makeComplexity());
     expect(roadmap.sprints[0].par).toBe(4);
     expect(roadmap.sprints[0].slope).toBe(2);
   });
 
   it('uses defaults when no complexity provided', () => {
-    const roadmap = generateRoadmapFromVision(makeVision({ priorities: ['reliability'] }), makeEmptyBacklog());
+    const todos = [makeTodo({ text: 'Add retry test coverage', file: 'src/reliability.ts', line: 5 })];
+    const backlog: MergedBacklog = { local: makeLocalBacklog(todos), totalItems: 1 };
+    const roadmap = generateRoadmapFromVision(makeVision({ priorities: ['reliability'] }), backlog);
     expect(roadmap.sprints[0].par).toBe(4);
     expect(roadmap.sprints[0].slope).toBe(3);
   });
@@ -134,9 +135,21 @@ describe('generateRoadmapFromVision', () => {
   });
 
   it('creates proper phase names with capitalized priority', () => {
-    const roadmap = generateRoadmapFromVision(makeVision({ priorities: ['dx'] }), makeEmptyBacklog());
+    const todos = [makeTodo({ text: 'Improve CLI tooling', file: 'src/cli/tool.ts', line: 1 })];
+    const backlog: MergedBacklog = { local: makeLocalBacklog(todos), totalItems: 1 };
+    const roadmap = generateRoadmapFromVision(makeVision({ priorities: ['dx'] }), backlog);
     expect(roadmap.phases[0].name).toContain('Dx');
     expect(roadmap.phases[0].sprints).toEqual([1]);
+  });
+
+  it('does not create investigate-and-plan placeholders for unmatched priorities', () => {
+    const todos = [makeTodo({ text: 'Add database index', file: 'src/db.ts', line: 1 })];
+    const backlog: MergedBacklog = { local: makeLocalBacklog(todos), totalItems: 1 };
+    const roadmap = generateRoadmapFromVision(makeVision({ priorities: ['reliability'] }), backlog);
+
+    const allTickets = roadmap.sprints.flatMap(s => s.tickets);
+    expect(allTickets.map(t => t.title)).not.toContain('Investigate and plan reliability improvements');
+    expect(roadmap.sprints.find(s => s.theme === 'General')?.tickets[0].title).toContain('database index');
   });
 
   it('generates valid ticket keys', () => {


### PR DESCRIPTION
## Summary
- fix `slope vision create/update` list parsing so commas inside parentheses/brackets/braces are preserved for priorities and non-goals
- stop `slope roadmap generate` from creating `Investigate and plan ...` placeholder tickets when no concrete backlog signals exist
- add S96 roadmap scope, scorecard, and regression coverage for #376 and #377

## Validation
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `node dist/cli/index.js validate docs/retros/sprint-96.json`
- `node dist/cli/index.js roadmap validate`

Closes #376.
Closes #377.