### PR TITLE
fix: move npm publish to trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - uses: pnpm/action-setup@v4
         with:
@@ -34,7 +35,10 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
+
       - name: Publish
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/docs/guides/npm-publishing.md
+++ b/docs/guides/npm-publishing.md
@@ -1,0 +1,50 @@
+# npm Publishing
+
+SLOPE publishes `@slope-dev/slope` from the `Publish to npm` GitHub Actions workflow when a GitHub release is published.
+
+## Trusted Publishing Setup
+
+The workflow uses npm trusted publishing with GitHub Actions OIDC. The npm package settings must have a trusted publisher configured:
+
+- Provider: GitHub Actions
+- GitHub owner: `srbryers`
+- Repository: `slope`
+- Workflow filename: `publish.yml`
+- Allowed action: `npm publish`
+
+The workflow file must keep:
+
+- `permissions.id-token: write`
+- `actions/setup-node` using Node `24`
+- npm CLI `11.5.1` or newer before `npm publish`
+- no `NODE_AUTH_TOKEN`/`NPM_TOKEN` publish step fallback
+
+npm trusted publishing automatically generates provenance; do not pass a long-lived npm token unless deliberately reverting to token-based publishing.
+
+Reference: https://docs.npmjs.com/trusted-publishers/
+
+## Recovering a Failed Publish
+
+If a GitHub release exists but npm is behind:
+
+1. Confirm the npm version:
+   ```sh
+   npm view @slope-dev/slope version --registry https://registry.npmjs.org
+   ```
+2. Confirm the trusted publisher settings above on npmjs.com.
+3. Re-run the failed `Publish to npm` workflow for the release tag.
+4. Verify npm now reports the release version:
+   ```sh
+   npm view @slope-dev/slope version --registry https://registry.npmjs.org
+   ```
+
+For the `v1.55.12` incident, npm reported `1.55.11` after the GitHub release was published. After trusted publishing is configured, re-run the `v1.55.12` publish workflow and verify npm reports `1.55.12`.
+
+## Token Fallback
+
+Token-based publishing is not the default path. If trusted publishing must be disabled, replace the publish step with a scoped npm automation/granular token that has publish access to `@slope-dev/slope`, store it as `NPM_TOKEN`, and verify the token before publishing:
+
+```sh
+npm whoami --registry https://registry.npmjs.org
+npm access ls-collaborators @slope-dev/slope
+```

--- a/docs/retros/sprint-104.json
+++ b/docs/retros/sprint-104.json
@@ -1,0 +1,79 @@
+{
+  "sprint_number": 104,
+  "player": "sebastianbryers",
+  "theme": "npm Trusted Publishing Repair",
+  "par": 3,
+  "slope": 1,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-05-21",
+  "shots": [
+    {
+      "ticket_key": "S104-1",
+      "title": "Move publish workflow to npm trusted publishing (#406)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The repo workflow can be corrected, but npm package trusted-publisher settings must be configured on npmjs.com before the failed release can be rerun."
+        }
+      ],
+      "notes": "Updated the publish workflow to Node 24, npm 11.5.1+, OIDC trusted publishing without NPM_TOKEN, and documented npm-side maintenance steps."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "npm trusted publishing is split between repo workflow configuration and npm package settings.",
+      "outcome": "The repo now uses OIDC-compatible publishing, but the npm trusted publisher must be configured for package scope authorization."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Validation used YAML parsing, git diff checks, npm registry version check, and workflow review against npm trusted publishing requirements.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A release-infra fix with one external dependency that cannot be closed from the repository alone.",
+    "advice_for_next_player": "Before rerunning a failed publish, verify npm trusted publisher settings and then confirm npm view reports the target version.",
+    "what_surprised_you": "The workflow already had id-token permission, but still used a stale token-based publish path.",
+    "excited_about_next": "Once npm settings are configured, v1.55.12 can be rerun and future releases should not depend on long-lived tokens."
+  },
+  "bunker_locations": [
+    "GitHub workflow OIDC is necessary but insufficient; npm package settings must authorize the workflow filename and repository.",
+    "Node 22 in Actions may carry npm 10, below npm's trusted-publishing CLI requirement."
+  ],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Validation used ruby -e \"require 'yaml'; YAML.load_file('.github/workflows/publish.yml')\".",
+    "Validation used git diff --check and npm view @slope-dev/slope version --registry https://registry.npmjs.org.",
+    "npm currently reports @slope-dev/slope latest as 1.55.11; v1.55.12 still needs the publish workflow rerun after npm trusted publisher setup."
+  ],
+  "slope_factors": [
+    "release_infra",
+    "npm_publish",
+    "trusted_publishing"
+  ]
+}


### PR DESCRIPTION
## Summary
- update the npm publish workflow to Node 24 and npm 11.5.1+
- remove the token-based publish fallback and rely on GitHub Actions OIDC trusted publishing
- document npm trusted publisher settings and recovery steps for the v1.55.12 failed publish
- add S104 scorecard

Refs #406

## Important follow-up
This PR repairs the repo-side workflow, but #406 should stay open until npmjs.com has the trusted publisher configured for `srbryers/slope` + `publish.yml`, the failed v1.55.12 workflow is rerun, and `npm view @slope-dev/slope version` reports `1.55.12`.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml')"`
- `git diff --check`
- `npm view @slope-dev/slope version --registry https://registry.npmjs.org` currently reports `1.55.11`
- `slope validate docs/retros/sprint-104.json`
