### PR TITLE
fix: ignore sprint-zero scoping commits in shipped detector

### DIFF
--- a/src/core/analyzers/git.ts
+++ b/src/core/analyzers/git.ts
@@ -10,14 +10,16 @@ function git(cmd: string, cwd: string): string {
   }
 }
 
-/** Extract sprint IDs referenced in commit subjects.
+/** Extract shipped sprint IDs referenced in commit subjects.
  *  Matches `S\d+` not followed by another digit or a dot — so `S75.5` does
  *  NOT count as a reference to S75, and `S70+S71` correctly yields {70, 71}.
+ *  Ticket zero (`S101-0`) is reserved for sprint scoping/planning commits and
+ *  does not mean implementation for that sprint has shipped.
  *  Pure function — separated from git I/O for testability.
  */
 export function extractSprintReferences(commitSubjects: string[]): Set<number> {
   const result = new Set<number>();
-  const re = /\bS(\d+)(?![\d.])/g;
+  const re = /\bS(\d+)(?!(?:[\d.]|-0\b))/g;
   for (const line of commitSubjects) {
     let m: RegExpExecArray | null;
     while ((m = re.exec(line)) !== null) {

--- a/tests/core/analyzers/git.test.ts
+++ b/tests/core/analyzers/git.test.ts
@@ -129,6 +129,14 @@ describe('extractSprintReferences', () => {
     expect(extractSprintReferences(['feat(S78-1): wire forceApi flag'])).toEqual(new Set([78]));
   });
 
+  it('does not treat ticket-zero scoping commits as shipped sprint refs', () => {
+    expect(extractSprintReferences(['docs(S101-0): scope guard utilization sprint'])).toEqual(new Set());
+  });
+
+  it('still treats nonzero ticket commits as shipped sprint refs', () => {
+    expect(extractSprintReferences(['fix(S101-2): normalize apply_patch paths'])).toEqual(new Set([101]));
+  });
+
   it('does not match S75 inside S75.5', () => {
     expect(extractSprintReferences(['feat(S75.5): The Bug Clearing'])).toEqual(new Set());
   });
@@ -202,6 +210,13 @@ describe('findShippedSprintsOnMain', () => {
     );
 
     expect(findShippedSprintsOnMain(tmpDir, 'HEAD')).toEqual(new Set([99]));
+  });
+
+  it('does not mark sprint scoping commits as shipped work', () => {
+    gitInit(tmpDir);
+    gitCommit(tmpDir, 'docs(S101-0): scope guard utilization sprint');
+
+    expect(findShippedSprintsOnMain(tmpDir, 'HEAD')).toEqual(new Set());
   });
 
   it('does not treat arbitrary S-prefixed file paths as shipped sprint refs', () => {


### PR DESCRIPTION
## Summary

Fixes the validator regression exposed by the S101 scoping merge: `docs(S101-0): ...` should not make S101 look shipped.

Closes #400.

## Validation

- `pnpm vitest run tests/core/analyzers/git.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `node dist/cli/index.js roadmap validate`
