### PR TITLE
fix: make review help read-only

### DIFF
--- a/docs/retros/sprint-103.json
+++ b/docs/retros/sprint-103.json
@@ -1,0 +1,70 @@
+{
+  "sprint_number": 103,
+  "player": "sebastianbryers",
+  "theme": "Review Help Read-Only Routing",
+  "par": 3,
+  "slope": 0,
+  "score": 1,
+  "score_label": "eagle",
+  "date": "2026-05-21",
+  "shots": [
+    {
+      "ticket_key": "S103-1",
+      "title": "Route slope review --help before review generation (#412)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Reused the existing read-only review-state help dispatcher for top-level review --help/-h and added routing regression coverage."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Top-level dispatcher tests are needed when a subcommand module already has correct --help behavior.",
+      "outcome": "The routing predicate now covers top-level review help without importing the full CLI entrypoint in tests."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused review-state tests, compiled CLI help smokes, typecheck, build, and full Vitest suite passed.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A small follow-up that cleanly reused the existing help machinery.",
+    "advice_for_next_player": "When fixing help behavior, verify both the command handler and the top-level CLI route.",
+    "what_surprised_you": "The read-only handler was already correct; only the CLI entrypoint bypassed it.",
+    "excited_about_next": "The remaining open items can move back to guard telemetry and plugin packaging."
+  },
+  "bunker_locations": [
+    "A subcommand can have correct read-only help while the top-level CLI dispatcher still routes --help into the mutating default path."
+  ],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Validation used pnpm vitest run tests/cli/review-state.test.ts tests/cli/guards/sprint-completion.test.ts.",
+    "Additional validation used pnpm run typecheck, pnpm run build, node dist/cli/index.js review --help, node dist/cli/index.js review -h, and pnpm test."
+  ],
+  "slope_factors": [
+    "agent_dx",
+    "cli_dispatch"
+  ]
+}

--- a/src/cli/commands/review-state.ts
+++ b/src/cli/commands/review-state.ts
@@ -590,6 +590,26 @@ function amendCommand(args: string[], cwd: string): void {
 
 // --- Main Command Router ---
 
+export const REVIEW_STATE_SUBCOMMANDS = [
+  'start',
+  'round',
+  'status',
+  'reset',
+  'recommend',
+  'findings',
+  'amend',
+  'defer',
+  'deferred',
+  'resolve',
+  'run',
+];
+
+export function shouldRouteToReviewState(args: string[]): boolean {
+  const sub = args[0];
+  const help = args.includes('--help') || args.includes('-h');
+  return REVIEW_STATE_SUBCOMMANDS.includes(sub) || (help && (!sub || sub.startsWith('-')));
+}
+
 /** Per-subcommand usage text. Kept inside the dispatcher so `--help` can
  *  short-circuit before any state-mutating handler runs (#353). */
 function printReviewHelp(sub: string | undefined): void {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,7 +50,7 @@ import { mapCommand } from './commands/map.js';
 import { flowsCommand } from './commands/flows.js';
 import { workflowCommand } from './commands/workflow.js';
 import { inspirationsCommand } from './commands/inspirations.js';
-import { reviewStateCommand } from './commands/review-state.js';
+import { reviewStateCommand, shouldRouteToReviewState } from './commands/review-state.js';
 import { analyzeCommand } from './commands/analyze.js';
 import { visionCommand } from './commands/vision.js';
 import { transcriptCommand } from './commands/transcript.js';
@@ -131,8 +131,7 @@ switch (subcommand) {
     break;
   case 'review': {
     const reviewArgs = process.argv.slice(3);
-    const reviewSub = reviewArgs[0];
-    if (['start', 'round', 'status', 'reset', 'recommend', 'findings', 'amend', 'defer', 'deferred', 'resolve', 'run'].includes(reviewSub)) {
+    if (shouldRouteToReviewState(reviewArgs)) {
       reviewStateCommand(reviewArgs).catch(err => {
         console.error('Error:', err.message);
         process.exit(1);

--- a/tests/cli/review-state.test.ts
+++ b/tests/cli/review-state.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node
 import { join } from 'node:path';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { loadReviewState, saveReviewState } from '../../src/cli/commands/review-state.js';
+import { loadReviewState, saveReviewState, shouldRouteToReviewState } from '../../src/cli/commands/review-state.js';
 import type { ReviewState } from '../../src/cli/commands/review-state.js';
 
 let tmpDir: string;
@@ -81,6 +81,14 @@ describe('reviewStateCommand', () => {
   }
 
   describe('--help is read-only (#353)', () => {
+    it('routes top-level review help to the read-only review-state dispatcher (#412)', () => {
+      expect(shouldRouteToReviewState(['--help'])).toBe(true);
+      expect(shouldRouteToReviewState(['-h'])).toBe(true);
+      expect(shouldRouteToReviewState(['start', '--help'])).toBe(true);
+      expect(shouldRouteToReviewState(['docs/retros/sprint-1.json'])).toBe(false);
+      expect(shouldRouteToReviewState(['--plain'])).toBe(false);
+    });
+
     it('does NOT start a review when called as `slope review start --help`', async () => {
       const log = vi.spyOn(console, 'log').mockImplementation(() => {});
       try {


### PR DESCRIPTION
## Summary
- route `slope review --help` and `slope review -h` to the existing read-only review-state help dispatcher
- extract and test review routing so top-level help cannot fall through to review generation
- add S103 scorecard

Closes #412

## Validation
- `pnpm vitest run tests/cli/review-state.test.ts tests/cli/guards/sprint-completion.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `node dist/cli/index.js review --help`
- `node dist/cli/index.js review -h`
- `pnpm test`
- `slope validate docs/retros/sprint-103.json`
- `pnpm vitest run tests/cli/loop/analyze-scorecards.test.ts tests/cli/extract-file-refs.test.ts`
