### PR TITLE
Fix session state source-of-truth drift

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -1596,6 +1596,59 @@
           ]
         }
       ]
+    },
+    {
+      "id": 99,
+      "theme": "Session State Source-of-Truth Repair",
+      "par": 4,
+      "slope": 3,
+      "type": "bug fix + dx",
+      "status": "planned",
+      "depends_on": [
+        98
+      ],
+      "note": "Fix the session-state split exposed by mid-session sprint starts: status commands, briefing, and workflow guards must agree on the active sprint and must not stay pinned in adhoc mode once a sprint is started.",
+      "tickets": [
+        {
+          "key": "S99-1",
+          "title": "Make sprint-state the active sprint source for status and briefing (#389)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 389
+        },
+        {
+          "key": "S99-2",
+          "title": "Promote adhoc session mode to sprint when a sprint starts mid-session (#387/#388)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 387,
+          "depends_on": [
+            "S99-1"
+          ]
+        },
+        {
+          "key": "S99-3",
+          "title": "Keep workflow guard suppression aligned with live sprint state (#387)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 387,
+          "depends_on": [
+            "S99-2"
+          ]
+        },
+        {
+          "key": "S99-4",
+          "title": "Add fresh-session and worktree regressions for sprint status/session mode drift (#387/#388/#389)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 387,
+          "depends_on": [
+            "S99-1",
+            "S99-2",
+            "S99-3"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -1603,7 +1603,9 @@
       "par": 4,
       "slope": 3,
       "type": "bug fix + dx",
-      "status": "planned",
+      "status": "complete",
+      "score": 4,
+      "score_label": "par",
       "depends_on": [
         98
       ],

--- a/docs/retros/sprint-99.json
+++ b/docs/retros/sprint-99.json
@@ -1,0 +1,107 @@
+{
+  "sprint_number": 99,
+  "player": "sebastianbryers",
+  "theme": "Session State Source-of-Truth Repair",
+  "par": 4,
+  "slope": 3,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-19",
+  "shots": [
+    {
+      "ticket_key": "S99-1",
+      "title": "Make sprint-state the active sprint source for status and briefing (#389)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added active sprint-state precedence to sprint inference so status, briefing, claim defaults, and other inferred sprint commands agree with .slope/sprint-state.json."
+    },
+    {
+      "ticket_key": "S99-2",
+      "title": "Promote adhoc session mode to sprint when a sprint starts mid-session (#387/#388)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added session-mode synchronization that promotes an adhoc-pinned session to sprint mode whenever active sprint-state appears."
+    },
+    {
+      "ticket_key": "S99-3",
+      "title": "Keep workflow guard suppression aligned with live sprint state (#387)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Routed adhoc guard suppression through live sprint-state synchronization so workflow guards no longer stay suppressed after mid-session sprint start."
+    },
+    {
+      "ticket_key": "S99-4",
+      "title": "Add fresh-session and worktree regressions for sprint status/session mode drift (#387/#388/#389)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added focused tests for sprint inference, slope status, guard suppression, and session-briefing dedup after sprint-state appears."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "wind",
+      "impact": "minor",
+      "description": "slope review recommend still selected a stale Sprint 29 plan, so PR review routing should use the concrete PR review command for this sprint."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Session mode is derived state; active sprint-state must be allowed to repair stale adhoc pins.",
+      "outcome": "isAdhocSession now synchronizes with live sprint-state before suppressing sprint-workflow guards."
+    },
+    {
+      "type": "lessons",
+      "description": "Sprint inference should prefer the explicit sprint-state file over stale config or copied worktree database state.",
+      "outcome": "inferSprintContext now returns source=sprint-state for active sprint-state and ignores completed sprint-state as stale."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused regressions, typecheck, build, compiled CLI smokes, full test suite, roadmap validation, and map check passed.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A compact repair with a clear source-of-truth boundary.",
+    "advice_for_next_player": "When a guard suppresses based on session-local state, test the path where the underlying sprint state changes after the session has already started.",
+    "what_surprised_you": "The narrow status fix was not enough; the shared sprint inference path needed the same precedence so briefing and claim defaults stay aligned.",
+    "excited_about_next": "The guard workflow is in better shape for the upcoming /review-pr enforcement work."
+  },
+  "bunker_locations": [
+    "Derived session_mode can drift from .slope/sprint-state.json unless guard suppression checks resynchronize before deciding.",
+    "Commands that infer a sprint from config/roadmap/scorecards must treat active sprint-state as the current local source of truth."
+  ],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Validation used pnpm vitest run tests/cli/sprint-inference.test.ts tests/cli/commands/status.test.ts tests/cli/commands/guard.test.ts tests/cli/guards/session-briefing.test.ts tests/cli/sprint-workflow.test.ts.",
+    "Additional validation used pnpm typecheck, pnpm build, compiled CLI smokes for status/session-mode, pnpm test, slope roadmap validate, and slope map --check.",
+    "Issue #388 is a duplicate symptom of #387 and should be closed by the same PR."
+  ],
+  "slope_factors": [
+    "guard_runtime",
+    "workflow_state"
+  ]
+}

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { loadConfig } from '../config.js';
 import { inferSprintContext } from '../sprint-inference.js';
 import { resolveStore } from '../store.js';
+import { isActiveSprintState, loadSprintState } from '../sprint-state.js';
 
 function parseArgs(args: string[]): Record<string, string> {
   const result: Record<string, string> = {};
@@ -17,6 +18,8 @@ function parseArgs(args: string[]): Record<string, string> {
 
 function resolveSprint(flags: Record<string, string>, cwd: string): number {
   if (flags.sprint) return parseInt(flags.sprint, 10);
+  const sprintState = loadSprintState(cwd);
+  if (isActiveSprintState(sprintState)) return sprintState.sprint;
   const config = loadConfig(cwd);
   return inferSprintContext(cwd, config).sprint;
 }

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -5,7 +5,6 @@ import { join } from 'node:path';
 import { loadConfig } from '../config.js';
 import { inferSprintContext } from '../sprint-inference.js';
 import { resolveStore } from '../store.js';
-import { isActiveSprintState, loadSprintState } from '../sprint-state.js';
 
 function parseArgs(args: string[]): Record<string, string> {
   const result: Record<string, string> = {};
@@ -18,8 +17,6 @@ function parseArgs(args: string[]): Record<string, string> {
 
 function resolveSprint(flags: Record<string, string>, cwd: string): number {
   if (flags.sprint) return parseInt(flags.sprint, 10);
-  const sprintState = loadSprintState(cwd);
-  if (isActiveSprintState(sprintState)) return sprintState.sprint;
   const config = loadConfig(cwd);
   return inferSprintContext(cwd, config).sprint;
 }

--- a/src/cli/guards/session-briefing.ts
+++ b/src/cli/guards/session-briefing.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import type { HookInput, GuardResult, Suggestion } from '../../core/index.js';
 import { loadConfig, parseRoadmap, formatStrategicContext } from '../../core/index.js';
 import { loadSprintState } from '../sprint-state.js';
-import { loadSessionState, updateSessionState, setSessionMode } from '../session-state.js';
+import { loadSessionState, updateSessionState, setSessionMode, syncSessionModeWithSprintState } from '../session-state.js';
 
 /**
  * Session-briefing guard: fires PostToolUse on all tools.
@@ -16,7 +16,10 @@ export async function sessionBriefingGuard(input: HookInput, cwd: string): Promi
 
   // Dedup: only fire once per session
   const sessionState = loadSessionState(cwd);
-  if (sessionState.briefing_session_id === sessionId) return {};
+  if (sessionState.briefing_session_id === sessionId) {
+    syncSessionModeWithSprintState(cwd, sessionId);
+    return {};
+  }
 
   // Mark as briefed (atomic write)
   updateSessionState(cwd, 'briefing_session_id', sessionId);

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
+import { isActiveSprintState, loadSprintState } from './sprint-state.js';
 
 const SESSION_STATE_FILE = '.slope/.session-state.json';
 
@@ -67,8 +68,29 @@ export function setSessionMode(cwd: string, sessionId: string, mode: SessionMode
  *  Returns false if mode is 'sprint', unset, or set by a different session. */
 export function isAdhocSession(cwd: string, sessionId: string): boolean {
   if (!sessionId) return false;
+  const mode = syncSessionModeWithSprintState(cwd, sessionId);
+  return mode === 'adhoc';
+}
+
+/** Keep pinned session mode aligned with live sprint-state.
+ *  If a sprint starts after a session was pinned adhoc, promote the session
+ *  back to sprint mode so sprint-workflow guards do not stay suppressed. */
+export function syncSessionModeWithSprintState(cwd: string, sessionId: string): SessionMode | null {
+  if (!sessionId) return null;
   const state = loadSessionState(cwd);
-  return state.session_mode === 'adhoc' && state.session_mode_id === sessionId;
+  const sprintState = loadSprintState(cwd);
+
+  if (isActiveSprintState(sprintState)) {
+    if (state.session_mode !== 'sprint' || state.session_mode_id !== sessionId) {
+      state.session_mode = 'sprint';
+      state.session_mode_id = sessionId;
+      saveSessionState(cwd, state);
+    }
+    return 'sprint';
+  }
+
+  if (state.session_mode_id !== sessionId) return null;
+  return state.session_mode ?? null;
 }
 
 // ── Context dedup ───────────────────────────────────

--- a/src/cli/sprint-inference.ts
+++ b/src/cli/sprint-inference.ts
@@ -13,11 +13,12 @@ import {
 } from '../core/index.js';
 import type { RoadmapDefinition, RoadmapSprint, SlopeConfig } from '../core/index.js';
 import { loadConfig } from './config.js';
+import { isActiveSprintState, loadSprintState } from './sprint-state.js';
 
 export interface InferredSprintContext {
   sprint: number;
   label: string;
-  source: 'config' | 'roadmap' | 'scorecards' | 'initial';
+  source: 'sprint-state' | 'config' | 'roadmap' | 'scorecards' | 'initial';
   latestScorecard: number;
   roadmapSprint?: RoadmapSprint;
 }
@@ -36,6 +37,16 @@ export function loadRoadmapForInference(cwd: string, config: SlopeConfig): Roadm
 
 export function inferSprintContext(cwd: string = process.cwd(), config: SlopeConfig = loadConfig(cwd)): InferredSprintContext {
   const latestScorecard = detectLatestSprint(config, cwd);
+  const sprintState = loadSprintState(cwd);
+  if (isActiveSprintState(sprintState)) {
+    return {
+      sprint: sprintState.sprint,
+      label: formatSprintLabel(sprintState.sprint),
+      source: 'sprint-state',
+      latestScorecard,
+    };
+  }
+
   if (config.currentSprint) {
     return {
       sprint: config.currentSprint,

--- a/src/cli/sprint-state.ts
+++ b/src/cli/sprint-state.ts
@@ -57,6 +57,11 @@ export function loadSprintState(cwd: string): SprintState | null {
   }
 }
 
+/** True when sprint-state represents an active workflow sprint. */
+export function isActiveSprintState(state: SprintState | null): state is SprintState {
+  return Boolean(state && state.phase !== 'complete');
+}
+
 /** Save sprint state atomically via tmp + rename. */
 export function saveSprintState(cwd: string, state: SprintState): void {
   const dir = join(cwd, '.slope');

--- a/tests/cli/commands/guard.test.ts
+++ b/tests/cli/commands/guard.test.ts
@@ -12,7 +12,8 @@ import '../../../src/core/adapters/windsurf.js';
 import '../../../src/core/adapters/generic.js';
 
 import { guardCommand, guardManageCommand, shouldSuppressGuardInAdhoc } from '../../../src/cli/commands/guard.js';
-import { setSessionMode } from '../../../src/cli/session-state.js';
+import { loadSessionState, setSessionMode } from '../../../src/cli/session-state.js';
+import { createSprintState, saveSprintState } from '../../../src/cli/sprint-state.js';
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `slope-guard-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -199,6 +200,13 @@ describe('adhoc guard suppression', () => {
 
   it('keeps most sprint workflow guards suppressed in adhoc sessions', () => {
     expect(shouldSuppressGuardInAdhoc('workflow-step-gate', cwd, 'test-session')).toBe(true);
+  });
+
+  it('promotes adhoc sessions when live sprint-state appears', () => {
+    saveSprintState(cwd, createSprintState(74, 'planning'));
+
+    expect(shouldSuppressGuardInAdhoc('workflow-step-gate', cwd, 'test-session')).toBe(false);
+    expect(loadSessionState(cwd).session_mode).toBe('sprint');
   });
 
   it('allows claim-required to run in adhoc sessions', () => {

--- a/tests/cli/commands/status.test.ts
+++ b/tests/cli/commands/status.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { statusCommand } from '../../../src/cli/commands/status.js';
+import { createSprintState, saveSprintState } from '../../../src/cli/sprint-state.js';
+
+let tmpDir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-status-'));
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+    currentSprint: 18,
+    store_path: '.slope/slope.db',
+  }));
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function captureLog(fn: () => Promise<void>): Promise<string> {
+  const logs: string[] = [];
+  vi.spyOn(console, 'log').mockImplementation((...args) => { logs.push(args.join(' ')); });
+  try {
+    await fn();
+  } finally {
+    vi.restoreAllMocks();
+  }
+  return logs.join('\n');
+}
+
+describe('slope status', () => {
+  it('prefers live sprint-state over stale configured sprint context', async () => {
+    saveSprintState(tmpDir, createSprintState(74, 'planning'));
+
+    const output = await captureLog(() => statusCommand([]));
+
+    expect(output).toContain('S74 — Course Status');
+    expect(output).not.toContain('S18 — Course Status');
+  });
+
+  it('keeps explicit --sprint override behavior', async () => {
+    saveSprintState(tmpDir, createSprintState(74, 'planning'));
+
+    const output = await captureLog(() => statusCommand(['--sprint=18']));
+
+    expect(output).toContain('S18 — Course Status');
+  });
+});

--- a/tests/cli/guards/session-briefing.test.ts
+++ b/tests/cli/guards/session-briefing.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { sessionBriefingGuard } from '../../../src/cli/guards/session-briefing.js';
+import { loadSessionState, setSessionMode, updateSessionState } from '../../../src/cli/session-state.js';
+import { createSprintState, saveSprintState } from '../../../src/cli/sprint-state.js';
+import type { HookInput } from '../../../src/core/index.js';
+
+let tmpDir: string;
+
+function makeInput(): HookInput {
+  return {
+    session_id: 'test-session',
+    cwd: tmpDir,
+    hook_event_name: 'PostToolUse',
+    tool_name: 'Bash',
+    tool_input: { command: 'slope sprint start --number=74 --phase=planning' },
+  };
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-session-briefing-'));
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({ metaphor: 'golf' }));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('sessionBriefingGuard', () => {
+  it('promotes an already-briefed adhoc session after sprint-state appears', async () => {
+    updateSessionState(tmpDir, 'briefing_session_id', 'test-session');
+    setSessionMode(tmpDir, 'test-session', 'adhoc');
+    saveSprintState(tmpDir, createSprintState(74, 'planning'));
+
+    const result = await sessionBriefingGuard(makeInput(), tmpDir);
+
+    expect(result).toEqual({});
+    expect(loadSessionState(tmpDir).session_mode).toBe('sprint');
+  });
+});

--- a/tests/cli/sprint-inference.test.ts
+++ b/tests/cli/sprint-inference.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { inferSprintContext } from '../../src/cli/sprint-inference.js';
+import { createSprintState, saveSprintState } from '../../src/cli/sprint-state.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-sprint-inference-'));
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+    currentSprint: 18,
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+  }));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('inferSprintContext', () => {
+  it('prefers active sprint-state over stale config currentSprint', () => {
+    saveSprintState(tmpDir, createSprintState(74, 'planning'));
+
+    const context = inferSprintContext(tmpDir);
+
+    expect(context.sprint).toBe(74);
+    expect(context.source).toBe('sprint-state');
+  });
+
+  it('ignores completed sprint-state when inferring current work', () => {
+    saveSprintState(tmpDir, createSprintState(74, 'complete'));
+
+    const context = inferSprintContext(tmpDir);
+
+    expect(context.sprint).toBe(18);
+    expect(context.source).toBe('config');
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #387/#388 by promoting an adhoc-pinned session back to sprint mode whenever active `.slope/sprint-state.json` appears, so sprint-workflow guards stop being silently suppressed after a mid-session sprint start.
- Fixes #389 by making active sprint-state the first source used by shared sprint inference, so `slope status`, `slope briefing`, claim defaults, and related inferred-sprint commands agree with `slope sprint status`.
- Adds regressions for sprint inference, `slope status`, guard suppression, and session-briefing dedup after sprint-state appears.
- Records S99 roadmap scope and scorecard.

## Validation

- `pnpm vitest run tests/cli/sprint-inference.test.ts tests/cli/commands/status.test.ts tests/cli/commands/guard.test.ts tests/cli/guards/session-briefing.test.ts tests/cli/sprint-workflow.test.ts`
- `pnpm typecheck`
- `pnpm build`
- compiled CLI smoke: `slope status` reports S74 from sprint-state despite stale `currentSprint: 18`
- compiled CLI smoke: already-briefed adhoc session flips to `session_mode: sprint` once sprint-state exists
- `pnpm test`
- `slope roadmap validate`
- `slope map --check`
- `slope validate docs/retros/sprint-99.json`
- `slope pr review --pr=391 --sprint=99 --json`
- `slope review docs/retros/sprint-99.json --plain`

Closes #387.
Closes #388.
Closes #389.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session state synchronization to ensure session mode correctly aligns with active sprint state during mid-session sprint transitions.

* **Documentation**
  * Added sprint 99 roadmap entry and retrospective data.

* **Tests**
  * Added test coverage for session-sprint state consistency and guard behavior during live sprint scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->