### PR TITLE
fix: make slope init help read-only

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -926,6 +926,41 @@ export function printInstallSummary(providers: InitProvider[]): void {
   console.log('');
 }
 
+export function printInitHelp(): void {
+  console.log(`
+Usage:
+  slope init [options]
+  slope init --interactive
+  slope init --harness=<id>
+  slope init [--claude-code|--cursor|--windsurf|--cline|--codex|--opencode|--ob1|--pi|--generic|--all]
+
+Options:
+  --help, -h              Show this help without writing files
+  --interactive, -i       Run guided setup wizard
+  --harness=<id>          Install templates/hooks for a specific harness
+  --claude-code           Install Claude Code rules, hooks, MCP config, and CLAUDE.md
+  --cursor                Install Cursor rules, hooks, MCP config, and .cursorrules
+  --windsurf              Install Windsurf rules, hooks, MCP config, and .windsurfrules
+  --cline                 Install Cline rules and guidance files
+  --codex                 Install Codex hooks and AGENTS.md guidance
+  --opencode              Install OpenCode AGENTS.md, MCP config, and plugin
+  --ob1                   Install OB1 MCP config and hooks
+  --pi                    Install Pi extension and skills
+  --generic               Install generic SLOPE checklist
+  --all                   Install all supported harness templates except generic
+  --team                  Enable multi-developer team mode
+  --with-example          Seed docs/retros/sprint-1.json with an example scorecard
+  --metaphor=<id>         Set metaphor theme, e.g. golf or gaming
+  --auto-install          Add @slope-dev/slope as a dev dependency when possible
+  --migrate               Upgrade an existing .slope/config.json in place
+
+Examples:
+  slope init --codex
+  slope init --claude-code --metaphor=golf
+  slope init --harness=cursor --with-example
+`);
+}
+
 async function runInteractiveInit(cwd: string, _args: string[]): Promise<void> {
   // Check for TTY — @clack/prompts requires an interactive terminal
   if (!process.stdin.isTTY) {
@@ -951,6 +986,13 @@ async function runInteractiveInit(cwd: string, _args: string[]): Promise<void> {
 
 export async function initCommand(args: string[]): Promise<void> {
   const cwd = process.cwd();
+
+  // Help must be read-only. Agents often probe commands with --help before
+  // running setup, so short-circuit before any init side effects. (GH #402)
+  if (args.includes('--help') || args.includes('-h')) {
+    printInitHelp();
+    return;
+  }
 
   // Interactive mode: prompt for project details, then exit
   // (do not fall through to non-interactive path which would overwrite the config)

--- a/tests/cli/init-summary.test.ts
+++ b/tests/cli/init-summary.test.ts
@@ -10,6 +10,26 @@ let tmpDir: string;
 let originalCwd: string;
 let consoleSpy: ReturnType<typeof vi.spyOn>;
 
+const INIT_ARTIFACTS = [
+  '.slope',
+  '.claude',
+  '.cursor',
+  '.codex',
+  '.windsurf',
+  '.clinerules',
+  '.ob1',
+  '.pi',
+  '.agents',
+  'docs',
+  'AGENTS.md',
+  'CLAUDE.md',
+  '.mcp.json',
+  'opencode.json',
+  'CODEBASE.md',
+  'SLOPE-CHECKLIST.md',
+  '.gitignore',
+];
+
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'slope-init-summary-'));
   originalCwd = process.cwd();
@@ -23,6 +43,12 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
+
+function expectNoInitArtifacts(): void {
+  for (const artifact of INIT_ARTIFACTS) {
+    expect(existsSync(join(tmpDir, artifact)), artifact).toBe(false);
+  }
+}
 
 describe('printInstallSummary', () => {
   it('prints core files section', () => {
@@ -136,6 +162,31 @@ describe('printInstallSummary', () => {
 });
 
 describe('initCommand prints summary', () => {
+  it('prints help and does not write files for --help', async () => {
+    await initCommand(['--help']);
+
+    const output = consoleSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(output).toContain('Usage:');
+    expect(output).toContain('slope init [options]');
+    expect(output).toContain('--claude-code');
+    expect(output).toContain('--codex');
+    expect(output).toContain('--all');
+    expect(output).toContain('--harness=<id>');
+    expect(output).toContain('--interactive');
+    expect(output).toContain('--with-example');
+    expect(output).toContain('--metaphor=<id>');
+    expectNoInitArtifacts();
+  });
+
+  it('prints help and does not write files for -h', async () => {
+    await initCommand(['-h']);
+
+    const output = consoleSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(output).toContain('Usage:');
+    expect(output).toContain('--help, -h');
+    expectNoInitArtifacts();
+  });
+
   it('prints summary after --claude-code init', async () => {
     await initCommand(['--claude-code']);
 


### PR DESCRIPTION
## Summary

- Fixes #402
- Adds a dedicated `slope init` help path before any setup side effects run
- Covers `--help` and `-h` with temp-project regression tests that assert no init artifacts are written

## Verification

- `pnpm vitest run tests/cli/init-summary.test.ts`
- `pnpm vitest run tests/cli/init-detect.test.ts tests/cli/init-mcp.test.ts tests/cli/interactive-init.test.ts tests/cli/init-no-example-retro.test.ts tests/cli/init-codex.test.ts tests/cli/metaphor.test.ts`
- `pnpm typecheck`
- `pnpm build`
- Built CLI smoke checks for `init --help` and `init -h` in temp dirs: usage present, no init artifacts created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `slope init` command now supports `--help` and `-h` flags to display usage information and available initialization options, including interactive mode, provider selection, team mode, and other settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->