### PR TITLE
chore: bump version to 1.55.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.55.11",
+  "version": "1.55.12",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Patch release for recent bugfixes on main, including #402 / PR #403.

## Verification

- CI will run full build, test, and typecheck on this version-only change.