### PR TITLE
fix: harden state writes and claim help

### DIFF
--- a/docs/retros/sprint-102.json
+++ b/docs/retros/sprint-102.json
@@ -1,0 +1,87 @@
+{
+  "sprint_number": 102,
+  "player": "sebastianbryers",
+  "theme": "State Write Race and Claim Help Fixes",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-21",
+  "shots": [
+    {
+      "ticket_key": "S102-1",
+      "title": "Make slope claim --help read-only (#410)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added early --help/-h handling before store resolution, target validation, and session mutation, with read-only regression coverage."
+    },
+    {
+      "ticket_key": "S102-2",
+      "title": "Harden SLOPE state writes against concurrent races (#409)",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The initial fix covered fixed temp filenames; review identified stale read-modify-write phase transitions and added a locked sprint-state mutator."
+        }
+      ],
+      "notes": "Added unique same-directory temp writes, file locks, locked sprint/session state mutation paths, and child-process concurrency regressions."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 2,
+    "fairways_total": 2,
+    "greens_in_regulation": 2,
+    "greens_total": 2,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Concurrent state safety needs both unique temp files and a lock around read-modify-write operations.",
+      "outcome": "Sprint/session state updates now serialize gate, phase, mode, and dedup mutations instead of relying only on atomic rename."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused concurrency tests, typecheck, build, and the full Vitest suite passed.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A compact reliability sprint that exposed the difference between atomic file replacement and safe state mutation.",
+    "advice_for_next_player": "When fixing state races, test both rename failures and lost-update behavior across separate processes.",
+    "what_surprised_you": "S102 was not in the roadmap, so auto-card fell back to a full-history scorecard and had to be replaced manually.",
+    "excited_about_next": "The remaining agent-DX issues can build on a less fragile guard-state foundation."
+  },
+  "bunker_locations": [
+    "Fixed temp filenames cause ENOENT under concurrent writers; use unique temp paths in the target directory.",
+    "Atomic rename alone does not prevent lost updates when callers load, mutate, then save stale state."
+  ],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Validation used pnpm vitest run tests/cli/atomic-write.test.ts tests/cli/commands/claim-help.test.ts tests/cli/sprint-state.test.ts tests/cli/guards/sprint-completion.test.ts tests/cli/guards/workflow-gate.test.ts tests/cli/sprint-workflow.test.ts.",
+    "Additional validation used pnpm run typecheck, pnpm run build, and pnpm test.",
+    "slope review --help currently generates a sprint review instead of printing help; this was observed during closeout and should be tracked separately."
+  ],
+  "slope_factors": [
+    "state_management",
+    "guard_runtime",
+    "agent_dx"
+  ]
+}

--- a/src/cli/atomic-write.ts
+++ b/src/cli/atomic-write.ts
@@ -1,0 +1,108 @@
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { basename, dirname, join } from 'node:path';
+
+const DEFAULT_LOCK_TIMEOUT_MS = 5000;
+const DEFAULT_LOCK_RETRY_MS = 10;
+const DEFAULT_STALE_LOCK_MS = 60000;
+
+export interface FileLockOptions {
+  timeoutMs?: number;
+  retryMs?: number;
+  staleMs?: number;
+}
+
+export function createAtomicTempPath(filePath: string): string {
+  const unique = `${process.pid}.${Date.now()}.${randomBytes(6).toString('hex')}`;
+  return join(dirname(filePath), `.${basename(filePath)}.${unique}.tmp`);
+}
+
+export function atomicWriteFileSync(filePath: string, contents: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+
+  const tmpPath = createAtomicTempPath(filePath);
+  try {
+    writeFileSync(tmpPath, contents);
+    renameSync(tmpPath, filePath);
+  } catch (error) {
+    try {
+      if (existsSync(tmpPath)) unlinkSync(tmpPath);
+    } catch {
+      // Preserve the original write/rename failure.
+    }
+    throw error;
+  }
+}
+
+function sleepSync(ms: number): void {
+  const buffer = new SharedArrayBuffer(4);
+  Atomics.wait(new Int32Array(buffer), 0, 0, ms);
+}
+
+function unlinkIfPresent(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+
+function removeStaleLock(lockPath: string, staleMs: number): void {
+  try {
+    const stat = statSync(lockPath);
+    if (Date.now() - stat.mtimeMs > staleMs) {
+      unlinkIfPresent(lockPath);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}
+
+export function withFileLockSync<T>(
+  filePath: string,
+  callback: () => T,
+  options: FileLockOptions = {},
+): T {
+  mkdirSync(dirname(filePath), { recursive: true });
+
+  const lockPath = `${filePath}.lock`;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+  const retryMs = options.retryMs ?? DEFAULT_LOCK_RETRY_MS;
+  const staleMs = options.staleMs ?? DEFAULT_STALE_LOCK_MS;
+  const deadline = Date.now() + timeoutMs;
+  let fd: number | null = null;
+
+  while (fd === null) {
+    try {
+      fd = openSync(lockPath, 'wx');
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') throw error;
+
+      removeStaleLock(lockPath, staleMs);
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for file lock: ${lockPath}`);
+      }
+      sleepSync(retryMs);
+    }
+  }
+
+  try {
+    return callback();
+  } finally {
+    try {
+      closeSync(fd);
+    } finally {
+      unlinkIfPresent(lockPath);
+    }
+  }
+}

--- a/src/cli/commands/claim.ts
+++ b/src/cli/commands/claim.ts
@@ -13,6 +13,26 @@ function parseArgs(args: string[]): Record<string, string> {
   return result;
 }
 
+function hasHelpFlag(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
+function printClaimHelp(): void {
+  console.log(`slope claim --target=<target> [options]
+
+Register a sprint claim for a ticket, file, or area.
+
+Options:
+  --target=<target>      Ticket, file path, or area to claim
+  --scope=<scope>        Claim scope: ticket or area (default: ticket)
+  --sprint=<number>      Sprint number (default: inferred from context)
+  --player=<name>        Player name (default: USER env var)
+  --notes=<text>         Optional claim notes
+  --force                Override overlap conflicts
+  --help, -h             Show this help
+`);
+}
+
 function resolveSprint(flags: Record<string, string>, cwd: string): number {
   if (flags.sprint) return parseInt(flags.sprint, 10);
   const config = loadConfig(cwd);
@@ -20,6 +40,11 @@ function resolveSprint(flags: Record<string, string>, cwd: string): number {
 }
 
 export async function claimCommand(args: string[]): Promise<void> {
+  if (hasHelpFlag(args)) {
+    printClaimHelp();
+    return;
+  }
+
   const flags = parseArgs(args);
   const force = args.includes('--force');
   const cwd = process.cwd();

--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -2,6 +2,7 @@ import {
   loadSprintState,
   saveSprintState,
   createSprintState,
+  mutateSprintState,
   updateGate,
   updateSprintPhase,
   clearSprintState,
@@ -231,8 +232,7 @@ function startCommand(args: string[], cwd: string): void {
   const existing = loadSprintState(cwd);
   if (existing && existing.sprint === sprint) {
     if (phaseArg && existing.phase !== phase) {
-      existing.phase = phase;
-      saveSprintState(cwd, existing);
+      updateSprintPhase(cwd, phase);
       console.log(`Sprint ${sprint} phase updated: ${phase}.`);
       return;
     }
@@ -416,8 +416,12 @@ function syncSprintStateWithWorkflow(cwd: string, sprintId: string | undefined, 
   if (existing.sprint !== sprint || existing.phase === 'complete') return;
   if (SPRINT_PHASE_ORDER[nextPhase] <= SPRINT_PHASE_ORDER[existing.phase]) return;
 
-  existing.phase = nextPhase;
-  saveSprintState(cwd, existing);
+  mutateSprintState(cwd, current => {
+    if (current.sprint !== sprint || current.phase === 'complete') return false;
+    if (SPRINT_PHASE_ORDER[nextPhase] <= SPRINT_PHASE_ORDER[current.phase]) return false;
+    current.phase = nextPhase;
+    return true;
+  });
 }
 
 async function runWorkflowCommand(args: string[], cwd: string): Promise<void> {

--- a/src/cli/guards/sprint-completion.ts
+++ b/src/cli/guards/sprint-completion.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { loadConfig } from '../config.js';
-import { loadSprintState, saveSprintState, updateGate, isSprintComplete, pendingGates } from '../sprint-state.js';
+import { loadSprintState, mutateSprintState, updateGate, isSprintComplete, pendingGates } from '../sprint-state.js';
 
 /**
  * Sprint-completion guard: enforces post-implementation gates.
@@ -282,10 +282,14 @@ function handlePrMerge(input: HookInput, cwd: string): GuardResult {
   const exitCode = response.exit_code ?? response.exitCode;
   if (exitCode !== 0 && exitCode !== '0' && exitCode !== undefined) return {};
 
-  state.phase = 'scoring';
-  saveSprintState(cwd, state);
+  const updated = mutateSprintState(cwd, current => {
+    if (current.phase === 'scoring' || current.phase === 'complete') return false;
+    current.phase = 'scoring';
+    return true;
+  });
+  if (!updated) return {};
 
-  const pending = pendingGates(state);
+  const pending = pendingGates(updated);
   return {
     context: [
       `SLOPE: PR merged — sprint phase is now 'scoring'. Remaining gates:`,

--- a/src/cli/guards/workflow-gate.ts
+++ b/src/cli/guards/workflow-gate.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { HookInput, GuardResult } from '../../core/index.js';
-import { loadSprintState, saveSprintState } from '../sprint-state.js';
+import { mutateSprintState } from '../sprint-state.js';
 
 interface ReviewState {
   rounds_required: number;
@@ -33,11 +33,11 @@ export async function workflowGateGuard(input: HookInput, cwd: string): Promise<
 
   if (state.rounds_completed >= state.rounds_required) {
     // Transition sprint-state to implementing when review is complete
-    const sprintState = loadSprintState(cwd);
-    if (sprintState && (sprintState.phase === 'planning' || sprintState.phase === 'reviewing')) {
+    mutateSprintState(cwd, sprintState => {
+      if (sprintState.phase !== 'planning' && sprintState.phase !== 'reviewing') return false;
       sprintState.phase = 'implementing';
-      saveSprintState(cwd, sprintState);
-    }
+      return true;
+    });
     return {};
   }
 

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
+import { atomicWriteFileSync, withFileLockSync } from './atomic-write.js';
 import { isActiveSprintState, loadSprintState } from './sprint-state.js';
 
 const SESSION_STATE_FILE = '.slope/.session-state.json';
@@ -37,30 +38,46 @@ export function loadSessionState(cwd: string): SessionState {
   }
 }
 
-/** Save consolidated session state atomically via tmp + rename. */
-export function saveSessionState(cwd: string, state: SessionState): void {
-  const dir = join(cwd, '.slope');
-  mkdirSync(dir, { recursive: true });
+function sessionStatePath(cwd: string): string {
+  return join(cwd, SESSION_STATE_FILE);
+}
 
-  const filePath = join(cwd, SESSION_STATE_FILE);
-  const tmpPath = filePath + '.tmp';
-  writeFileSync(tmpPath, JSON.stringify(state, null, 2) + '\n');
-  renameSync(tmpPath, filePath);
+function saveSessionStateUnlocked(filePath: string, state: SessionState): void {
+  atomicWriteFileSync(filePath, JSON.stringify(state, null, 2) + '\n');
+}
+
+function mutateSessionState(cwd: string, mutator: (state: SessionState) => boolean): SessionState {
+  const filePath = sessionStatePath(cwd);
+  return withFileLockSync(filePath, () => {
+    const state = loadSessionState(cwd);
+    if (mutator(state)) {
+      saveSessionStateUnlocked(filePath, state);
+    }
+    return state;
+  });
+}
+
+/** Save consolidated session state atomically via unique tmp + rename. */
+export function saveSessionState(cwd: string, state: SessionState): void {
+  const filePath = sessionStatePath(cwd);
+  withFileLockSync(filePath, () => saveSessionStateUnlocked(filePath, state));
 }
 
 /** Update a single field in session state and save atomically. */
 export function updateSessionState(cwd: string, field: keyof SessionState, value: string): void {
-  const state = loadSessionState(cwd);
-  (state as Record<string, unknown>)[field] = value;
-  saveSessionState(cwd, state);
+  mutateSessionState(cwd, state => {
+    (state as Record<string, unknown>)[field] = value;
+    return true;
+  });
 }
 
 /** Set the session mode (adhoc or sprint) for a given session. */
 export function setSessionMode(cwd: string, sessionId: string, mode: SessionMode): void {
-  const state = loadSessionState(cwd);
-  state.session_mode = mode;
-  state.session_mode_id = sessionId;
-  saveSessionState(cwd, state);
+  mutateSessionState(cwd, state => {
+    state.session_mode = mode;
+    state.session_mode_id = sessionId;
+    return true;
+  });
 }
 
 /** Check if the current session is in adhoc mode.
@@ -77,18 +94,21 @@ export function isAdhocSession(cwd: string, sessionId: string): boolean {
  *  back to sprint mode so sprint-workflow guards do not stay suppressed. */
 export function syncSessionModeWithSprintState(cwd: string, sessionId: string): SessionMode | null {
   if (!sessionId) return null;
-  const state = loadSessionState(cwd);
   const sprintState = loadSprintState(cwd);
 
   if (isActiveSprintState(sprintState)) {
-    if (state.session_mode !== 'sprint' || state.session_mode_id !== sessionId) {
+    mutateSessionState(cwd, state => {
+      if (state.session_mode === 'sprint' && state.session_mode_id === sessionId) {
+        return false;
+      }
       state.session_mode = 'sprint';
       state.session_mode_id = sessionId;
-      saveSessionState(cwd, state);
-    }
+      return true;
+    });
     return 'sprint';
   }
 
+  const state = loadSessionState(cwd);
   if (state.session_mode_id !== sessionId) return null;
   return state.session_mode ?? null;
 }
@@ -115,13 +135,12 @@ function loadDedupState(cwd: string): ContextDedupState | null {
   try { return JSON.parse(readFileSync(path, 'utf8')); } catch { return null; }
 }
 
-function saveDedupState(cwd: string, state: ContextDedupState): void {
-  const dir = join(cwd, '.slope');
-  mkdirSync(dir, { recursive: true });
-  const filePath = join(cwd, CONTEXT_DEDUP_FILE);
-  const tmpPath = filePath + '.tmp';
-  writeFileSync(tmpPath, JSON.stringify(state) + '\n');
-  renameSync(tmpPath, filePath);
+function dedupStatePath(cwd: string): string {
+  return join(cwd, CONTEXT_DEDUP_FILE);
+}
+
+function saveDedupStateUnlocked(filePath: string, state: ContextDedupState): void {
+  atomicWriteFileSync(filePath, JSON.stringify(state) + '\n');
 }
 
 function hashContent(content: string): string {
@@ -142,41 +161,45 @@ export function dedupGuardContext(
   if (!sessionId || !context) return null;
 
   const hash = hashContent(context);
-  let state = loadDedupState(cwd);
+  const filePath = dedupStatePath(cwd);
 
-  // Reset if session changed
-  if (!state || state.session_id !== sessionId) {
-    state = { session_id: sessionId, seen: {}, total_chars: 0 };
-  }
+  return withFileLockSync(filePath, () => {
+    let state = loadDedupState(cwd);
 
-  // Prune entries older than 24 hours (prevents unbounded growth across long sessions)
-  const DEDUP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
-  const now = Date.now();
-  for (const [h, entry] of Object.entries(state.seen)) {
-    if (entry.ts && (now - entry.ts) > DEDUP_MAX_AGE_MS) {
-      delete state.seen[h];
+    // Reset if session changed
+    if (!state || state.session_id !== sessionId) {
+      state = { session_id: sessionId, seen: {}, total_chars: 0 };
     }
-  }
 
-  const existing = state.seen[hash];
-  if (existing) {
-    // Already injected — return compressed reference
-    existing.count++;
-    existing.ts = now;
-    saveDedupState(cwd, state);
-    return `SLOPE ${guardName}: (same as prior warning, shown ${existing.count}x)`;
-  }
+    // Prune entries older than 24 hours (prevents unbounded growth across long sessions)
+    const DEDUP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    for (const [h, entry] of Object.entries(state.seen)) {
+      if (entry.ts && (now - entry.ts) > DEDUP_MAX_AGE_MS) {
+        delete state.seen[h];
+      }
+    }
 
-  // Check token budget — if exceeded, return short message instead of full context
-  const budget = DEFAULT_CONTEXT_BUDGET_CHARS;
-  if ((state.total_chars ?? 0) + context.length > budget) {
-    saveDedupState(cwd, state);
-    return `SLOPE ${guardName}: context budget exhausted (${Math.round((state.total_chars ?? 0) / 4)}+ tokens injected). Run \`slope briefing --compact\` for status.`;
-  }
+    const existing = state.seen[hash];
+    if (existing) {
+      // Already injected — return compressed reference
+      existing.count++;
+      existing.ts = now;
+      saveDedupStateUnlocked(filePath, state);
+      return `SLOPE ${guardName}: (same as prior warning, shown ${existing.count}x)`;
+    }
 
-  // New content — track chars and record
-  state.total_chars = (state.total_chars ?? 0) + context.length;
-  state.seen[hash] = { guard: guardName, count: 1, ts: now };
-  saveDedupState(cwd, state);
-  return null;
+    // Check token budget — if exceeded, return short message instead of full context
+    const budget = DEFAULT_CONTEXT_BUDGET_CHARS;
+    if ((state.total_chars ?? 0) + context.length > budget) {
+      saveDedupStateUnlocked(filePath, state);
+      return `SLOPE ${guardName}: context budget exhausted (${Math.round((state.total_chars ?? 0) / 4)}+ tokens injected). Run \`slope briefing --compact\` for status.`;
+    }
+
+    // New content — track chars and record
+    state.total_chars = (state.total_chars ?? 0) + context.length;
+    state.seen[hash] = { guard: guardName, count: 1, ts: now };
+    saveDedupStateUnlocked(filePath, state);
+    return null;
+  });
 }

--- a/src/cli/sprint-state.ts
+++ b/src/cli/sprint-state.ts
@@ -1,5 +1,6 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from 'node:fs';
+import { readFileSync, existsSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
+import { atomicWriteFileSync, withFileLockSync } from './atomic-write.js';
 
 /** Sprint lifecycle phases */
 export const SPRINT_PHASES = ['planning', 'reviewing', 'implementing', 'scoring', 'complete'] as const;
@@ -62,34 +63,48 @@ export function isActiveSprintState(state: SprintState | null): state is SprintS
   return Boolean(state && state.phase !== 'complete');
 }
 
-/** Save sprint state atomically via tmp + rename. */
-export function saveSprintState(cwd: string, state: SprintState): void {
-  const dir = join(cwd, '.slope');
-  mkdirSync(dir, { recursive: true });
+function sprintStatePath(cwd: string): string {
+  return join(cwd, SPRINT_STATE_FILE);
+}
 
+function saveSprintStateUnlocked(filePath: string, state: SprintState): void {
   state.updated_at = new Date().toISOString();
+  atomicWriteFileSync(filePath, JSON.stringify(state, null, 2) + '\n');
+}
 
-  const filePath = join(cwd, SPRINT_STATE_FILE);
-  const tmpPath = filePath + '.tmp';
-  writeFileSync(tmpPath, JSON.stringify(state, null, 2) + '\n');
-  renameSync(tmpPath, filePath);
+/** Save sprint state atomically via unique tmp + rename. */
+export function saveSprintState(cwd: string, state: SprintState): void {
+  const filePath = sprintStatePath(cwd);
+  withFileLockSync(filePath, () => saveSprintStateUnlocked(filePath, state));
+}
+
+/** Mutate sprint state while holding the state file lock. Returns null if missing/corrupt. */
+export function mutateSprintState(cwd: string, mutator: (state: SprintState) => boolean): SprintState | null {
+  const filePath = sprintStatePath(cwd);
+  return withFileLockSync(filePath, () => {
+    const state = loadSprintState(cwd);
+    if (!state) return null;
+    if (mutator(state)) {
+      saveSprintStateUnlocked(filePath, state);
+    }
+    return state;
+  });
 }
 
 /** Update a single gate and save. */
 export function updateGate(cwd: string, gate: GateName, value: boolean): void {
-  const state = loadSprintState(cwd);
-  if (!state) return;
-  state.gates[gate] = value;
-  saveSprintState(cwd, state);
+  mutateSprintState(cwd, state => {
+    state.gates[gate] = value;
+    return true;
+  });
 }
 
 /** Update the current sprint lifecycle phase. */
 export function updateSprintPhase(cwd: string, phase: SprintPhase): SprintState | null {
-  const state = loadSprintState(cwd);
-  if (!state) return null;
-  state.phase = phase;
-  saveSprintState(cwd, state);
-  return state;
+  return mutateSprintState(cwd, state => {
+    state.phase = phase;
+    return true;
+  });
 }
 
 /** Check if all gates are true. */
@@ -124,8 +139,9 @@ export function createSprintState(sprint: number, phase: SprintPhase = 'planning
 
 /** Delete the sprint state file. */
 export function clearSprintState(cwd: string): void {
-  const statePath = join(cwd, SPRINT_STATE_FILE);
-  if (existsSync(statePath)) {
-    unlinkSync(statePath);
-  }
+  const statePath = sprintStatePath(cwd);
+  if (!existsSync(statePath)) return;
+  withFileLockSync(statePath, () => {
+    if (existsSync(statePath)) unlinkSync(statePath);
+  });
 }

--- a/tests/cli/atomic-write.test.ts
+++ b/tests/cli/atomic-write.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import * as ts from 'typescript';
+import { atomicWriteFileSync, createAtomicTempPath } from '../../src/cli/atomic-write.js';
+
+interface ChildResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-atomic-write-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function compileCliModules(moduleNames: string[]): string {
+  const moduleDir = join(tmpDir, 'compiled-cli');
+  mkdirSync(moduleDir, { recursive: true });
+  writeFileSync(join(moduleDir, 'package.json'), JSON.stringify({ type: 'module' }));
+
+  for (const moduleName of moduleNames) {
+    const sourcePath = join(process.cwd(), 'src', 'cli', `${moduleName}.ts`);
+    const source = readFileSync(sourcePath, 'utf8');
+    const transpiled = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ES2022,
+        target: ts.ScriptTarget.ES2022,
+      },
+    });
+    writeFileSync(join(moduleDir, `${moduleName}.js`), transpiled.outputText);
+  }
+
+  return moduleDir;
+}
+
+function runNode(script: string): Promise<ChildResult> {
+  return new Promise(resolve => {
+    const child = spawn(process.execPath, ['--input-type=module', '--eval', script], {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', chunk => { stdout += String(chunk); });
+    child.stderr.on('data', chunk => { stderr += String(chunk); });
+    child.on('close', code => resolve({ code, stdout, stderr }));
+  });
+}
+
+function expectChildrenSucceeded(results: ChildResult[]): void {
+  const failures = results.filter(result => result.code !== 0);
+  expect(failures.map(result => result.stderr).join('\n')).toBe('');
+  expect(failures).toHaveLength(0);
+}
+
+describe('atomicWriteFileSync', () => {
+  it('generates unique same-directory temp paths instead of a fixed .tmp path', () => {
+    const filePath = join(tmpDir, '.slope', 'sprint-state.json');
+    const tempPaths = new Set(Array.from({ length: 100 }, () => createAtomicTempPath(filePath)));
+
+    expect(tempPaths.size).toBe(100);
+    for (const tempPath of tempPaths) {
+      expect(dirname(tempPath)).toBe(dirname(filePath));
+      expect(tempPath).not.toBe(`${filePath}.tmp`);
+      expect(tempPath.endsWith('.tmp')).toBe(true);
+      expect(tempPath).toContain('.sprint-state.json.');
+    }
+  });
+
+  it('leaves a valid target and no fixed temp file after repeated writes', () => {
+    const filePath = join(tmpDir, '.slope', 'session-state.json');
+
+    for (let i = 0; i < 10; i++) {
+      atomicWriteFileSync(filePath, JSON.stringify({ value: i }) + '\n');
+    }
+
+    expect(JSON.parse(readFileSync(filePath, 'utf8'))).toEqual({ value: 9 });
+    expect(existsSync(`${filePath}.tmp`)).toBe(false);
+  });
+});
+
+describe('withFileLockSync', () => {
+  it('serializes concurrent read-modify-write updates across processes', async () => {
+    const moduleDir = compileCliModules(['atomic-write']);
+    const helperUrl = pathToFileURL(join(moduleDir, 'atomic-write.js')).href;
+    const filePath = join(tmpDir, 'counter.json');
+    const writers = 6;
+    const iterations = 12;
+    writeFileSync(filePath, JSON.stringify({ count: 0, writers: {} }) + '\n');
+
+    const results = await Promise.all(Array.from({ length: writers }, (_, writerIndex) => {
+      const writerId = `writer-${writerIndex}`;
+      return runNode(`
+        import { existsSync, readFileSync } from 'node:fs';
+        import { atomicWriteFileSync, withFileLockSync } from ${JSON.stringify(helperUrl)};
+
+        const filePath = ${JSON.stringify(filePath)};
+        const writerId = ${JSON.stringify(writerId)};
+        const iterations = ${iterations};
+        const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+        for (let i = 0; i < iterations; i++) {
+          await sleep(Math.floor(Math.random() * 4));
+          withFileLockSync(filePath, () => {
+            const state = existsSync(filePath)
+              ? JSON.parse(readFileSync(filePath, 'utf8'))
+              : { count: 0, writers: {} };
+            state.count += 1;
+            state.writers[writerId] = (state.writers[writerId] ?? 0) + 1;
+            atomicWriteFileSync(filePath, JSON.stringify(state, null, 2) + '\\n');
+          });
+        }
+      `);
+    }));
+
+    expectChildrenSucceeded(results);
+    const state = JSON.parse(readFileSync(filePath, 'utf8'));
+    expect(state.count).toBe(writers * iterations);
+    for (let i = 0; i < writers; i++) {
+      expect(state.writers[`writer-${i}`]).toBe(iterations);
+    }
+  }, 15000);
+
+  it('keeps representative sprint and session state writes valid under concurrent processes', async () => {
+    const moduleDir = compileCliModules(['atomic-write', 'sprint-state', 'session-state']);
+    const sprintUrl = pathToFileURL(join(moduleDir, 'sprint-state.js')).href;
+    const sessionUrl = pathToFileURL(join(moduleDir, 'session-state.js')).href;
+    const slopeDir = join(tmpDir, '.slope');
+    mkdirSync(slopeDir, { recursive: true });
+    writeFileSync(join(slopeDir, 'sprint-state.json'), JSON.stringify({
+      sprint: 102,
+      phase: 'implementing',
+      gates: {
+        tests: false,
+        code_review: false,
+        architect_review: false,
+        scorecard: false,
+        review_md: false,
+      },
+      started_at: '2026-05-21T00:00:00.000Z',
+      updated_at: '2026-05-21T00:00:00.000Z',
+    }, null, 2) + '\n');
+
+    const sprintJobs = ['tests', 'code_review', 'architect_review', 'scorecard', 'review_md']
+      .map(gate => runNode(`
+        import { updateGate } from ${JSON.stringify(sprintUrl)};
+        await new Promise(resolve => setTimeout(resolve, Math.floor(Math.random() * 8)));
+        updateGate(${JSON.stringify(tmpDir)}, ${JSON.stringify(gate)}, true);
+      `));
+
+    const sessionFields = [
+      ['briefing_session_id', 'session-briefing'],
+      ['push_prompted_session_id', 'session-push'],
+      ['claim_warned_session_id', 'session-claim'],
+      ['handoff_read_session_id', 'session-handoff'],
+      ['last_push_command', 'git push origin fix'],
+    ] as const;
+    const sessionJobs = sessionFields.map(([field, value]) => runNode(`
+      import { updateSessionState } from ${JSON.stringify(sessionUrl)};
+      await new Promise(resolve => setTimeout(resolve, Math.floor(Math.random() * 8)));
+      updateSessionState(${JSON.stringify(tmpDir)}, ${JSON.stringify(field)}, ${JSON.stringify(value)});
+    `));
+
+    const results = await Promise.all([...sprintJobs, ...sessionJobs]);
+
+    expectChildrenSucceeded(results);
+    const sprintState = JSON.parse(readFileSync(join(slopeDir, 'sprint-state.json'), 'utf8'));
+    expect(Object.values(sprintState.gates)).toEqual([true, true, true, true, true]);
+    const sessionState = JSON.parse(readFileSync(join(slopeDir, '.session-state.json'), 'utf8'));
+    for (const [field, value] of sessionFields) {
+      expect(sessionState[field]).toBe(value);
+    }
+    expect(readdirSync(slopeDir).filter(name => name.endsWith('.tmp') || name.endsWith('.lock'))).toEqual([]);
+  }, 15000);
+});

--- a/tests/cli/commands/claim-help.test.ts
+++ b/tests/cli/commands/claim-help.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const resolveStoreMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/cli/store.js', () => ({
+  resolveStore: resolveStoreMock,
+}));
+
+describe('slope claim help is read-only (GH #410)', () => {
+  let tmpDir: string;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'slope-claim-help-'));
+    resolveStoreMock.mockReset();
+    resolveStoreMock.mockImplementation(() => {
+      throw new Error('resolveStore should not run for help output');
+    });
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('prints usage for --help before resolving storage or validating --target', async () => {
+    const { claimCommand } = await import('../../../src/cli/commands/claim.js');
+
+    await claimCommand(['--help']);
+
+    const output = consoleLogSpy.mock.calls.map(call => String(call[0])).join('\n');
+    expect(output).toContain('slope claim --target=<target>');
+    expect(output).toContain('--scope=<scope>');
+    expect(output).toContain('--force');
+    expect(output).toContain('--help, -h');
+    expect(resolveStoreMock).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(existsSync(join(tmpDir, '.slope'))).toBe(false);
+  });
+
+  it('prints usage for -h before resolving storage or validating --target', async () => {
+    const { claimCommand } = await import('../../../src/cli/commands/claim.js');
+
+    await claimCommand(['-h']);
+
+    const output = consoleLogSpy.mock.calls.map(call => String(call[0])).join('\n');
+    expect(output).toContain('slope claim --target=<target>');
+    expect(resolveStoreMock).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(existsSync(join(tmpDir, '.slope'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- fix `slope claim --help` / `-h` so help prints before store resolution, target validation, or state mutation
- add shared unique-temp atomic writes plus file locks for SLOPE state files
- serialize sprint/session read-modify-write paths and add concurrent child-process regressions
- add S102 scorecard

Closes #409
Closes #410

## Validation
- `pnpm vitest run tests/cli/atomic-write.test.ts tests/cli/commands/claim-help.test.ts tests/cli/sprint-state.test.ts tests/cli/guards/sprint-completion.test.ts tests/cli/guards/workflow-gate.test.ts tests/cli/sprint-workflow.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test`
- `slope validate docs/retros/sprint-102.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--help` and `-h` command-line flag support to `slope claim` for displaying usage information and available options.

* **Improvements**
  * Improved reliability of data persistence mechanisms to prevent data loss during concurrent operations.

* **Tests**
  * Added comprehensive test coverage for new help functionality and concurrent write safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->