### PR TITLE
fix: make pr review help read-only

### DIFF
--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -94,6 +94,29 @@ Defaults:
 `);
 }
 
+function printReviewHelp(): void {
+  console.log(`
+slope pr review — Generate post-PR review prompts
+
+Usage:
+  slope pr review [--pr=N] [--sprint=N] [--type=architect|code|both] [--json]
+
+Options:
+  --help, -h                       Show this help without resolving PR state
+  --pr=N                           Review a specific pull request
+  --sprint=N                       Use a specific sprint for review context
+  --type=architect|code|both       Select review prompt type (default: both)
+  --json                           Emit machine-readable review prompts
+
+Defaults:
+  --pr   Resolved from current branch via \`gh pr view --json number\`.
+`);
+}
+
+function hasHelpFlag(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 function parseFlags(args: string[]): FinalizeOptions {
   const opts: FinalizeOptions = {};
   for (const a of args) {
@@ -384,6 +407,13 @@ async function finalizeSubcommand(args: string[]): Promise<void> {
 }
 
 async function reviewSubcommand(args: string[]): Promise<void> {
+  // Help must be read-only. Agents probe subcommand syntax with --help, so do
+  // not infer PRs, read diffs, or record review state on help flags. (GH #405)
+  if (hasHelpFlag(args)) {
+    printReviewHelp();
+    return;
+  }
+
   const opts = parseReviewFlags(args);
   const plan = await planPrReview(opts);
 

--- a/tests/cli/pr-help.test.ts
+++ b/tests/cli/pr-help.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execSync: execSyncMock,
+  };
+});
+
+describe('slope pr review help is read-only (GH #405)', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    execSyncMock.mockReset();
+    execSyncMock.mockImplementation(() => {
+      throw new Error('execSync should not run for help output');
+    });
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints review help for --help without resolving PR state', async () => {
+    const { prCommand } = await import('../../src/cli/commands/pr.js');
+
+    await prCommand(['review', '--help']);
+
+    const output = consoleLogSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(output).toContain('slope pr review');
+    expect(output).toContain('--pr=N');
+    expect(output).toContain('--sprint=N');
+    expect(output).toContain('--type=architect|code|both');
+    expect(output).toContain('--json');
+    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('prints review help for -h without resolving PR state', async () => {
+    const { prCommand } = await import('../../src/cli/commands/pr.js');
+
+    await prCommand(['review', '-h']);
+
+    const output = consoleLogSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(output).toContain('slope pr review');
+    expect(output).toContain('--help, -h');
+    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #405
- Adds subcommand-specific `slope pr review` help before PR inference or diff lookup
- Covers `--help` and `-h` with regression tests that fail if the command attempts any git/gh `execSync` call

## Verification

- `pnpm vitest run tests/cli/pr-help.test.ts tests/cli/pr-finalize.test.ts tests/cli/pr-review-state.test.ts`
- `pnpm typecheck`
- `pnpm build`
- Built CLI smoke: `node dist/cli/index.js pr review --help`
- Built CLI smoke: `node dist/cli/index.js pr review -h`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `pr review` subcommand now properly handles and displays help information when invoked with the `--help` or `-h` flags, ensuring the command doesn't execute and only provides guidance to users.

* **Tests**
  * Added comprehensive test coverage to verify the help flag behavior operates correctly and safely.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->