### PR TITLE
fix: parse Codex apply_patch paths in guards

### DIFF
--- a/docs/retros/sprint-101-review.md
+++ b/docs/retros/sprint-101-review.md
@@ -1,0 +1,22 @@
+
+## Sprint 101 Review: Guard apply_patch path normalization
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 0 |
+| Score | 1 |
+| Label | Eagle |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S101-1 | Long Iron | Green | — | 9 files changed (Clean git signals but no CI confirmation — defaulting to green) |
+

--- a/docs/retros/sprint-101.json
+++ b/docs/retros/sprint-101.json
@@ -1,0 +1,46 @@
+{
+  "sprint_number": 101,
+  "theme": "Guard apply_patch path normalization",
+  "par": 3,
+  "slope": 0,
+  "score": 1,
+  "score_label": "eagle",
+  "date": "2026-05-21",
+  "shots": [
+    {
+      "ticket_key": "S101-1",
+      "title": "fix(396): parse codex apply_patch paths in guards",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "9 files changed (Clean git signals but no CI confirmation — defaulting to green)"
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [],
+  "slope_factors": [],
+  "_auto_generated": true,
+  "_commits": 1,
+  "_ci_signal": null,
+  "_pr_signal": null,
+  "_note": "Auto-generated from git only (no CI). Shots default to green. Provide --test-output for better scoring."
+}

--- a/src/cli/guards/claim-required.ts
+++ b/src/cli/guards/claim-required.ts
@@ -8,6 +8,7 @@ import { inferSprintContext } from '../sprint-inference.js';
 import { loadSprintState } from '../sprint-state.js';
 import { loadSessionState, updateSessionState } from '../session-state.js';
 import { resolveStore } from '../store.js';
+import { normalizeTouchedPath, resolveTouchedPaths } from './hook-input.js';
 
 const IMPLEMENTATION_DIRS = [
   'app/',
@@ -113,8 +114,7 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
       }
     } catch { /* claims unavailable */ }
   } else if (!sprintState) {
-    const filePath = input.tool_input?.file_path as string | undefined;
-    const relativePath = normalizeHookPath(filePath, cwd);
+    const relativePath = findImplementationWritePath(input, cwd);
     if (!relativePath || !isImplementationWritePath(relativePath)) return {};
 
     const hint = inferMissingSprintHint(cwd);
@@ -127,8 +127,7 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
         : 'Suggested commands: `slope sprint start --number=<N> --phase=implementing` then `slope claim --target=<path> --ticket=<ticket>`.',
     ]);
   } else {
-    const filePath = input.tool_input?.file_path as string | undefined;
-    const relativePath = normalizeHookPath(filePath, cwd);
+    const relativePath = findImplementationWritePath(input, cwd);
     if (!relativePath || !isImplementationWritePath(relativePath)) return {};
 
     return implementationWritePolicyResult(policy, [
@@ -216,14 +215,12 @@ function implementationWritePolicyResult(policy: ImplementationWritePolicy, line
   };
 }
 
-function normalizeHookPath(filePath: string | undefined, cwd: string): string | null {
-  if (!filePath) return null;
-  const normalizedCwd = cwd.replace(/\\/g, '/').replace(/\/$/, '');
-  const normalizedPath = filePath.replace(/\\/g, '/');
-  const relativePath = normalizedPath.startsWith(`${normalizedCwd}/`)
-    ? normalizedPath.slice(normalizedCwd.length + 1)
-    : normalizedPath;
-  return relativePath.replace(/^\.\//, '');
+function findImplementationWritePath(input: HookInput, cwd: string): string | null {
+  for (const touchedPath of resolveTouchedPaths(input)) {
+    const relativePath = normalizeTouchedPath(touchedPath, cwd);
+    if (relativePath && isImplementationWritePath(relativePath)) return relativePath;
+  }
+  return null;
 }
 
 export function isImplementationWritePath(relativePath: string): boolean {
@@ -269,13 +266,10 @@ async function detectCrossSessionOverlap(
   cwd: string,
   sprintNumber: number,
 ): Promise<string | null> {
-  const filePath = input.tool_input?.file_path as string | undefined;
-  if (!filePath) return null;
-
-  const relativePath = filePath.startsWith(cwd)
-    ? filePath.slice(cwd.length + 1)
-    : filePath;
-  const fileArea = dirname(relativePath);
+  const relativePaths = resolveTouchedPaths(input)
+    .map(filePath => normalizeTouchedPath(filePath, cwd))
+    .filter((filePath): filePath is string => Boolean(filePath));
+  if (relativePaths.length === 0) return null;
 
   try {
     const store = await resolveStore(cwd);
@@ -288,13 +282,16 @@ async function detectCrossSessionOverlap(
       c.session_id && c.session_id !== input.session_id,
     );
 
-    for (const claim of otherClaims) {
-      const overlaps = claimOverlapsPath(claim.scope, claim.target, relativePath, fileArea);
+    for (const relativePath of relativePaths) {
+      const fileArea = dirname(relativePath);
+      for (const claim of otherClaims) {
+        const overlaps = claimOverlapsPath(claim.scope, claim.target, relativePath, fileArea);
 
-      if (overlaps) {
-        const agent = sessions.find(s => s.session_id === claim.session_id);
-        const agentDesc = agent?.agent_role ?? agent?.role ?? 'another agent';
-        return `SLOPE multi-agent: ${relativePath} overlaps with ${agentDesc}'s claim on "${claim.target}". Coordinate to avoid conflicts.`;
+        if (overlaps) {
+          const agent = sessions.find(s => s.session_id === claim.session_id);
+          const agentDesc = agent?.agent_role ?? agent?.role ?? 'another agent';
+          return `SLOPE multi-agent: ${relativePath} overlaps with ${agentDesc}'s claim on "${claim.target}". Coordinate to avoid conflicts.`;
+        }
       }
     }
   } catch { /* store unavailable — skip overlap check */ }

--- a/src/cli/guards/hazard.ts
+++ b/src/cli/guards/hazard.ts
@@ -4,6 +4,7 @@ import type { HookInput, GuardResult } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import type { CommonIssuesFile } from '../../core/index.js';
 import { dedupGuardContext } from '../session-state.js';
+import { normalizeTouchedPath, resolveTouchedPaths } from './hook-input.js';
 
 // ── Disk state for compaction survival ──────────────
 
@@ -58,81 +59,104 @@ function pruneState(state: HazardState, currentSprint: number): HazardState {
  * Writes state to disk so warnings survive context compaction.
  */
 export async function hazardGuard(input: HookInput, cwd: string): Promise<GuardResult> {
-  const filePath = input.tool_input?.file_path as string | undefined;
-  if (!filePath) return {};
+  const areas = resolveTouchedAreas(input, cwd);
+  if (areas.length === 0) return {};
 
-  const config = loadConfig();
-  const recency = config.guidance?.hazardRecency ?? 5;
+  const config = loadConfig(cwd);
   const currentSprint = config.currentSprint ?? 0;
-
-  // Determine the area from the file path (use directory)
-  const area = dirname(filePath).replace(cwd + '/', '').replace(cwd, '');
-  if (!area || area === '.') return {};
 
   // Load and prune disk state
   let state = loadHazardState(cwd);
   state = pruneState(state, currentSprint);
 
-  // Compute fresh warnings from common issues (ranked by recency)
-  const MAX_HAZARDS = 3;
-  const freshWarnings: Array<{ lastSprint: number; text: string }> = [];
-
+  let issues: CommonIssuesFile | null = null;
   try {
     const issuesPath = join(cwd, config.commonIssuesPath);
     if (existsSync(issuesPath)) {
-      const issues: CommonIssuesFile = JSON.parse(readFileSync(issuesPath, 'utf8'));
-      const areaLower = area.toLowerCase();
-
-      for (const pattern of issues.recurring_patterns) {
-        // Check if pattern is relevant to this area
-        const text = `${pattern.title} ${pattern.description} ${pattern.prevention}`.toLowerCase();
-        if (text.includes(areaLower) || areaLower.split('/').some(seg => text.includes(seg))) {
-          const lastSprint = Math.max(...pattern.sprints_hit);
-          freshWarnings.push({ lastSprint, text: `[${pattern.category}] ${pattern.title} (S${lastSprint}) — ${pattern.prevention.slice(0, 80)}` });
-        }
-      }
+      issues = JSON.parse(readFileSync(issuesPath, 'utf8'));
     }
   } catch { /* skip — common issues are optional */ }
 
-  // Sort by recency (most recent first) and cap at top N
+  for (const area of areas) {
+    // Compute fresh warnings from common issues (ranked by recency)
+    const freshTexts = computeFreshWarnings(area, issues);
+
+    // Merge fresh warnings with any disk-cached warnings for this area
+    const cached = state.entries.find(e => e.area === area);
+    const allWarnings = freshTexts.length > 0 ? freshTexts : (cached?.warnings ?? []);
+
+    if (freshTexts.length === 0 && cached) {
+      state.entries = state.entries.filter(e => e.area !== area);
+      saveHazardState(cwd, state);
+    }
+
+    // Persist fresh warnings to disk (update or add entry)
+    if (freshTexts.length > 0) {
+      const entry: HazardStateEntry = {
+        area,
+        warnings: freshTexts,
+        sprint: currentSprint,
+        timestamp: Date.now(),
+      };
+      state.entries = state.entries.filter(e => e.area !== area);
+      state.entries.push(entry);
+      saveHazardState(cwd, state);
+    }
+
+    if (allWarnings.length === 0) continue;
+
+    const fullContext = formatHazardContext(area, allWarnings);
+
+    // Session dedup: if this exact context was already injected, return compressed reference
+    const dedup = dedupGuardContext(cwd, input.session_id, 'hazard', fullContext);
+    if (dedup) return { context: dedup };
+
+    return { context: fullContext };
+  }
+
+  return {};
+}
+
+function resolveTouchedAreas(input: HookInput, cwd: string): string[] {
+  const seen = new Set<string>();
+  const areas: string[] = [];
+  for (const touchedPath of resolveTouchedPaths(input)) {
+    const relativePath = normalizeTouchedPath(touchedPath, cwd);
+    if (!relativePath) continue;
+    const area = dirname(relativePath);
+    if (!area || area === '.' || seen.has(area)) continue;
+    seen.add(area);
+    areas.push(area);
+  }
+  return areas;
+}
+
+function computeFreshWarnings(area: string, issues: CommonIssuesFile | null): string[] {
+  if (!issues) return [];
+
+  const areaLower = area.toLowerCase();
+  const freshWarnings: Array<{ lastSprint: number; text: string }> = [];
+
+  for (const pattern of issues.recurring_patterns) {
+    // Check if pattern is relevant to this area
+    const text = `${pattern.title} ${pattern.description} ${pattern.prevention}`.toLowerCase();
+    if (text.includes(areaLower) || areaLower.split('/').some(seg => text.includes(seg))) {
+      const lastSprint = Math.max(...pattern.sprints_hit);
+      freshWarnings.push({ lastSprint, text: `[${pattern.category}] ${pattern.title} (S${lastSprint}) — ${pattern.prevention.slice(0, 80)}` });
+    }
+  }
+
+  // Sort by recency (most recent first)
   freshWarnings.sort((a, b) => b.lastSprint - a.lastSprint);
-  const freshTexts = freshWarnings.map(w => w.text);
+  return freshWarnings.map(w => w.text);
+}
 
-  // Merge fresh warnings with any disk-cached warnings for this area
-  const cached = state.entries.find(e => e.area === area);
-  const allWarnings = freshTexts.length > 0 ? freshTexts : (cached?.warnings ?? []);
-
-  if (freshTexts.length === 0 && cached) {
-    state.entries = state.entries.filter(e => e.area !== area);
-    saveHazardState(cwd, state);
-  }
-
-  // Persist fresh warnings to disk (update or add entry)
-  if (freshTexts.length > 0) {
-    const entry: HazardStateEntry = {
-      area,
-      warnings: freshTexts,
-      sprint: currentSprint,
-      timestamp: Date.now(),
-    };
-    state.entries = state.entries.filter(e => e.area !== area);
-    state.entries.push(entry);
-    saveHazardState(cwd, state);
-  }
-
-  if (allWarnings.length === 0) return {};
-
-  // Cap output at top N, show overflow count
-  const shown = allWarnings.slice(0, MAX_HAZARDS);
+function formatHazardContext(area: string, allWarnings: string[]): string {
+  const maxHazards = 3;
+  const shown = allWarnings.slice(0, maxHazards);
   const overflow = allWarnings.length - shown.length;
-  const header = `SLOPE hazards (${area}, ${allWarnings.length} total${overflow > 0 ? `, showing top ${MAX_HAZARDS}` : ''}):`;
+  const header = `SLOPE hazards (${area}, ${allWarnings.length} total${overflow > 0 ? `, showing top ${maxHazards}` : ''}):`;
   const lines = [header, ...shown.map(w => `• ${w}`)];
   if (overflow > 0) lines.push(`  (+${overflow} more — run \`slope briefing --area=${area}\` for all)`);
-  const fullContext = lines.join('\n');
-
-  // Session dedup: if this exact context was already injected, return compressed reference
-  const dedup = dedupGuardContext(cwd, input.session_id, 'hazard', fullContext);
-  if (dedup) return { context: dedup };
-
-  return { context: fullContext };
+  return lines.join('\n');
 }

--- a/src/cli/guards/hook-input.ts
+++ b/src/cli/guards/hook-input.ts
@@ -1,0 +1,97 @@
+import { isAbsolute, resolve } from 'node:path';
+import type { HookInput } from '../../core/index.js';
+
+const PATCH_TEXT_KEYS = ['command', 'patch', 'input'] as const;
+const DIRECT_PATH_KEYS = ['file_path', 'path'] as const;
+const DIRECT_PATH_ARRAY_KEYS = ['file_paths', 'paths'] as const;
+
+/**
+ * Resolve file paths touched by a hook input across agent harness payloads.
+ *
+ * Claude-style tools usually provide tool_input.file_path. Codex apply_patch
+ * hooks carry the edited files inside the patch text, commonly in
+ * tool_input.command.
+ */
+export function resolveTouchedPaths(input: HookInput): string[] {
+  const toolInput = input.tool_input ?? {};
+  const paths: string[] = [];
+
+  for (const key of DIRECT_PATH_KEYS) {
+    const value = toolInput[key];
+    if (typeof value === 'string') paths.push(value);
+  }
+
+  for (const key of DIRECT_PATH_ARRAY_KEYS) {
+    const value = toolInput[key];
+    if (!Array.isArray(value)) continue;
+    for (const item of value) {
+      if (typeof item === 'string') paths.push(item);
+    }
+  }
+
+  const patchText = getApplyPatchText(input);
+  if (patchText) paths.push(...parseApplyPatchTouchedPaths(patchText));
+
+  return uniqueNonEmpty(paths);
+}
+
+export function resolvePrimaryTouchedPath(input: HookInput): string | undefined {
+  return resolveTouchedPaths(input)[0];
+}
+
+export function normalizeTouchedPath(filePath: string | undefined, cwd: string): string | null {
+  if (!filePath) return null;
+
+  const normalizedCwd = cwd.replace(/\\/g, '/').replace(/\/$/, '');
+  const normalizedPath = filePath.trim().replace(/\\/g, '/');
+  if (!normalizedPath) return null;
+
+  const relativePath = normalizedPath.startsWith(`${normalizedCwd}/`)
+    ? normalizedPath.slice(normalizedCwd.length + 1)
+    : normalizedPath;
+
+  return relativePath.replace(/^\.\//, '');
+}
+
+export function toAbsoluteTouchedPath(filePath: string, cwd: string): string {
+  const trimmed = filePath.trim();
+  return isAbsolute(trimmed) ? resolve(trimmed) : resolve(cwd, trimmed);
+}
+
+export function getApplyPatchText(input: HookInput): string | null {
+  const toolInput = input.tool_input ?? {};
+  for (const key of PATCH_TEXT_KEYS) {
+    const value = toolInput[key];
+    if (typeof value === 'string' && value.includes('*** Begin Patch')) {
+      return value;
+    }
+  }
+  return null;
+}
+
+export function parseApplyPatchTouchedPaths(patchText: string): string[] {
+  const paths: string[] = [];
+  for (const line of patchText.split(/\r?\n/)) {
+    const match = line.match(/^\*\*\* (?:Add|Update|Delete) File: (.+)$/);
+    if (match) {
+      paths.push(match[1]);
+      continue;
+    }
+
+    const moveMatch = line.match(/^\*\*\* Move to: (.+)$/);
+    if (moveMatch) paths.push(moveMatch[1]);
+  }
+  return uniqueNonEmpty(paths);
+}
+
+function uniqueNonEmpty(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}

--- a/src/cli/guards/roadmap-edit-shipped.ts
+++ b/src/cli/guards/roadmap-edit-shipped.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { loadConfig } from '../../core/index.js';
+import { getApplyPatchText, resolveTouchedPaths, toAbsoluteTouchedPath } from './hook-input.js';
 
 const DEFAULT_ROADMAP_PATH = 'docs/backlog/roadmap.json';
 
@@ -17,9 +18,6 @@ const DEFAULT_ROADMAP_PATH = 'docs/backlog/roadmap.json';
 export async function roadmapEditShippedGuard(input: HookInput, cwd: string): Promise<GuardResult> {
   if (process.env.SLOPE_ALLOW_SHIPPED_EDIT === '1') return {};
 
-  const filePath = input.tool_input?.file_path as string | undefined;
-  if (!filePath) return {};
-
   let roadmapAbs: string;
   try {
     const config = loadConfig(cwd);
@@ -28,7 +26,9 @@ export async function roadmapEditShippedGuard(input: HookInput, cwd: string): Pr
     roadmapAbs = resolve(cwd, DEFAULT_ROADMAP_PATH);
   }
 
-  if (resolve(filePath) !== roadmapAbs) return {};
+  const touchesRoadmap = resolveTouchedPaths(input)
+    .some(filePath => toAbsoluteTouchedPath(filePath, cwd) === roadmapAbs);
+  if (!touchesRoadmap) return {};
 
   let currentContent: string;
   try {
@@ -37,17 +37,8 @@ export async function roadmapEditShippedGuard(input: HookInput, cwd: string): Pr
     return {}; // file doesn't exist yet — nothing to protect
   }
 
-  const newString = input.tool_input?.new_string as string | undefined;
-  const oldString = input.tool_input?.old_string as string | undefined;
-  if (newString === undefined) return {};
-
-  let wouldBeContent: string;
-  if (oldString !== undefined) {
-    if (!currentContent.includes(oldString)) return {}; // Edit will fail with its own error
-    wouldBeContent = currentContent.replace(oldString, newString);
-  } else {
-    wouldBeContent = newString;
-  }
+  const wouldBeContent = resolveWouldBeContent(input, roadmapAbs, currentContent, cwd);
+  if (wouldBeContent === null) return {};
 
   let current: { sprints?: unknown[] };
   let next: { sprints?: unknown[] };
@@ -101,6 +92,117 @@ export async function roadmapEditShippedGuard(input: HookInput, cwd: string): Pr
       'correct shipped-sprint history.',
     ].join('\n'),
   };
+}
+
+function resolveWouldBeContent(
+  input: HookInput,
+  roadmapAbs: string,
+  currentContent: string,
+  cwd: string,
+): string | null {
+  const newString = input.tool_input?.new_string as string | undefined;
+  const oldString = input.tool_input?.old_string as string | undefined;
+  if (newString !== undefined) {
+    if (oldString !== undefined) {
+      if (!currentContent.includes(oldString)) return null; // Edit will fail with its own error
+      return currentContent.replace(oldString, newString);
+    }
+    return newString;
+  }
+
+  const patchText = getApplyPatchText(input);
+  if (!patchText) return null;
+  return applyPatchToFileContent(patchText, roadmapAbs, currentContent, cwd);
+}
+
+function applyPatchToFileContent(
+  patchText: string,
+  targetAbs: string,
+  currentContent: string,
+  cwd: string,
+): string | null {
+  let nextContent = currentContent;
+  let inTargetFile = false;
+  let operation: 'add' | 'update' | 'delete' | null = null;
+  let currentHunk: string[] = [];
+  const addedFileLines: string[] = [];
+  let touchedTarget = false;
+
+  const flushHunk = (): boolean => {
+    if (!inTargetFile || operation !== 'update' || currentHunk.length === 0) {
+      currentHunk = [];
+      return true;
+    }
+
+    const replacement = applyHunk(nextContent, currentHunk);
+    currentHunk = [];
+    if (replacement === null) return false;
+    nextContent = replacement;
+    return true;
+  };
+
+  for (const line of patchText.split(/\r?\n/)) {
+    const fileMatch = line.match(/^\*\*\* (Add|Update|Delete) File: (.+)$/);
+    if (fileMatch) {
+      if (!flushHunk()) return null;
+
+      operation = fileMatch[1].toLowerCase() as 'add' | 'update' | 'delete';
+      inTargetFile = toAbsoluteTouchedPath(fileMatch[2], cwd) === targetAbs;
+      if (inTargetFile) {
+        touchedTarget = true;
+        if (operation === 'delete') nextContent = JSON.stringify({ sprints: [] });
+        addedFileLines.length = 0;
+      }
+      continue;
+    }
+
+    if (!inTargetFile) continue;
+    if (line === '*** End Patch') break;
+    if (line.startsWith('*** ')) continue;
+
+    if (operation === 'add') {
+      if (line.startsWith('+')) addedFileLines.push(line.slice(1));
+      continue;
+    }
+
+    if (operation !== 'update') continue;
+    if (line.startsWith('@@')) {
+      if (!flushHunk()) return null;
+      continue;
+    }
+    currentHunk.push(line);
+  }
+
+  if (!flushHunk()) return null;
+  if (operation === 'add' && inTargetFile) nextContent = addedFileLines.join('\n');
+
+  return touchedTarget ? nextContent : null;
+}
+
+function applyHunk(content: string, hunkLines: string[]): string | null {
+  const oldLines: string[] = [];
+  const newLines: string[] = [];
+
+  for (const line of hunkLines) {
+    if (line === '\\ No newline at end of file') continue;
+    const marker = line[0];
+    const text = line.slice(1);
+    if (marker === ' ') {
+      oldLines.push(text);
+      newLines.push(text);
+    } else if (marker === '-') {
+      oldLines.push(text);
+    } else if (marker === '+') {
+      newLines.push(text);
+    }
+  }
+
+  const oldBlock = oldLines.join('\n');
+  const newBlock = newLines.join('\n');
+  if (!oldBlock) return null;
+  if (!content.includes(oldBlock)) return null;
+
+  return content.replace(oldBlock, newBlock);
 }
 
 /** Detect built-in object types that need special equality handling.

--- a/src/cli/guards/scope-drift.ts
+++ b/src/cli/guards/scope-drift.ts
@@ -2,8 +2,11 @@ import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { loadConfig } from '../config.js';
+import type { SlopeConfig } from '../config.js';
+import { loadSprintState } from '../sprint-state.js';
 import { resolveStore } from '../store.js';
 import { dedupGuardContext } from '../session-state.js';
+import { normalizeTouchedPath, resolveTouchedPaths } from './hook-input.js';
 
 // ── Disk state for compaction survival ──────────────
 
@@ -59,19 +62,17 @@ function pruneState(state: DriftState, currentSprint: number): DriftState {
  * Writes state to disk so warnings survive context compaction.
  */
 export async function scopeDriftGuard(input: HookInput, cwd: string): Promise<GuardResult> {
-  const config = loadConfig();
+  const config = loadConfig(cwd);
   if (config.guidance?.scopeDrift === false) return {};
 
-  const filePath = input.tool_input?.file_path as string | undefined;
-  if (!filePath) return {};
-
   // Normalize file path relative to cwd
-  const relativePath = filePath.startsWith(cwd)
-    ? filePath.slice(cwd.length + 1)
-    : filePath;
+  const relativePaths = resolveTouchedPaths(input)
+    .map(filePath => normalizeTouchedPath(filePath, cwd))
+    .filter((filePath): filePath is string => Boolean(filePath));
+  if (relativePaths.length === 0) return {};
 
   // Look up active claims for the current sprint
-  const sprintNumber = config.currentSprint;
+  const sprintNumber = resolveCurrentSprint(cwd, config);
   if (!sprintNumber) return {}; // Can't check without a sprint
 
   // Load and prune disk state
@@ -89,16 +90,19 @@ export async function scopeDriftGuard(input: HookInput, cwd: string): Promise<Gu
     const areaClaims = claims.filter(c => c.scope === 'area');
     if (areaClaims.length === 0) return {}; // No area claims — ticket-only claims don't restrict files
 
-    const inScope = areaClaims.some(c => relativePath.startsWith(c.target));
+    const outOfScopePath = relativePaths.find(relativePath =>
+      !areaClaims.some(c => isWithinClaimedArea(relativePath, c.target)),
+    );
 
-    if (inScope) {
-      // File is in scope — clear any cached drift entry for this file
-      state.entries = state.entries.filter(e => e.file !== relativePath);
+    if (!outOfScopePath) {
+      // Files are in scope — clear any cached drift entries for these files
+      state.entries = state.entries.filter(e => !relativePaths.includes(e.file));
       saveDriftState(cwd, state);
       return {};
     }
 
     // Out of scope — cache drift violation to disk
+    const relativePath = outOfScopePath;
     const claimedAreas = areaClaims.map(c => c.target).join(', ');
     const entry: DriftStateEntry = {
       file: relativePath,
@@ -115,12 +119,22 @@ export async function scopeDriftGuard(input: HookInput, cwd: string): Promise<Gu
     return { context: dedup ?? driftMsg };
   } catch {
     // Store not available — fall back to disk state (advisory, not blocking)
-    const cached = state.entries.find(e => e.file === relativePath);
+    const cached = state.entries.find(e => relativePaths.includes(e.file));
     if (cached && (Date.now() - cached.timestamp) < STALE_MS) {
-      const cachedMsg = `SLOPE scope drift: ${relativePath} is outside claimed areas (${cached.claimedAreas}). Intentional?`;
+      const cachedMsg = `SLOPE scope drift: ${cached.file} is outside claimed areas (${cached.claimedAreas}). Intentional?`;
       const dedup = dedupGuardContext(cwd, input.session_id, 'scope-drift', cachedMsg);
       return { context: dedup ?? cachedMsg };
     }
     return {}; // No cached state or too stale — fail open
   }
+}
+
+function resolveCurrentSprint(cwd: string, config: SlopeConfig): number | undefined {
+  const sprintState = loadSprintState(cwd);
+  return sprintState?.sprint ?? config.currentSprint;
+}
+
+function isWithinClaimedArea(relativePath: string, target: string): boolean {
+  const normalizedTarget = target.replace(/\\/g, '/').replace(/\/$/, '');
+  return relativePath === normalizedTarget || relativePath.startsWith(`${normalizedTarget}/`);
 }

--- a/tests/cli/guards.test.ts
+++ b/tests/cli/guards.test.ts
@@ -45,6 +45,34 @@ function makeInput(overrides: Partial<HookInput> = {}): HookInput {
   };
 }
 
+function applyPatchCommand(path: string): string {
+  return [
+    '*** Begin Patch',
+    `*** Update File: ${path}`,
+    '@@',
+    '-old',
+    '+new',
+    '*** End Patch',
+  ].join('\n');
+}
+
+function writeSprintState(sprint: number): void {
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope/sprint-state.json'), JSON.stringify({
+    sprint,
+    phase: 'implementing',
+    gates: {
+      tests: false,
+      code_review: false,
+      architect_review: false,
+      scorecard: false,
+      review_md: false,
+    },
+    started_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }));
+}
+
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'slope-guard-'));
   mockConfig.guidance = {};
@@ -142,6 +170,33 @@ describe('hazardGuard', () => {
     );
     expect(result.context).toContain('SLOPE hazards');
     expect(result.context).toContain('Migration conflict in core');
+  });
+
+  it('warns for Codex apply_patch input when patch touches an area with known issues', async () => {
+    mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+    writeFileSync(join(tmpDir, '.slope/common-issues.json'), JSON.stringify({
+      recurring_patterns: [
+        {
+          id: 1,
+          title: 'Version command regression',
+          category: 'testing',
+          sprints_hit: [100],
+          gotcha_refs: [],
+          description: 'src/cli/commands changes need direct CLI smoke tests',
+          prevention: 'Smoke test the built command after editing src/cli/commands',
+        },
+      ],
+    }));
+
+    const result = await hazardGuard(
+      makeInput({
+        tool_name: 'apply_patch',
+        tool_input: { command: applyPatchCommand(join(tmpDir, 'src/cli/commands/version.ts')) },
+      }),
+      tmpDir,
+    );
+    expect(result.context).toContain('SLOPE hazards');
+    expect(result.context).toContain('Version command regression');
   });
 
   it('returns empty when area has no matching issues', async () => {
@@ -384,6 +439,31 @@ describe('scopeDriftGuard', () => {
     expect(result.context).toContain('scope drift');
     expect(result.context).toContain('src/core');
     spy.mockRestore();
+  });
+
+  it('warns for Codex apply_patch input when patch touches outside claimed areas', async () => {
+    writeSprintState(10);
+    const { createStore } = await import('../../src/store/index.js');
+    const store = createStore({ storePath: '.slope/slope.db', cwd: tmpDir });
+    await store.claim({
+      sprint_number: 10,
+      player: 'test',
+      target: 'src/core',
+      scope: 'area',
+    });
+    store.close();
+
+    const result = await scopeDriftGuard(
+      makeInput({
+        tool_name: 'apply_patch',
+        tool_input: { command: applyPatchCommand(join(tmpDir, 'src/cli/commands/version.ts')) },
+      }),
+      tmpDir,
+    );
+
+    expect(result.context).toContain('scope drift');
+    expect(result.context).toContain('src/cli/commands/version.ts');
+    expect(result.context).toContain('src/core');
   });
 
   it('fails open when disk state is older than 24 hours', async () => {

--- a/tests/cli/guards/claim-required.test.ts
+++ b/tests/cli/guards/claim-required.test.ts
@@ -19,6 +19,25 @@ function makeInput(cwd: string, filePath: string): HookInput {
   };
 }
 
+function makeApplyPatchInput(cwd: string, filePath: string): HookInput {
+  return {
+    session_id: 'test-session',
+    cwd,
+    hook_event_name: 'PreToolUse',
+    tool_name: 'apply_patch',
+    tool_input: {
+      command: [
+        '*** Begin Patch',
+        `*** Update File: ${filePath}`,
+        '@@',
+        '-old',
+        '+new',
+        '*** End Patch',
+      ].join('\n'),
+    },
+  };
+}
+
 function writeConfig(cwd: string, guidance: Record<string, unknown> = {}): void {
   mkdirSync(join(cwd, '.slope'), { recursive: true });
   writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({
@@ -141,6 +160,21 @@ describe('claimRequiredGuard', () => {
       expect(result.decision).toBe('ask');
       expect(result.context).toContain('no active sprint state');
       expect(result.context).toContain('slope sprint start');
+      expect(result.context).toContain('slope claim');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('asks before Codex apply_patch implementation writes when no sprint state is active', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
+    try {
+      writeConfig(cwd);
+      const result = await claimRequiredGuard(makeApplyPatchInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+
+      expect(result.decision).toBe('ask');
+      expect(result.context).toContain('src/foo.ts');
+      expect(result.context).toContain('no active sprint state');
       expect(result.context).toContain('slope claim');
     } finally {
       rmSync(cwd, { recursive: true, force: true });

--- a/tests/cli/guards/hook-input.test.ts
+++ b/tests/cli/guards/hook-input.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeTouchedPath,
+  parseApplyPatchTouchedPaths,
+  resolveTouchedPaths,
+  toAbsoluteTouchedPath,
+} from '../../../src/cli/guards/hook-input.js';
+import type { HookInput } from '../../../src/core/index.js';
+
+function makeInput(toolInput: Record<string, unknown>): HookInput {
+  return {
+    session_id: 'test-session',
+    cwd: '/repo',
+    hook_event_name: 'PreToolUse',
+    tool_name: 'apply_patch',
+    tool_input: toolInput,
+  };
+}
+
+describe('hook input path helpers', () => {
+  it('resolves direct file_path and path payloads', () => {
+    expect(resolveTouchedPaths(makeInput({
+      file_path: '/repo/src/a.ts',
+      path: '/repo/src/b.ts',
+    }))).toEqual(['/repo/src/a.ts', '/repo/src/b.ts']);
+  });
+
+  it('parses Codex apply_patch command text', () => {
+    const patch = [
+      '*** Begin Patch',
+      '*** Update File: /repo/src/a.ts',
+      '@@',
+      '-old',
+      '+new',
+      '*** Add File: src/b.ts',
+      '+new file',
+      '*** Delete File: src/c.ts',
+      '*** Move to: src/d.ts',
+      '*** End Patch',
+    ].join('\n');
+
+    expect(parseApplyPatchTouchedPaths(patch)).toEqual([
+      '/repo/src/a.ts',
+      'src/b.ts',
+      'src/c.ts',
+      'src/d.ts',
+    ]);
+    expect(resolveTouchedPaths(makeInput({ command: patch }))).toEqual([
+      '/repo/src/a.ts',
+      'src/b.ts',
+      'src/c.ts',
+      'src/d.ts',
+    ]);
+  });
+
+  it('normalizes absolute and relative touched paths against cwd', () => {
+    expect(normalizeTouchedPath('/repo/src/a.ts', '/repo')).toBe('src/a.ts');
+    expect(normalizeTouchedPath('./src/a.ts', '/repo')).toBe('src/a.ts');
+    expect(toAbsoluteTouchedPath('src/a.ts', '/repo')).toBe('/repo/src/a.ts');
+  });
+});

--- a/tests/cli/guards/roadmap-edit-shipped.test.ts
+++ b/tests/cli/guards/roadmap-edit-shipped.test.ts
@@ -71,6 +71,43 @@ function editInput(filePath: string, oldString: string, newString: string): Hook
   };
 }
 
+function applyPatchInput(filePath: string, oldLine: string, newLine: string): HookInput {
+  return {
+    session_id: 'test',
+    cwd: '/tmp',
+    hook_event_name: 'PreToolUse',
+    tool_name: 'apply_patch',
+    tool_input: {
+      command: [
+        '*** Begin Patch',
+        `*** Update File: ${filePath}`,
+        '@@',
+        `-${oldLine}`,
+        `+${newLine}`,
+        '*** End Patch',
+      ].join('\n'),
+    },
+    tool_response: {},
+  };
+}
+
+function deletePatchInput(filePath: string): HookInput {
+  return {
+    session_id: 'test',
+    cwd: '/tmp',
+    hook_event_name: 'PreToolUse',
+    tool_name: 'apply_patch',
+    tool_input: {
+      command: [
+        '*** Begin Patch',
+        `*** Delete File: ${filePath}`,
+        '*** End Patch',
+      ].join('\n'),
+    },
+    tool_response: {},
+  };
+}
+
 describe('roadmapEditShippedGuard', () => {
   let cwd: string;
   let originalEnv: string | undefined;
@@ -161,6 +198,28 @@ describe('roadmapEditShippedGuard', () => {
     const newString = '"title": "Hijacked"';
     const result = await roadmapEditShippedGuard(editInput(path, oldString, newString), cwd);
     expect(result.decision).toBe('deny');
+  });
+
+  it('blocks Codex apply_patch edits to shipped sprint fields', async () => {
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const result = await roadmapEditShippedGuard(
+      applyPatchInput(
+        path,
+        '      "theme": "Shipped sprint",',
+        '      "theme": "Rewritten history",',
+      ),
+      cwd,
+    );
+    expect(result.decision).toBe('deny');
+    expect(result.blockReason).toContain('S1');
+    expect(result.blockReason).toContain('shipped sprint fields modified');
+  });
+
+  it('blocks Codex apply_patch deleting a roadmap with shipped sprints', async () => {
+    const path = writeRoadmap(cwd, baseRoadmap());
+    const result = await roadmapEditShippedGuard(deletePatchInput(path), cwd);
+    expect(result.decision).toBe('deny');
+    expect(result.blockReason).toContain('removed');
   });
 
   it('allows Edit when old_string does not match current content', async () => {


### PR DESCRIPTION
## Summary
- add shared guard helper for touched paths from file_path/path arrays and Codex apply_patch patch text
- update hazard, scope-drift, claim-required, and roadmap-edit-shipped guards to use resolved touched paths
- add Codex apply_patch regressions for each affected guard and S101 scorecard/review artifacts

Fixes #396.

## Verification
- pnpm vitest run tests/cli/guards/hook-input.test.ts tests/cli/guards.test.ts tests/cli/guards/claim-required.test.ts tests/cli/guards/roadmap-edit-shipped.test.ts
- pnpm typecheck
- pnpm build
- pnpm test
- built CLI scope-drift probes for apply_patch and Edit payloads touching src/cli/commands/version.ts