### PR TITLE
feat: record guard metric reasons

### DIFF
--- a/docs/retros/sprint-105-review.md
+++ b/docs/retros/sprint-105-review.md
@@ -1,0 +1,52 @@
+## Sprint 105 Review: Guard Metric Silent Reasons
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 1 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S105-1 | Short Iron | Green | - | Added metric-only guard reason codes, reason aggregation in guard analytics, CLI reason counts, and focused tests for JSONL output shape plus guard-specific silent reasons. |
+
+### Hazards Discovered
+
+Known hazards for future sprints:
+
+- Reason-only GuardResult fields must remain hook-internal; adapters and batched output should keep ignoring results without context, decisions, block reasons, or suggestions.
+- review recommend can undercount ad hoc GitHub issue work when the active sprint has no roadmap or plan ticket entry.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Reason-only guard results need to remain invisible to hook output while still being captured in metrics. | Adapters and batched guard output still key off context, decisions, block reasons, and suggestions; metricReason is only consumed by recordGuardExecution. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Focused guard/analytics tests, typecheck, build, guard metrics smoke, and full Vitest suite passed. |
+
+### Course Management Notes
+
+- Validation used pnpm vitest run tests/core/analytics.test.ts tests/cli/commands/guard.test.ts tests/cli/guards.test.ts tests/cli/guards/pr-review.test.ts tests/cli/guards/pr-review-recommend.test.ts.
+- Additional validation used pnpm run typecheck, pnpm run build, node dist/cli/index.js guard metrics, and pnpm test.
+- slope review recommend reported only optional code review for S105; manual code and architecture review found no issues.
+
+### 19th Hole
+
+- **How did it feel?** A compact telemetry change with clear acceptance criteria and useful immediate feedback from the live guard metrics file.
+- **Advice for next player?** When adding guard result metadata, verify both direct guard tests and real guardCommand JSONL output so internal fields do not leak into hook responses.
+- **What surprised you?** The live metrics immediately showed old adhoc suppressions and a new irrelevant-command reason, which confirms the CLI surface makes underutilization easier to diagnose.
+- **Excited about next?** Use the new reason counts to decide whether hazard and other guards are redundant, underfed, or missing payload data.

--- a/docs/retros/sprint-105.json
+++ b/docs/retros/sprint-105.json
@@ -1,0 +1,73 @@
+{
+  "sprint_number": 105,
+  "player": "sebastianbryers",
+  "theme": "Guard Metric Silent Reasons",
+  "par": 3,
+  "slope": 1,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-05-21",
+  "shots": [
+    {
+      "ticket_key": "S105-1",
+      "title": "Record actionable guard metric reasons (#398)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Added metric-only guard reason codes, reason aggregation in guard analytics, CLI reason counts, and focused tests for JSONL output shape plus guard-specific silent reasons."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Reason-only guard results need to remain invisible to hook output while still being captured in metrics.",
+      "outcome": "Adapters and batched guard output still key off context, decisions, block reasons, and suggestions; metricReason is only consumed by recordGuardExecution."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused guard/analytics tests, typecheck, build, guard metrics smoke, and full Vitest suite passed.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A compact telemetry change with clear acceptance criteria and useful immediate feedback from the live guard metrics file.",
+    "advice_for_next_player": "When adding guard result metadata, verify both direct guard tests and real guardCommand JSONL output so internal fields do not leak into hook responses.",
+    "what_surprised_you": "The live metrics immediately showed old adhoc suppressions and a new irrelevant-command reason, which confirms the CLI surface makes underutilization easier to diagnose.",
+    "excited_about_next": "Use the new reason counts to decide whether hazard and other guards are redundant, underfed, or missing payload data."
+  },
+  "bunker_locations": [
+    "Reason-only GuardResult fields must remain hook-internal; adapters and batched output should keep ignoring results without context, decisions, block reasons, or suggestions.",
+    "review recommend can undercount ad hoc GitHub issue work when the active sprint has no roadmap or plan ticket entry."
+  ],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Validation used pnpm vitest run tests/core/analytics.test.ts tests/cli/commands/guard.test.ts tests/cli/guards.test.ts tests/cli/guards/pr-review.test.ts tests/cli/guards/pr-review-recommend.test.ts.",
+    "Additional validation used pnpm run typecheck, pnpm run build, node dist/cli/index.js guard metrics, and pnpm test.",
+    "slope review recommend reported only optional code review for S105; manual code and architecture review found no issues."
+  ],
+  "slope_factors": [
+    "agent_dx",
+    "guard_metrics",
+    "diagnostics"
+  ]
+}

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -467,6 +467,18 @@ export async function guardManageCommand(args: string[]): Promise<void> {
       for (const m of report.by_guard) {
         console.log(`  ${m.guard.padEnd(22)} ${String(m.total).padStart(5)}  ${String(m.allow).padStart(5)}  ${String(m.deny).padStart(5)}  ${String(m.context).padStart(7)}  ${String(m.silent).padStart(6)}  ${String(m.block_rate.toFixed(0)).padStart(5)}%`);
       }
+      const reasonRows = report.by_guard.flatMap(m =>
+        Object.entries(m.reason_counts ?? {}).map(([reason, count]) => ({ guard: m.guard, reason, count })),
+      );
+      if (reasonRows.length > 0) {
+        console.log('');
+        console.log('  Reasons (silent/context/suppressed):');
+        console.log('  Guard                 Reason                Count');
+        console.log('  ────────────────────  ────────────────────  ─────');
+        for (const row of reasonRows) {
+          console.log(`  ${row.guard.padEnd(22)} ${row.reason.padEnd(20)}  ${String(row.count).padStart(5)}`);
+        }
+      }
       console.log('');
       break;
     }
@@ -740,9 +752,14 @@ function recordGuardExecution(cwd: string, guardName: string, input: HookInput, 
       event: input.hook_event_name,
       tool: input.tool_name ?? '',
       decision,
+      ...(shouldRecordMetricReason(decision, result.metricReason) ? { reason: result.metricReason } : {}),
     });
     appendFileSync(metricsPath, line + '\n');
   } catch { /* never block guard execution */ }
+}
+
+function shouldRecordMetricReason(decision: string, reason: string | undefined): boolean {
+  return Boolean(reason && (decision === 'silent' || decision === 'context'));
 }
 
 function recordGuardSuppression(cwd: string, guardName: string, input: HookInput, reason: string): void {

--- a/src/cli/guards/hazard.ts
+++ b/src/cli/guards/hazard.ts
@@ -60,7 +60,7 @@ function pruneState(state: HazardState, currentSprint: number): HazardState {
  */
 export async function hazardGuard(input: HookInput, cwd: string): Promise<GuardResult> {
   const areas = resolveTouchedAreas(input, cwd);
-  if (areas.length === 0) return {};
+  if (areas.length === 0) return { metricReason: 'no-file-path' };
 
   const config = loadConfig(cwd);
   const currentSprint = config.currentSprint ?? 0;
@@ -109,12 +109,12 @@ export async function hazardGuard(input: HookInput, cwd: string): Promise<GuardR
 
     // Session dedup: if this exact context was already injected, return compressed reference
     const dedup = dedupGuardContext(cwd, input.session_id, 'hazard', fullContext);
-    if (dedup) return { context: dedup };
+    if (dedup) return { context: dedup, metricReason: 'deduped' };
 
-    return { context: fullContext };
+    return { context: fullContext, metricReason: 'matched' };
   }
 
-  return {};
+  return { metricReason: issues ? 'no-match' : 'state-unavailable' };
 }
 
 function resolveTouchedAreas(input: HookInput, cwd: string): string[] {

--- a/src/cli/guards/pr-review.ts
+++ b/src/cli/guards/pr-review.ts
@@ -17,7 +17,7 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
   const command = (input.tool_input?.command as string) ?? '';
   const response = (input.tool_response?.stdout as string) ?? (input.tool_response?.result as string) ?? '';
 
-  if (!command.includes('gh pr create')) return {};
+  if (!command.includes('gh pr create')) return { metricReason: 'irrelevant-command' };
 
   // Substring fast-path used to gate the regex match, but `includes()` over
   // arbitrary text can never tightly bound a URL — CodeQL flags it as
@@ -26,7 +26,7 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
   // a path containing `/pull/<digits>`. If it matches, treat it as a real
   // PR URL; if not, the guard skips.
   const urlMatch = response.match(/(https:\/\/github\.com\/[^\s]+\/pull\/(\d+))/);
-  if (!urlMatch) return {};
+  if (!urlMatch) return { metricReason: 'no-match' };
   const prUrl = urlMatch[1];
   const prNumber = urlMatch[2];
 
@@ -36,6 +36,7 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
   const recLine = formatRecommendations(recs);
 
   return {
+    metricReason: 'matched',
     context: [
       `SLOPE PR Review: A pull request was just created (${prUrl}).`,
       ...(recLine ? [`Recommended reviews based on diff: ${recLine}.`] : []),

--- a/src/cli/guards/scope-drift.ts
+++ b/src/cli/guards/scope-drift.ts
@@ -125,7 +125,7 @@ export async function scopeDriftGuard(input: HookInput, cwd: string): Promise<Gu
       const dedup = dedupGuardContext(cwd, input.session_id, 'scope-drift', cachedMsg);
       return { context: dedup ?? cachedMsg };
     }
-    return {}; // No cached state or too stale — fail open
+    return { metricReason: 'state-unavailable' }; // No cached state or too stale — fail open
   }
 }
 

--- a/src/core/analytics.ts
+++ b/src/core/analytics.ts
@@ -130,6 +130,7 @@ export interface GuardMetrics {
   context: number;
   silent: number;
   block_rate: number;      // (deny / total) * 100
+  reason_counts?: Record<string, number>; // reason counts for silent/context/suppressed outcomes
 }
 
 export interface GuardEffectivenessReport {
@@ -140,7 +141,7 @@ export interface GuardEffectivenessReport {
 }
 
 /** Possible decision values in guard metrics JSONL (superset of GuardResult.decision) */
-export type GuardDecision = 'allow' | 'deny' | 'ask' | 'context' | 'silent';
+export type GuardDecision = 'allow' | 'deny' | 'ask' | 'context' | 'silent' | 'suppressed';
 
 interface GuardMetricLine {
   ts: string;
@@ -148,6 +149,16 @@ interface GuardMetricLine {
   event: string;
   tool?: string;
   decision: string;
+  reason?: unknown;
+}
+
+interface GuardMetricCounts {
+  allow: number;
+  deny: number;
+  ask: number;
+  context: number;
+  silent: number;
+  reasonCounts: Map<string, number>;
 }
 
 /**
@@ -156,7 +167,7 @@ interface GuardMetricLine {
  * Malformed lines are skipped gracefully.
  */
 export function computeGuardMetrics(lines: string[]): GuardEffectivenessReport {
-  const byGuard = new Map<string, { allow: number; deny: number; ask: number; context: number; silent: number }>();
+  const byGuard = new Map<string, GuardMetricCounts>();
 
   for (const line of lines) {
     const trimmed = line.trim();
@@ -172,7 +183,7 @@ export function computeGuardMetrics(lines: string[]): GuardEffectivenessReport {
     if (!parsed.guard || typeof parsed.guard !== 'string') continue;
 
     if (!byGuard.has(parsed.guard)) {
-      byGuard.set(parsed.guard, { allow: 0, deny: 0, ask: 0, context: 0, silent: 0 });
+      byGuard.set(parsed.guard, { allow: 0, deny: 0, ask: 0, context: 0, silent: 0, reasonCounts: new Map() });
     }
     const entry = byGuard.get(parsed.guard)!;
 
@@ -180,8 +191,19 @@ export function computeGuardMetrics(lines: string[]): GuardEffectivenessReport {
       case 'allow': entry.allow++; break;
       case 'deny': entry.deny++; break;
       case 'ask': entry.ask++; break;
-      case 'context': entry.context++; break;
-      default: entry.silent++; break;
+      case 'context':
+        entry.context++;
+        recordMetricReason(entry, parsed.reason);
+        break;
+      case 'silent':
+      case 'suppressed':
+        entry.silent++;
+        recordMetricReason(entry, parsed.reason);
+        break;
+      default:
+        entry.silent++;
+        recordMetricReason(entry, parsed.reason);
+        break;
     }
   }
 
@@ -199,8 +221,13 @@ export function computeGuardMetrics(lines: string[]): GuardEffectivenessReport {
     metrics.push({
       guard,
       total,
-      ...counts,
+      allow: counts.allow,
+      deny: counts.deny,
+      ask: counts.ask,
+      context: counts.context,
+      silent: counts.silent,
       block_rate: blockRate,
+      reason_counts: toReasonCountsObject(counts.reasonCounts),
     });
 
     totalExecutions += total;
@@ -226,6 +253,19 @@ export function computeGuardMetrics(lines: string[]): GuardEffectivenessReport {
     most_active: mostActive,
     most_blocking: mostBlocking,
   };
+}
+
+function recordMetricReason(entry: GuardMetricCounts, reason: unknown): void {
+  if (typeof reason !== 'string') return;
+  const normalized = reason.trim();
+  if (!normalized) return;
+  entry.reasonCounts.set(normalized, (entry.reasonCounts.get(normalized) ?? 0) + 1);
+}
+
+function toReasonCountsObject(reasonCounts: Map<string, number>): Record<string, number> {
+  return Object.fromEntries(
+    [...reasonCounts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
+  );
 }
 
 // --- Convergence Detection ---

--- a/src/core/guard.ts
+++ b/src/core/guard.ts
@@ -64,6 +64,16 @@ export interface Suggestion {
   priority?: 'critical' | 'high' | 'normal';
 }
 
+/** Machine-readable reason code recorded in guard metrics. */
+export type GuardMetricReason =
+  | 'no-file-path'
+  | 'no-match'
+  | 'deduped'
+  | 'irrelevant-command'
+  | 'state-unavailable'
+  | 'adhoc-session'
+  | (string & {});
+
 /** A guard's response — what guidance to inject */
 export interface GuardResult {
   /** Text injected into the agent's context */
@@ -74,6 +84,8 @@ export interface GuardResult {
   blockReason?: string;
   /** Structured suggestion — adapter formats for platform */
   suggestion?: Suggestion;
+  /** Optional machine-readable reason for metrics; never emitted to hook output */
+  metricReason?: GuardMetricReason;
 }
 
 /** Known guard names */

--- a/tests/cli/commands/guard.test.ts
+++ b/tests/cli/commands/guard.test.ts
@@ -167,6 +167,24 @@ describe('guardCommand dispatcher path', () => {
     expect(metrics).toContain('"reason":"adhoc-session"');
   });
 
+  it('records guard-specific silent reason metrics', async () => {
+    const output = await runGuardCommandWithInput(
+      ['hazard'],
+      makeHookInput(cwd, { tool_input: {} }),
+    );
+
+    expect(output).toBe('');
+    const metrics = readFileSync(join(cwd, '.slope', 'guard-metrics.jsonl'), 'utf8')
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line));
+    expect(metrics.at(-1)).toMatchObject({
+      guard: 'hazard',
+      decision: 'silent',
+      reason: 'no-file-path',
+    });
+  });
+
   it('keeps claim-required effective when batched with suppressed write guards', async () => {
     const output = await runGuardCommandWithInput(
       ['__batch', 'workflow-step-gate', 'claim-required'],
@@ -182,6 +200,21 @@ describe('guardCommand dispatcher path', () => {
     expect(metrics).toContain('"decision":"suppressed"');
     expect(metrics).toContain('"guard":"claim-required"');
     expect(metrics).toContain('"decision":"ask"');
+  });
+
+  it('prints metric reason counts in the metrics command', async () => {
+    writeFileSync(join(cwd, '.slope', 'guard-metrics.jsonl'), [
+      JSON.stringify({ ts: '2026-05-21T00:00:00.000Z', guard: 'hazard', event: 'PreToolUse', tool: 'apply_patch', decision: 'silent', reason: 'no-file-path' }),
+      JSON.stringify({ ts: '2026-05-21T00:00:01.000Z', guard: 'hazard', event: 'PreToolUse', tool: 'apply_patch', decision: 'context', reason: 'deduped' }),
+    ].join('\n') + '\n');
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await guardManageCommand(['metrics']);
+    const output = logSpy.mock.calls.map(c => String(c[0])).join('\n');
+
+    expect(output).toContain('Reasons (silent/context/suppressed)');
+    expect(output).toContain('no-file-path');
+    expect(output).toContain('deduped');
   });
 });
 

--- a/tests/cli/guards.test.ts
+++ b/tests/cli/guards.test.ts
@@ -137,7 +137,7 @@ describe('exploreGuard', () => {
 describe('hazardGuard', () => {
   it('returns empty when no file path in input', async () => {
     const result = await hazardGuard(makeInput({ tool_input: {} }), tmpDir);
-    expect(result).toEqual({});
+    expect(result).toEqual({ metricReason: 'no-file-path' });
   });
 
   it('returns empty when no common issues file', async () => {
@@ -145,7 +145,7 @@ describe('hazardGuard', () => {
       makeInput({ tool_input: { file_path: join(tmpDir, 'src/foo.ts') } }),
       tmpDir,
     );
-    expect(result).toEqual({});
+    expect(result).toEqual({ metricReason: 'state-unavailable' });
   });
 
   it('warns when editing in area with known issues', async () => {
@@ -219,7 +219,7 @@ describe('hazardGuard', () => {
       makeInput({ tool_input: { file_path: join(tmpDir, 'packages/cli/src/index.ts') } }),
       tmpDir,
     );
-    expect(result).toEqual({});
+    expect(result).toEqual({ metricReason: 'no-match' });
   });
 
   it('does not include permissionDecision (non-blocking)', async () => {
@@ -244,6 +244,31 @@ describe('hazardGuard', () => {
     );
     expect(result.decision).toBeUndefined();
     expect(result.blockReason).toBeUndefined();
+  });
+
+  it('tags repeated hazard context as deduped for metrics', async () => {
+    mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+    writeFileSync(join(tmpDir, '.slope/common-issues.json'), JSON.stringify({
+      recurring_patterns: [
+        {
+          id: 1,
+          title: 'Core issue',
+          category: 'testing',
+          sprints_hit: [8],
+          gotcha_refs: [],
+          description: 'Affects core package testing',
+          prevention: 'Run tests after editing core',
+        },
+      ],
+    }));
+
+    const input = makeInput({ tool_input: { file_path: join(tmpDir, 'packages/core/src/foo.ts') } });
+    const first = await hazardGuard(input, tmpDir);
+    const second = await hazardGuard(input, tmpDir);
+
+    expect(first.metricReason).toBe('matched');
+    expect(second.context).toContain('same as prior warning');
+    expect(second.metricReason).toBe('deduped');
   });
 
   it('writes warnings to disk state for compaction survival', async () => {
@@ -317,7 +342,7 @@ describe('hazardGuard', () => {
       makeInput({ tool_input: { file_path: join(tmpDir, 'packages/core/src/foo.ts') } }),
       tmpDir,
     );
-    expect(result).toEqual({});
+    expect(result).toEqual({ metricReason: 'state-unavailable' });
   });
 
   it('keeps entries from old sprint if still fresh (<7 days)', async () => {
@@ -359,7 +384,7 @@ describe('hazardGuard', () => {
       makeInput({ tool_input: { file_path: join(tmpDir, 'packages/core/src/foo.ts') } }),
       tmpDir,
     );
-    expect(result).toEqual({});
+    expect(result).toEqual({ metricReason: 'state-unavailable' });
   });
 });
 
@@ -485,6 +510,21 @@ describe('scopeDriftGuard', () => {
       tmpDir,
     );
     expect(result).toEqual({});
+  });
+
+  it('tags store failures without cached drift as state-unavailable', async () => {
+    writeSprintState(10);
+
+    const storeModule = await import('../../src/cli/store.js');
+    const spy = vi.spyOn(storeModule, 'resolveStore').mockRejectedValueOnce(new Error('store unavailable'));
+
+    const result = await scopeDriftGuard(
+      makeInput({ tool_input: { file_path: join(tmpDir, 'packages/other/src/bar.ts') } }),
+      tmpDir,
+    );
+
+    expect(result).toEqual({ metricReason: 'state-unavailable' });
+    spy.mockRestore();
   });
 
   it('clears disk state on sprint change', async () => {

--- a/tests/cli/guards/pr-review-recommend.test.ts
+++ b/tests/cli/guards/pr-review-recommend.test.ts
@@ -47,12 +47,12 @@ describe('prReviewGuard recommendations (GH #302)', () => {
       { ...makeInput(''), tool_input: { command: 'gh pr view 1' } },
       cwd,
     );
-    expect(result).toEqual({});
+    expect(result).toEqual({ metricReason: 'irrelevant-command' });
   });
 
   it('does not fire when output is missing PR URL', async () => {
     const result = await prReviewGuard(makeInput('error: failed'), cwd);
-    expect(result).toEqual({});
+    expect(result).toEqual({ metricReason: 'no-match' });
   });
 
   it('emits context with PR URL extracted from output', async () => {

--- a/tests/core/analytics.test.ts
+++ b/tests/core/analytics.test.ts
@@ -304,6 +304,28 @@ describe('computeGuardMetrics', () => {
     expect(result.by_guard[0].silent).toBe(1);
   });
 
+  it('aggregates reason counts for silent, context, and suppressed outcomes', () => {
+    const lines = [
+      JSON.stringify({ ts: '2025-01-01', guard: 'hazard', event: 'PreToolUse', tool: 'Edit', decision: 'silent', reason: 'no-file-path' }),
+      JSON.stringify({ ts: '2025-01-01', guard: 'hazard', event: 'PreToolUse', tool: 'Edit', decision: 'silent', reason: 'no-match' }),
+      JSON.stringify({ ts: '2025-01-01', guard: 'hazard', event: 'PreToolUse', tool: 'Edit', decision: 'context', reason: 'deduped' }),
+      JSON.stringify({ ts: '2025-01-01', guard: 'workflow-step-gate', event: 'PreToolUse', tool: 'Edit', decision: 'suppressed', reason: 'adhoc-session' }),
+    ];
+    const result = computeGuardMetrics(lines);
+    const hazard = result.by_guard.find(g => g.guard === 'hazard');
+    const workflow = result.by_guard.find(g => g.guard === 'workflow-step-gate');
+
+    expect(hazard?.silent).toBe(2);
+    expect(hazard?.context).toBe(1);
+    expect(hazard?.reason_counts).toEqual({
+      'deduped': 1,
+      'no-file-path': 1,
+      'no-match': 1,
+    });
+    expect(workflow?.silent).toBe(1);
+    expect(workflow?.reason_counts).toEqual({ 'adhoc-session': 1 });
+  });
+
   it('computes block_rate correctly', () => {
     const lines = [
       JSON.stringify({ ts: '2025-01-01', guard: 'g', event: 'PreToolUse', tool: 'X', decision: 'deny' }),


### PR DESCRIPTION
## Summary
- add metric-only guard reason codes and record them in guard metrics JSONL for silent/context outcomes
- aggregate reason_counts in guard analytics and show them in slope guard metrics
- tag representative hazard, pr-review, scope-drift, and adhoc suppression paths with actionable reasons
- add S105 scorecard and review artifacts

Closes #398

## Validation
- pnpm vitest run tests/core/analytics.test.ts tests/cli/commands/guard.test.ts tests/cli/guards.test.ts tests/cli/guards/pr-review.test.ts tests/cli/guards/pr-review-recommend.test.ts
- pnpm run typecheck
- pnpm run build
- node dist/cli/index.js guard metrics
- pnpm test
- slope validate docs/retros/sprint-105.json