### PR TITLE
chore: bump version to 1.55.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.55.8",
+  "version": "1.55.9",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bump @slope-dev/slope from 1.55.8 to 1.55.9

## Release contents
- #380 review recommendation now counts table-form sprint plans emitted by `slope sprint plan`

## Validation
- #380 checks passed before merge
- this PR is version-only