### PR TITLE
chore: bump version to 1.55.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.55.7",
+  "version": "1.55.8",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bump @slope-dev/slope from 1.55.7 to 1.55.8

## Release contents
- #375 superseded roadmap sprint filtering
- #378 vision list parsing and roadmap generator failure-mode fixes

## Validation
- S96 implementation PR checks passed before merge
- this PR is version-only