### PR TITLE
Fix review closeout guard drift

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -1651,6 +1651,54 @@
           ]
         }
       ]
+    },
+    {
+      "id": 100,
+      "theme": "Review Closeout Guard Repair",
+      "par": 4,
+      "slope": 3,
+      "type": "bug fix + workflow guard",
+      "status": "planned",
+      "depends_on": [
+        99
+      ],
+      "note": "Close the remaining review/closeout reliability gaps before Codex plugin packaging: review recommendations must use active SLOPE context, PR review enforcement must be recorded as workflow state, and shipped-sprint validation must recognize normal squash merges.",
+      "tickets": [
+        {
+          "key": "S100-1",
+          "title": "Make review recommend prefer active sprint state over stale global Claude plans (#392)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 392
+        },
+        {
+          "key": "S100-2",
+          "title": "Add review recommend explicit sprint/context regressions (#392)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 392,
+          "depends_on": [
+            "S100-1"
+          ]
+        },
+        {
+          "key": "S100-3",
+          "title": "Record and enforce PR review completion in post-hole closeout (#390)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 390,
+          "depends_on": [
+            "S100-1"
+          ]
+        },
+        {
+          "key": "S100-4",
+          "title": "Teach shipped-sprint detection to recognize squash merges via sprint artifacts (#393)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 393
+        }
+      ]
     }
   ]
 }

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -1658,7 +1658,9 @@
       "par": 4,
       "slope": 3,
       "type": "bug fix + workflow guard",
-      "status": "planned",
+      "status": "complete",
+      "score": 4,
+      "score_label": "par",
       "depends_on": [
         99
       ],

--- a/docs/retros/sprint-100.json
+++ b/docs/retros/sprint-100.json
@@ -1,0 +1,114 @@
+{
+  "sprint_number": 100,
+  "player": "sebastianbryers",
+  "theme": "Review Closeout Guard Repair",
+  "par": 4,
+  "slope": 3,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-19",
+  "shots": [
+    {
+      "ticket_key": "S100-1",
+      "title": "Make review recommend prefer active sprint state over stale global Claude plans (#392)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Changed review recommendation context resolution so explicit --sprint and active sprint-state win before local or global Claude plan discovery."
+    },
+    {
+      "ticket_key": "S100-2",
+      "title": "Add review recommend explicit sprint/context regressions (#392)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added regressions for active sprint-state overriding stale plans, explicit --sprint overriding stale plans, and local SLOPE context suppressing unrelated global plan fallback."
+    },
+    {
+      "ticket_key": "S100-3",
+      "title": "Record and enforce PR review completion in post-hole closeout (#390)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added .slope/pr-reviews.json state, made the PR creation guard record pending reviews, made slope pr review mark them reviewed, and extended post-hole enforcement to surface pending PR review records."
+    },
+    {
+      "ticket_key": "S100-4",
+      "title": "Teach shipped-sprint detection to recognize squash merges via sprint artifacts (#393)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Enhanced shipped-sprint detection to read docs/retros/sprint-N artifacts from git history while keeping S-prefixed subject parsing isolated from arbitrary file paths."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "wind",
+      "impact": "minor",
+      "description": "The first full test rerun overlapped with a build, causing a transient dist import failure in a CLI map test; rerunning sequentially passed."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Review recommendation is a workflow decision and should use active SLOPE state before generic plan discovery.",
+      "outcome": "Compiled review recommend now reports Sprint 100 instead of the stale Sprint 29 global Claude plan."
+    },
+    {
+      "type": "lessons",
+      "description": "A reminder hook is not enough for post-PR review discipline; the workflow needs durable pending/reviewed state.",
+      "outcome": "PR creation now records pending review state and post-hole enforcement surfaces unreviewed PRs."
+    },
+    {
+      "type": "lessons",
+      "description": "Shipped-sprint detection should inspect shipped artifacts without broadening S-token matching to arbitrary file paths.",
+      "outcome": "The validator recognizes squash commits that add sprint scorecards and avoids false positives from S-prefixed source filenames."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused tests, typecheck, build, sequential full test suite, compiled CLI smokes, roadmap validation, and map check passed.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A compact closeout reliability sprint with three related guard-state repairs.",
+    "advice_for_next_player": "When a command can fall back to external agent artifacts, test with stale artifacts present and active SLOPE state set.",
+    "what_surprised_you": "The shipped-sprint warning was not a roadmap problem; it was a detector blind spot for normal squash-merge subjects.",
+    "excited_about_next": "The Codex plugin work now has a cleaner guard/review base to package."
+  },
+  "bunker_locations": [
+    "Review recommendation must not let stale global Claude plans override active SLOPE sprint-state.",
+    "PR review enforcement needs a durable pending/reviewed record; reminders alone are easy for agents to skip.",
+    "Shipped-sprint git analysis must keep subject parsing separate from file path artifact parsing to avoid false S-token matches."
+  ],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Validation used pnpm vitest run tests/cli/review-findings.test.ts tests/core/analyzers/git.test.ts tests/cli/pr-review-state.test.ts tests/cli/guards/pr-review.test.ts tests/cli/guards/post-hole-enforcement.test.ts tests/cli/pr-finalize.test.ts.",
+    "Additional validation used pnpm typecheck, pnpm build, sequential pnpm test, node dist/cli/index.js review recommend, node dist/cli/index.js roadmap validate, and slope map --check.",
+    "slope review recommend now chooses S100 from active sprint-state; node dist roadmap validation no longer emits false shipped-commit warnings for S94-S99."
+  ],
+  "slope_factors": [
+    "guard_runtime",
+    "workflow_state",
+    "git_history"
+  ]
+}

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { detectLatestSprint, loadConfig, normalizeScorecard, recommendReviews } from '../../core/index.js';
 import type { ReviewRecommendation } from '../../core/index.js';
 import { reviewRunCommand } from './review-run.js';
+import { recordPrReviewComplete } from '../pr-review-state.js';
 
 /**
  * `slope pr ...` — agent-friendly PR helpers.
@@ -123,6 +124,11 @@ function git(cmd: string): string {
   } catch {
     return '';
   }
+}
+
+function currentBranch(): string | undefined {
+  const branch = git('branch --show-current');
+  return branch || undefined;
 }
 
 function inferSprintNumber(explicit?: number): number | undefined {
@@ -391,6 +397,12 @@ async function reviewSubcommand(args: string[]): Promise<void> {
   if (opts.json) {
     reviewArgs.push('--json');
     await reviewRunCommand(reviewArgs);
+    recordPrReviewComplete(process.cwd(), {
+      pr: plan.pr,
+      sprint: plan.sprint,
+      branch: currentBranch(),
+      reviewType: plan.reviewType,
+    });
     return;
   }
 
@@ -403,6 +415,12 @@ async function reviewSubcommand(args: string[]): Promise<void> {
   console.log('\nReview prompts:\n');
 
   await reviewRunCommand(reviewArgs);
+  recordPrReviewComplete(process.cwd(), {
+    pr: plan.pr,
+    sprint: plan.sprint,
+    branch: currentBranch(),
+    reviewType: plan.reviewType,
+  });
 }
 
 async function issuesSubcommand(args: string[]): Promise<void> {

--- a/src/cli/commands/review-state.ts
+++ b/src/cli/commands/review-state.ts
@@ -7,7 +7,10 @@ import { createDeferred, listDeferred, resolveDeferred } from '../../core/deferr
 import type { DeferredSeverity } from '../../core/deferred.js';
 import { HAZARD_SEVERITY_PENALTIES } from '../../core/constants.js';
 import type { GolfScorecard } from '../../core/types.js';
+import type { RoadmapSprint, SlopeConfig } from '../../core/index.js';
 import { findPlanContent, countTickets, countPackageRefs } from '../guards/plan-analysis.js';
+import { inferSprintContext, loadRoadmapForInference } from '../sprint-inference.js';
+import { isActiveSprintState, loadSprintState } from '../sprint-state.js';
 
 export interface ReviewState {
   rounds_required: number;
@@ -186,50 +189,147 @@ function saveFindings(cwd: string, data: FindingsFile): void {
 
 // --- Review Recommend ---
 
-function recommendCommand(cwd: string): void {
-  const plan = findPlanContent(cwd);
-  let ticketCount = 0;
-  let slope = 0;
-  let filePatterns: string[] = [];
-  let sprintNumber = 0;
-  let hasNewInfra = false;
+interface ReviewRecommendationContext {
+  ticketCount: number;
+  slope: number;
+  filePatterns: string[];
+  sprintNumber: number;
+  hasNewInfra: boolean;
+}
 
-  if (plan) {
-    ticketCount = countTickets(plan.content);
-    // Extract slope from plan content
-    const slopeMatch = plan.content.match(/\*\*Slope:\*\*\s*(\d+)/);
-    if (slopeMatch) slope = parseInt(slopeMatch[1], 10);
-    // Extract sprint number
-    const sprintMatch = plan.content.match(/Sprint\s+(\d+)/);
-    if (sprintMatch) sprintNumber = parseInt(sprintMatch[1], 10);
-    // Extract file patterns from "Files to modify" sections
-    const fileMatches = plan.content.matchAll(/`([^`]+\.[a-z]+)`/g);
-    for (const m of fileMatches) filePatterns.push(m[1]);
-    // Check for new infrastructure keywords
-    hasNewInfra = /\b(new module|new package|new service|new infrastructure)\b/i.test(plan.content);
-  } else {
-    // Fallback: read current sprint's scorecard for ticket count and slope
+function parseSprintArg(args: string[]): number | null {
+  const sprintArg = args.find(a => a.startsWith('--sprint='));
+  if (!sprintArg) return null;
+  const value = parseInt(sprintArg.slice('--sprint='.length), 10);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function hasLocalSlopeContext(cwd: string, config: SlopeConfig): boolean {
+  return existsSync(join(cwd, '.slope', 'config.json'))
+    || existsSync(join(cwd, '.slope', 'sprint-state.json'))
+    || existsSync(join(cwd, config.roadmapPath))
+    || existsSync(join(cwd, config.scorecardDir));
+}
+
+function collectStringValues(value: unknown, out: string[] = []): string[] {
+  if (typeof value === 'string') {
+    out.push(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) collectStringValues(item, out);
+  } else if (value && typeof value === 'object') {
+    for (const item of Object.values(value)) collectStringValues(item, out);
+  }
+  return out;
+}
+
+function recommendationFromPlan(content: string): ReviewRecommendationContext {
+  const filePatterns: string[] = [];
+  const slopeMatch = content.match(/\*\*Slope:\*\*\s*(\d+)/);
+  const sprintMatch = content.match(/Sprint\s+(\d+)/);
+  const fileMatches = content.matchAll(/`([^`]+\.[a-z]+)`/g);
+  for (const m of fileMatches) filePatterns.push(m[1]);
+
+  return {
+    ticketCount: countTickets(content),
+    slope: slopeMatch ? parseInt(slopeMatch[1], 10) : 0,
+    sprintNumber: sprintMatch ? parseInt(sprintMatch[1], 10) : 0,
+    filePatterns,
+    hasNewInfra: /\b(new module|new package|new service|new infrastructure)\b/i.test(content),
+  };
+}
+
+function recommendationFromRoadmapSprint(sprint: RoadmapSprint): ReviewRecommendationContext {
+  const stringValues = collectStringValues(sprint);
+  const filePatterns = stringValues.filter(value => /[/.]/.test(value));
+  return {
+    ticketCount: sprint.tickets?.length ?? 0,
+    slope: sprint.slope ?? 0,
+    sprintNumber: sprint.id,
+    filePatterns,
+    hasNewInfra: /\b(new module|new package|new service|new infrastructure)\b/i.test(stringValues.join('\n')),
+  };
+}
+
+function recommendationFromScorecard(card: GolfScorecard): ReviewRecommendationContext {
+  const stringValues = collectStringValues(card);
+  return {
+    ticketCount: card.shots?.length ?? 0,
+    slope: card.slope ?? 0,
+    sprintNumber: card.sprint_number,
+    filePatterns: stringValues.filter(value => /[/.]/.test(value)),
+    hasNewInfra: /\b(new module|new package|new service|new infrastructure)\b/i.test(stringValues.join('\n')),
+  };
+}
+
+function recommendationFromSprint(cwd: string, config: SlopeConfig, sprintNumber: number): ReviewRecommendationContext | null {
+  const roadmap = loadRoadmapForInference(cwd, config);
+  const roadmapSprint = roadmap?.sprints.find(sprint => sprint.id === sprintNumber);
+  if (roadmapSprint) return recommendationFromRoadmapSprint(roadmapSprint);
+
+  const scorecardPath = join(cwd, config.scorecardDir, `sprint-${sprintNumber}.json`);
+  if (existsSync(scorecardPath)) {
     try {
-      const config = loadConfig(cwd);
-      sprintNumber = config.currentSprint ?? detectLatestSprint(config, cwd);
-      const scorecardPath = join(cwd, config.scorecardDir, `sprint-${sprintNumber}.json`);
-      if (existsSync(scorecardPath)) {
-        const card = normalizeScorecard(JSON.parse(readFileSync(scorecardPath, 'utf8')));
-        ticketCount = card.shots?.length ?? 0;
-        slope = card.slope ?? 0;
-      }
-    } catch { /* no config or scorecard */ }
+      const card = normalizeScorecard(JSON.parse(readFileSync(scorecardPath, 'utf8')));
+      return recommendationFromScorecard(card);
+    } catch { /* malformed scorecard: fall through */ }
   }
 
-  const recs = recommendReviews({
-    ticketCount,
-    slope,
-    filePatterns,
-    hasNewInfra,
-  });
+  return null;
+}
 
-  const sprintLabel = sprintNumber > 0 ? ` for Sprint ${sprintNumber}` : '';
-  console.log(`Recommended reviews${sprintLabel} (${ticketCount} ticket${ticketCount !== 1 ? 's' : ''}, slope ${slope}):\n`);
+function inferRecommendationContext(args: string[], cwd: string): ReviewRecommendationContext {
+  const config = loadConfig(cwd);
+  const explicitSprint = parseSprintArg(args);
+  if (explicitSprint) {
+    return recommendationFromSprint(cwd, config, explicitSprint) ?? {
+      ticketCount: 0,
+      slope: 0,
+      filePatterns: [],
+      sprintNumber: explicitSprint,
+      hasNewInfra: false,
+    };
+  }
+
+  const sprintState = loadSprintState(cwd);
+  if (isActiveSprintState(sprintState)) {
+    const context = recommendationFromSprint(cwd, config, sprintState.sprint);
+    if (context) return context;
+  }
+
+  const localPlan = findPlanContent(cwd, { includeGlobal: false });
+  if (localPlan) return recommendationFromPlan(localPlan.content);
+
+  if (hasLocalSlopeContext(cwd, config)) {
+    const inferred = inferSprintContext(cwd, config);
+    const context = recommendationFromSprint(cwd, config, inferred.sprint);
+    if (context) return context;
+    return {
+      ticketCount: 0,
+      slope: 0,
+      filePatterns: [],
+      sprintNumber: inferred.sprint,
+      hasNewInfra: false,
+    };
+  }
+
+  const globalPlan = findPlanContent(cwd, { includeRepoLocal: false, includeGlobal: true });
+  if (globalPlan) return recommendationFromPlan(globalPlan.content);
+
+  return {
+    ticketCount: 0,
+    slope: 0,
+    filePatterns: [],
+    sprintNumber: 0,
+    hasNewInfra: false,
+  };
+}
+
+function recommendCommand(args: string[], cwd: string): void {
+  const context = inferRecommendationContext(args, cwd);
+  const recs = recommendReviews(context);
+
+  const sprintLabel = context.sprintNumber > 0 ? ` for Sprint ${context.sprintNumber}` : '';
+  console.log(`Recommended reviews${sprintLabel} (${context.ticketCount} ticket${context.ticketCount !== 1 ? 's' : ''}, slope ${context.slope}):\n`);
   console.log('  Type           Priority      Reason');
   for (const rec of recs) {
     const type = rec.review_type.padEnd(14);
@@ -525,10 +625,11 @@ Clear any active review state. Use when a plan has been replaced or you
 want to restart the review counter.`);
       break;
     case 'recommend':
-      console.log(`Usage: slope review recommend
+      console.log(`Usage: slope review recommend [--sprint=N]
 
 Suggest which implementation review types (architect/code/ml/security/
-ux) apply to the current sprint based on the diff and ticket metadata.`);
+ux) apply to the current sprint based on active sprint state, roadmap,
+scorecard, or plan metadata.`);
       break;
     case 'findings':
       console.log(`Usage: slope review findings <add|list|clear> [options]
@@ -614,7 +715,7 @@ export async function reviewStateCommand(args: string[]): Promise<void> {
       resetCommand(cwd);
       break;
     case 'recommend':
-      recommendCommand(cwd);
+      recommendCommand(args.slice(1), cwd);
       break;
     case 'findings':
       findingsCommand(args.slice(1), cwd);

--- a/src/cli/guards/docs.ts
+++ b/src/cli/guards/docs.ts
@@ -106,9 +106,9 @@ export const GUARD_DOCS: Record<string, GuardDoc> = {
     level: 'full',
   },
   'pr-review': {
-    purpose: 'Prompts for the review workflow after PR creation. Ensures sprint review artifacts are created.',
+    purpose: 'Prompts for the review workflow after PR creation and records pending PR-review state.',
     triggers: 'PostToolUse on Bash. Fires after a shell command completes (checks for `gh pr create`).',
-    behavior: 'Advisory — if the command created a PR, injects a reminder to run `slope pr review --pr=<N>` and create review artifacts. For connector/API-created PRs where this Bash guard cannot fire, run the same command manually.',
+    behavior: 'Advisory — if the command created a PR, records it as pending in `.slope/pr-reviews.json` and injects a reminder to run `slope pr review --pr=<N>`. The post-hole guard surfaces pending records before the session ends.',
     configuration: 'Disable: add "pr-review" to guidance.disabled.',
     level: 'full',
   },

--- a/src/cli/guards/plan-analysis.ts
+++ b/src/cli/guards/plan-analysis.ts
@@ -8,6 +8,11 @@ export interface PlanFile {
   content: string;
 }
 
+export interface FindPlanContentOptions {
+  includeRepoLocal?: boolean;
+  includeGlobal?: boolean;
+}
+
 /** Extracted ticket info for specialist selection */
 export interface TicketInfo {
   title: string;
@@ -19,15 +24,17 @@ export interface TicketInfo {
  * Searches repo-local first ({cwd}/.claude/plans/), then falls back
  * to global (~/.claude/plans/) since Claude Code writes plans there.
  */
-export function findPlanContent(cwd: string): PlanFile | null {
+export function findPlanContent(cwd: string, options: FindPlanContentOptions = {}): PlanFile | null {
   const repoLocal = join(cwd, '.claude', 'plans');
   const global = join(homedir(), '.claude', 'plans');
+  const includeRepoLocal = options.includeRepoLocal ?? true;
+  const includeGlobal = options.includeGlobal ?? true;
 
   // Deduplicate when cwd is the home directory
   const searchDirs: Array<{ dir: string; relative: boolean }> = [
-    { dir: repoLocal, relative: true },
+    ...(includeRepoLocal ? [{ dir: repoLocal, relative: true }] : []),
   ];
-  if (global.replace(/\\/g, '/') !== repoLocal.replace(/\\/g, '/')) {
+  if (includeGlobal && global.replace(/\\/g, '/') !== repoLocal.replace(/\\/g, '/')) {
     searchDirs.push({ dir: global, relative: false });
   }
 

--- a/src/cli/guards/post-hole-enforcement.ts
+++ b/src/cli/guards/post-hole-enforcement.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { findShippedSprintsOnMain } from '../../core/index.js';
 import { loadConfig } from '../config.js';
+import { pendingPrReviews } from '../pr-review-state.js';
+import type { PrReviewRecord } from '../pr-review-state.js';
 
 /**
  * Post-hole enforcement guard: fires on Stop.
@@ -64,31 +66,44 @@ export async function postHoleEnforcementGuard(_input: HookInput, cwd: string): 
     }
   }
 
-  const shipped = findShippedSprintsOnMain(cwd);
-  if (shipped.size === 0) return {};
-
   type Drift = { sprint: number; issues: string[] };
+  const shipped = findShippedSprintsOnMain(cwd);
   const drifts: Drift[] = [];
-  for (const id of [...shipped].sort((a, b) => b - a)) {
-    const status = statusById.get(id);
-    // Replace EVERY '*' so patterns with multiple wildcards are sanitized
-    // (CodeQL js/incomplete-sanitization): single .replace() leaves later
-    // occurrences as literal '*' which won't match real filenames.
-    const scorecardFile = join(scorecardDirAbs, scorecardPattern.replaceAll('*', String(id)));
-    const hasScorecard = existsSync(scorecardFile);
+  if (shipped.size > 0) {
+    for (const id of [...shipped].sort((a, b) => b - a)) {
+      const status = statusById.get(id);
+      // Replace EVERY '*' so patterns with multiple wildcards are sanitized
+      // (CodeQL js/incomplete-sanitization): single .replace() leaves later
+      // occurrences as literal '*' which won't match real filenames.
+      const scorecardFile = join(scorecardDirAbs, scorecardPattern.replaceAll('*', String(id)));
+      const hasScorecard = existsSync(scorecardFile);
 
-    const issues: string[] = [];
-    if (status !== 'complete') issues.push(`status="${status ?? 'unset'}"`);
-    if (!hasScorecard) issues.push('no scorecard');
+      const issues: string[] = [];
+      if (status !== 'complete') issues.push(`status="${status ?? 'unset'}"`);
+      if (!hasScorecard) issues.push('no scorecard');
 
-    if (issues.length > 0) drifts.push({ sprint: id, issues });
+      if (issues.length > 0) drifts.push({ sprint: id, issues });
+    }
   }
 
-  if (drifts.length === 0) return {};
+  const prReviewGaps = pendingPrReviews(cwd);
+  if (drifts.length === 0 && prReviewGaps.length === 0) return {};
 
+  const sections: string[] = [];
+  if (drifts.length > 0) sections.push(formatCloseoutDriftMessage(drifts));
+  if (prReviewGaps.length > 0) sections.push(formatPendingPrReviewMessage(prReviewGaps));
+
+  const message = sections.join('\n\n');
+
+  if (process.env.SLOPE_POST_HOLE_BLOCK === '1') {
+    return { decision: 'deny', blockReason: message };
+  }
+  return { context: message };
+}
+
+function formatCloseoutDriftMessage(drifts: Array<{ sprint: number; issues: string[] }>): string {
   const shown = drifts.slice(0, 5);
   const remainder = drifts.length - shown.length;
-
   const lines = [
     `SLOPE post-hole enforcement: ${drifts.length} shipped sprint${drifts.length === 1 ? '' : 's'} with incomplete close-out:`,
     '',
@@ -106,11 +121,25 @@ export async function postHoleEnforcementGuard(_input: HookInput, cwd: string): 
     '  - Validate scorecard: slope validate',
     '  - Roadmap status: edit docs/backlog/roadmap.json (or slope sprint complete)',
   );
+  return lines.join('\n');
+}
 
-  const message = lines.join('\n');
-
-  if (process.env.SLOPE_POST_HOLE_BLOCK === '1') {
-    return { decision: 'deny', blockReason: message };
-  }
-  return { context: message };
+function formatPendingPrReviewMessage(records: PrReviewRecord[]): string {
+  const shown = records.slice(0, 5);
+  const remainder = records.length - shown.length;
+  const lines = [
+    `SLOPE PR review enforcement: ${records.length} created PR${records.length === 1 ? '' : 's'} missing a \`slope pr review\` record:`,
+    '',
+    ...shown.map(record => {
+      const sprintArg = record.sprint ? ` --sprint=${record.sprint}` : '';
+      const sprintLabel = record.sprint ? ` (S${record.sprint})` : '';
+      return `  • PR #${record.pr}${sprintLabel}: slope pr review --pr=${record.pr}${sprintArg}`;
+    }),
+  ];
+  if (remainder > 0) lines.push(`  …and ${remainder} more`);
+  lines.push(
+    '',
+    'Run the review command before presenting the PR as ready to merge.',
+  );
+  return lines.join('\n');
 }

--- a/src/cli/guards/pr-review.ts
+++ b/src/cli/guards/pr-review.ts
@@ -2,6 +2,8 @@ import { execSync } from 'node:child_process';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { recommendReviews } from '../../core/review.js';
 import type { ReviewRecommendation } from '../../core/index.js';
+import { recordPrReviewPending } from '../pr-review-state.js';
+import { isActiveSprintState, loadSprintState } from '../sprint-state.js';
 
 /**
  * PR review guard: fires PostToolUse on Bash.
@@ -28,6 +30,8 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
   const prUrl = urlMatch[1];
   const prNumber = urlMatch[2];
 
+  recordPendingReview(cwd, parseInt(prNumber, 10));
+
   const recs = computeRecommendations(cwd);
   const recLine = formatRecommendations(recs);
 
@@ -40,6 +44,18 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
       'Tip: also run `slope pr finalize` to add Closes #N for any issues referenced in commits.',
     ].join(' '),
   };
+}
+
+function recordPendingReview(cwd: string, pr: number): void {
+  try {
+    const state = loadSprintState(cwd);
+    const branch = execSync('git branch --show-current', { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    recordPrReviewPending(cwd, {
+      pr,
+      sprint: isActiveSprintState(state) ? state.sprint : undefined,
+      branch: branch || undefined,
+    });
+  } catch { /* review marker is best-effort; the reminder still fires */ }
 }
 
 /** Inspect the current branch's diff and call recommendReviews(). Best-effort

--- a/src/cli/guards/pr-review.ts
+++ b/src/cli/guards/pr-review.ts
@@ -49,11 +49,14 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
 function recordPendingReview(cwd: string, pr: number): void {
   try {
     const state = loadSprintState(cwd);
-    const branch = execSync('git branch --show-current', { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    let branch: string | undefined;
+    try {
+      branch = execSync('git branch --show-current', { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim() || undefined;
+    } catch { /* branch is metadata only */ }
     recordPrReviewPending(cwd, {
       pr,
       sprint: isActiveSprintState(state) ? state.sprint : undefined,
-      branch: branch || undefined,
+      branch,
     });
   } catch { /* review marker is best-effort; the reminder still fires */ }
 }

--- a/src/cli/pr-review-state.ts
+++ b/src/cli/pr-review-state.ts
@@ -1,0 +1,109 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PR_REVIEW_STATE_FILE = '.slope/pr-reviews.json';
+
+export interface PrReviewRecord {
+  pr: number;
+  sprint?: number;
+  branch?: string;
+  status: 'pending' | 'reviewed';
+  created_at: string;
+  reviewed_at?: string;
+  review_type?: 'architect' | 'code' | 'both';
+}
+
+export interface PrReviewState {
+  reviews: PrReviewRecord[];
+}
+
+export function loadPrReviewState(cwd: string): PrReviewState {
+  const filePath = join(cwd, PR_REVIEW_STATE_FILE);
+  if (!existsSync(filePath)) return { reviews: [] };
+  try {
+    const raw = JSON.parse(readFileSync(filePath, 'utf8')) as { reviews?: unknown };
+    if (!Array.isArray(raw.reviews)) return { reviews: [] };
+    return {
+      reviews: raw.reviews.filter(isPrReviewRecord),
+    };
+  } catch {
+    return { reviews: [] };
+  }
+}
+
+function isPrReviewRecord(value: unknown): value is PrReviewRecord {
+  const record = value as Partial<PrReviewRecord>;
+  return Boolean(
+    record
+      && typeof record.pr === 'number'
+      && (record.status === 'pending' || record.status === 'reviewed')
+      && typeof record.created_at === 'string',
+  );
+}
+
+function savePrReviewState(cwd: string, state: PrReviewState): void {
+  const dir = join(cwd, '.slope');
+  mkdirSync(dir, { recursive: true });
+  const filePath = join(cwd, PR_REVIEW_STATE_FILE);
+  const tmpPath = `${filePath}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(state, null, 2) + '\n');
+  renameSync(tmpPath, filePath);
+}
+
+export function recordPrReviewPending(cwd: string, input: { pr: number; sprint?: number; branch?: string }): void {
+  const state = loadPrReviewState(cwd);
+  const now = new Date().toISOString();
+  const existing = state.reviews.find(review => review.pr === input.pr);
+
+  if (existing) {
+    existing.sprint = input.sprint ?? existing.sprint;
+    existing.branch = input.branch ?? existing.branch;
+    if (existing.status !== 'reviewed') existing.status = 'pending';
+  } else {
+    state.reviews.push({
+      pr: input.pr,
+      sprint: input.sprint,
+      branch: input.branch,
+      status: 'pending',
+      created_at: now,
+    });
+  }
+
+  savePrReviewState(cwd, state);
+}
+
+export function recordPrReviewComplete(
+  cwd: string,
+  input: { pr: number; sprint?: number; branch?: string; reviewType?: 'architect' | 'code' | 'both' },
+): void {
+  const state = loadPrReviewState(cwd);
+  const now = new Date().toISOString();
+  const existing = state.reviews.find(review => review.pr === input.pr);
+
+  if (existing) {
+    existing.sprint = input.sprint ?? existing.sprint;
+    existing.branch = input.branch ?? existing.branch;
+    existing.status = 'reviewed';
+    existing.reviewed_at = now;
+    existing.review_type = input.reviewType ?? existing.review_type;
+  } else {
+    state.reviews.push({
+      pr: input.pr,
+      sprint: input.sprint,
+      branch: input.branch,
+      status: 'reviewed',
+      created_at: now,
+      reviewed_at: now,
+      review_type: input.reviewType,
+    });
+  }
+
+  savePrReviewState(cwd, state);
+}
+
+export function pendingPrReviews(cwd: string, sprint?: number): PrReviewRecord[] {
+  return loadPrReviewState(cwd).reviews
+    .filter(review => review.status === 'pending')
+    .filter(review => sprint == null || review.sprint == null || review.sprint === sprint)
+    .sort((a, b) => b.pr - a.pr);
+}

--- a/src/core/analyzers/git.ts
+++ b/src/core/analyzers/git.ts
@@ -27,6 +27,28 @@ export function extractSprintReferences(commitSubjects: string[]): Set<number> {
   return result;
 }
 
+/** Extract sprint IDs from shipped sprint artifact paths in git log output.
+ *  This catches normal GitHub squash merges whose subject is PR-oriented
+ *  (`Fix thing (#123)`) while the commit itself adds `docs/retros/sprint-N.json`.
+ */
+export function extractSprintArtifactReferences(logLines: string[]): Set<number> {
+  const result = new Set<number>();
+  const re = /^docs\/retros\/sprint-(\d+)(?:\.json|-review\.md)$/i;
+  for (const line of logLines) {
+    const m = line.trim().match(re);
+    if (m) result.add(parseInt(m[1], 10));
+  }
+  return result;
+}
+
+function unionSets<T>(...sets: Set<T>[]): Set<T> {
+  const result = new Set<T>();
+  for (const set of sets) {
+    for (const value of set) result.add(value);
+  }
+  return result;
+}
+
 /**
  * Allowed characters in git refs (branch / tag / abbreviated SHA). Permissive
  * enough for the names users actually pick (alphanumerics, slash, dot, dash,
@@ -52,8 +74,14 @@ export function findShippedSprintsOnMain(cwd: string, ref?: string): Set<number>
     // Cap at 1000 commits — plenty for sprint references (a project would
     // need to ship hundreds of sprints to exhaust this) and avoids slowing
     // session-end Stop hooks on deep-history repos.
-    const log = git(`log ${r} --oneline --no-decorate -n 1000`, cwd);
-    if (log) return extractSprintReferences(log.split('\n'));
+    const log = git(`log ${r} --format=%s --name-only -n 1000`, cwd);
+    if (log) {
+      const lines = log.split('\n');
+      return unionSets(
+        extractSprintReferences(lines),
+        extractSprintArtifactReferences(lines),
+      );
+    }
   }
   return new Set();
 }

--- a/src/core/analyzers/git.ts
+++ b/src/core/analyzers/git.ts
@@ -74,12 +74,12 @@ export function findShippedSprintsOnMain(cwd: string, ref?: string): Set<number>
     // Cap at 1000 commits — plenty for sprint references (a project would
     // need to ship hundreds of sprints to exhaust this) and avoids slowing
     // session-end Stop hooks on deep-history repos.
-    const log = git(`log ${r} --format=%s --name-only -n 1000`, cwd);
-    if (log) {
-      const lines = log.split('\n');
+    const subjects = git(`log ${r} --format=%s -n 1000`, cwd);
+    const files = git(`log ${r} --name-only --format= -n 1000`, cwd);
+    if (subjects || files) {
       return unionSets(
-        extractSprintReferences(lines),
-        extractSprintArtifactReferences(lines),
+        extractSprintReferences(subjects ? subjects.split('\n') : []),
+        extractSprintArtifactReferences(files ? files.split('\n') : []),
       );
     }
   }

--- a/tests/cli/guards/post-hole-enforcement.test.ts
+++ b/tests/cli/guards/post-hole-enforcement.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import { postHoleEnforcementGuard } from '../../../src/cli/guards/post-hole-enforcement.js';
+import { recordPrReviewComplete, recordPrReviewPending } from '../../../src/cli/pr-review-state.js';
 import type { HookInput } from '../../../src/core/index.js';
 
 function makeTmpRepo(): string {
@@ -74,6 +75,25 @@ describe('postHoleEnforcementGuard', () => {
   it('returns empty when no shipped sprints found', async () => {
     writeRoadmap(cwd, [{ id: 1, status: 'planned' }]);
     commit(cwd, 'chore: bump version'); // no S\d+ refs
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result).toEqual({});
+  });
+
+  it('warns when a created PR has no recorded PR review', async () => {
+    writeRoadmap(cwd, [{ id: 7, status: 'planned' }]);
+    recordPrReviewPending(cwd, { pr: 42, sprint: 7, branch: 'fix/test' });
+
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result.context).toContain('SLOPE PR review enforcement');
+    expect(result.context).toContain('PR #42');
+    expect(result.context).toContain('slope pr review --pr=42 --sprint=7');
+  });
+
+  it('does not warn when created PR review is recorded complete', async () => {
+    writeRoadmap(cwd, [{ id: 7, status: 'planned' }]);
+    recordPrReviewPending(cwd, { pr: 42, sprint: 7, branch: 'fix/test' });
+    recordPrReviewComplete(cwd, { pr: 42, sprint: 7, reviewType: 'both' });
+
     const result = await postHoleEnforcementGuard(stopInput, cwd);
     expect(result).toEqual({});
   });

--- a/tests/cli/guards/pr-review.test.ts
+++ b/tests/cli/guards/pr-review.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
 import '../../../src/core/adapters/claude-code.js';
 import { prReviewGuard } from '../../../src/cli/guards/pr-review.js';
+import { loadPrReviewState } from '../../../src/cli/pr-review-state.js';
+import { createSprintState, saveSprintState } from '../../../src/cli/sprint-state.js';
 import { formatPostToolUseOutput } from '../../../src/core/index.js';
 import type { HookInput } from '../../../src/core/index.js';
 
@@ -84,5 +90,32 @@ describe('prReviewGuard', () => {
 
     const result = await prReviewGuard(input, '/tmp/test');
     expect(result.context).toContain('pull/7');
+  });
+
+  it('records a pending PR review when gh pr create succeeds in a sprint repo', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-pr-review-guard-'));
+    try {
+      execSync('git init -q', { cwd });
+      execSync('git config user.email test@test', { cwd });
+      execSync('git config user.name test', { cwd });
+      saveSprintState(cwd, createSprintState(100, 'implementing'));
+
+      const input = makeInput(
+        'gh pr create --title "feat: test" --body "body"',
+        'https://github.com/owner/repo/pull/42',
+      );
+
+      await prReviewGuard(input, cwd);
+
+      const state = loadPrReviewState(cwd);
+      expect(state.reviews).toHaveLength(1);
+      expect(state.reviews[0]).toMatchObject({
+        pr: 42,
+        sprint: 100,
+        status: 'pending',
+      });
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/cli/pr-review-state.test.ts
+++ b/tests/cli/pr-review-state.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  loadPrReviewState,
+  pendingPrReviews,
+  recordPrReviewComplete,
+  recordPrReviewPending,
+} from '../../src/cli/pr-review-state.js';
+
+describe('pr review state', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'slope-pr-review-state-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('records pending PR reviews and marks them reviewed', () => {
+    recordPrReviewPending(cwd, { pr: 42, sprint: 100, branch: 'fix/test' });
+
+    expect(pendingPrReviews(cwd, 100).map(review => review.pr)).toEqual([42]);
+
+    recordPrReviewComplete(cwd, { pr: 42, sprint: 100, reviewType: 'both' });
+    const state = loadPrReviewState(cwd);
+
+    expect(state.reviews).toHaveLength(1);
+    expect(state.reviews[0].status).toBe('reviewed');
+    expect(state.reviews[0].reviewed_at).toBeDefined();
+    expect(pendingPrReviews(cwd, 100)).toEqual([]);
+  });
+
+  it('does not downgrade an already reviewed PR back to pending', () => {
+    recordPrReviewComplete(cwd, { pr: 42, sprint: 100, reviewType: 'both' });
+    recordPrReviewPending(cwd, { pr: 42, sprint: 100, branch: 'fix/test' });
+
+    expect(loadPrReviewState(cwd).reviews[0].status).toBe('reviewed');
+  });
+});

--- a/tests/cli/review-findings.test.ts
+++ b/tests/cli/review-findings.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { loadFindings } from '../../src/cli/commands/review-state.js';
 import type { FindingsFile } from '../../src/cli/commands/review-state.js';
+import { createSprintState, saveSprintState } from '../../src/cli/sprint-state.js';
 
 let tmpDir: string;
 let origCwd: typeof process.cwd;
@@ -26,6 +27,29 @@ afterEach(() => {
 async function runCommand(args: string[]) {
   const { reviewStateCommand } = await import('../../src/cli/commands/review-state.js');
   return reviewStateCommand(args);
+}
+
+function writeRoadmap(sprints: Array<{ id: number; slope: number; tickets: string[] }>): void {
+  const dir = join(tmpDir, 'docs', 'backlog');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'roadmap.json'), JSON.stringify({
+    name: 'Test Roadmap',
+    phases: [],
+    sprints: sprints.map(sprint => ({
+      id: sprint.id,
+      theme: `Sprint ${sprint.id}`,
+      par: 4,
+      slope: sprint.slope,
+      type: 'bug fix',
+      status: 'planned',
+      tickets: sprint.tickets.map((title, index) => ({
+        key: `S${sprint.id}-${index + 1}`,
+        title,
+        club: 'wedge',
+        complexity: 'small',
+      })),
+    })),
+  }, null, 2));
 }
 
 // --- loadFindings ---
@@ -135,7 +159,56 @@ describe('review recommend', () => {
     expect(logged).toContain('required');
   });
 
+  it('prefers active sprint-state over a stale plan file', async () => {
+    writeRoadmap([
+      { id: 74, slope: 3, tickets: ['Current source of truth', 'Guard repair', 'Regression coverage'] },
+    ]);
+    saveSprintState(tmpDir, createSprintState(74, 'implementing'));
+
+    const plansDir = join(tmpDir, '.claude', 'plans');
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(join(plansDir, 'stale-sprint-29.md'), [
+      '# Sprint 29 — Stale Global-ish Plan',
+      '**Slope:** 1',
+      '### S29-1: Old UI',
+      '`src/ui/old.ts`',
+    ].join('\n'));
+
+    const spy = vi.spyOn(console, 'log');
+    await runCommand(['recommend']);
+    const logged = spy.mock.calls.map(c => c[0]).join('\n');
+    spy.mockRestore();
+
+    expect(logged).toContain('Recommended reviews for Sprint 74 (3 tickets, slope 3)');
+    expect(logged).not.toContain('Sprint 29');
+  });
+
+  it('honors explicit --sprint over a stale plan file', async () => {
+    writeRoadmap([
+      { id: 88, slope: 2, tickets: ['Explicit review target', 'Second ticket'] },
+    ]);
+
+    const plansDir = join(tmpDir, '.claude', 'plans');
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(join(plansDir, 'stale-sprint-29.md'), [
+      '# Sprint 29 — Stale Plan',
+      '**Slope:** 5',
+      '### S29-1: Old work',
+    ].join('\n'));
+
+    const spy = vi.spyOn(console, 'log');
+    await runCommand(['recommend', '--sprint=88']);
+    const logged = spy.mock.calls.map(c => c[0]).join('\n');
+    spy.mockRestore();
+
+    expect(logged).toContain('Recommended reviews for Sprint 88 (2 tickets, slope 2)');
+    expect(logged).not.toContain('Sprint 29');
+  });
+
   it('outputs no recommendations when no plan', async () => {
+    mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+    writeFileSync(join(tmpDir, '.slope/config.json'), JSON.stringify({ scorecardDir: 'docs/retros' }));
+
     const spy = vi.spyOn(console, 'log');
     await runCommand(['recommend']);
     const logged = spy.mock.calls.map(c => c[0]).join('\n');

--- a/tests/core/analyzers/git.test.ts
+++ b/tests/core/analyzers/git.test.ts
@@ -204,6 +204,18 @@ describe('findShippedSprintsOnMain', () => {
     expect(findShippedSprintsOnMain(tmpDir, 'HEAD')).toEqual(new Set([99]));
   });
 
+  it('does not treat arbitrary S-prefixed file paths as shipped sprint refs', () => {
+    gitInit(tmpDir);
+    gitCommitFile(
+      tmpDir,
+      'src/S88Widget.ts',
+      'export const widget = true;\n',
+      'Add widget without sprint subject',
+    );
+
+    expect(findShippedSprintsOnMain(tmpDir, 'HEAD')).toEqual(new Set());
+  });
+
   it('refuses unsafe refs (shell-injection guard)', () => {
     gitInit(tmpDir);
     gitCommit(tmpDir, 'feat(S99): only on HEAD');

--- a/tests/core/analyzers/git.test.ts
+++ b/tests/core/analyzers/git.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
-import { analyzeGit, extractSprintReferences, findShippedSprintsOnMain } from '../../../src/core/analyzers/git.js';
+import { analyzeGit, extractSprintArtifactReferences, extractSprintReferences, findShippedSprintsOnMain } from '../../../src/core/analyzers/git.js';
 
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), 'slope-git-'));
@@ -19,6 +19,14 @@ function gitCommit(cwd: string, message: string): void {
   writeFileSync(join(cwd, `file-${Date.now()}-${Math.random()}.txt`), message);
   execSync('git add -A', { cwd, stdio: 'pipe' });
   execSync(`git commit -m "${message}" --allow-empty`, { cwd, stdio: 'pipe' });
+}
+
+function gitCommitFile(cwd: string, file: string, content: string, message: string): void {
+  const fullPath = join(cwd, file);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content);
+  execSync('git add -A', { cwd, stdio: 'pipe' });
+  execSync(`git commit -m "${message}"`, { cwd, stdio: 'pipe' });
 }
 
 describe('analyzeGit', () => {
@@ -140,6 +148,16 @@ describe('extractSprintReferences', () => {
   });
 });
 
+describe('extractSprintArtifactReferences', () => {
+  it('extracts sprint ids from scorecard and review artifact paths', () => {
+    expect(extractSprintArtifactReferences([
+      'docs/retros/sprint-99.json',
+      'docs/retros/sprint-100-review.md',
+      'docs/backlog/roadmap.json',
+    ])).toEqual(new Set([99, 100]));
+  });
+});
+
 describe('findShippedSprintsOnMain', () => {
   let tmpDir: string;
 
@@ -170,6 +188,18 @@ describe('findShippedSprintsOnMain', () => {
   it('honors explicit ref argument', () => {
     gitInit(tmpDir);
     gitCommit(tmpDir, 'feat(S99): only on HEAD');
+
+    expect(findShippedSprintsOnMain(tmpDir, 'HEAD')).toEqual(new Set([99]));
+  });
+
+  it('detects shipped sprints from scorecard artifacts in squash merge commits', () => {
+    gitInit(tmpDir);
+    gitCommitFile(
+      tmpDir,
+      'docs/retros/sprint-99.json',
+      JSON.stringify({ sprint_number: 99 }),
+      'Fix session state source-of-truth drift (#391)',
+    );
 
     expect(findShippedSprintsOnMain(tmpDir, 'HEAD')).toEqual(new Set([99]));
   });


### PR DESCRIPTION
## Summary

- Make `slope review recommend` prefer explicit/active SLOPE sprint context before Claude plan fallback.
- Record pending PR reviews from `gh pr create`, mark them reviewed from `slope pr review`, and surface unreviewed PRs in post-hole enforcement.
- Teach shipped-sprint detection to recognize `docs/retros/sprint-N` artifacts from squash merge commits without overmatching arbitrary S-prefixed file paths.
- Record Sprint 100 scorecard and roadmap closeout.

## Validation

- `pnpm vitest run tests/cli/review-findings.test.ts tests/core/analyzers/git.test.ts tests/cli/pr-review-state.test.ts tests/cli/guards/pr-review.test.ts tests/cli/guards/post-hole-enforcement.test.ts tests/cli/pr-finalize.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (sequential after build)
- `node dist/cli/index.js review recommend`
- `node dist/cli/index.js roadmap validate`
- `slope validate docs/retros/sprint-100.json`
- `slope review docs/retros/sprint-100.json --plain`
- `slope map --check`

Closes #392.
Closes #390.
Closes #393.
