### PR TITLE
feat: feed hazard guard from scorecards

### DIFF
--- a/docs/retros/sprint-106-review.md
+++ b/docs/retros/sprint-106-review.md
@@ -1,0 +1,52 @@
+## Sprint 106 Review: Scorecard Hazard Fallback
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 1 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S106-1 | Short Iron | Green | - | Added a scorecard-derived fallback for hazard guard warnings when common issues do not match, preserved common-issues precedence, documented source ordering, and covered shot hazards plus bunker locations in tests. |
+
+### Hazards Discovered
+
+Known hazards for future sprints:
+
+- Hazard guard fallback should keep common-issues.json as the first source and only read recent scorecards when no common issue matches the touched area.
+- Scorecard-derived hazard matching should avoid generic path segments such as src, test, tests, package, and packages to prevent broad false positives.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Scorecard fallback matching needs to be narrower than common-issue matching so generic path segments do not create noisy guard warnings. | The fallback ignores generic and very short path segments unless the full touched area appears in the scorecard text. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Focused guard and briefing tests, typecheck, build, guard docs smoke test, and full Vitest suite passed. |
+
+### Course Management Notes
+
+- Validation used pnpm vitest run tests/cli/guards.test.ts tests/cli/commands/guard.test.ts tests/core/briefing.test.ts.
+- Additional validation used pnpm run typecheck, pnpm run build, node dist/cli/index.js guard docs hazard, and pnpm test.
+- The fallback uses guidance.hazardRecency to limit recent scorecards and dedupes repeated scorecard warning text after sorting newest first.
+
+### 19th Hole
+
+- **How did it feel?** A targeted guard-feeding change with clear source precedence and enough tests to protect against both silence and warning spam.
+- **Advice for next player?** When expanding guard inputs, keep the hook output compact and document precedence so richer context does not become surprising behavior.
+- **What surprised you?** The existing hazard docs already claimed recent scorecard hazards were involved, so the implementation needed to make that contract true rather than introduce a new surface.
+- **Excited about next?** Use this richer guard signal to evaluate whether remaining underused guards need better payload coverage or should be retired.

--- a/docs/retros/sprint-106.json
+++ b/docs/retros/sprint-106.json
@@ -1,0 +1,73 @@
+{
+  "sprint_number": 106,
+  "player": "sebastianbryers",
+  "theme": "Scorecard Hazard Fallback",
+  "par": 4,
+  "slope": 1,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-21",
+  "shots": [
+    {
+      "ticket_key": "S106-1",
+      "title": "Feed hazard guard from scorecard hazard index (#397)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Added a scorecard-derived fallback for hazard guard warnings when common issues do not match, preserved common-issues precedence, documented source ordering, and covered shot hazards plus bunker locations in tests."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Scorecard fallback matching needs to be narrower than common-issue matching so generic path segments do not create noisy guard warnings.",
+      "outcome": "The fallback ignores generic and very short path segments unless the full touched area appears in the scorecard text."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused guard and briefing tests, typecheck, build, guard docs smoke test, and full Vitest suite passed.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A targeted guard-feeding change with clear source precedence and enough tests to protect against both silence and warning spam.",
+    "advice_for_next_player": "When expanding guard inputs, keep the hook output compact and document precedence so richer context does not become surprising behavior.",
+    "what_surprised_you": "The existing hazard docs already claimed recent scorecard hazards were involved, so the implementation needed to make that contract true rather than introduce a new surface.",
+    "excited_about_next": "Use this richer guard signal to evaluate whether remaining underused guards need better payload coverage or should be retired."
+  },
+  "bunker_locations": [
+    "Hazard guard fallback should keep common-issues.json as the first source and only read recent scorecards when no common issue matches the touched area.",
+    "Scorecard-derived hazard matching should avoid generic path segments such as src, test, tests, package, and packages to prevent broad false positives."
+  ],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Validation used pnpm vitest run tests/cli/guards.test.ts tests/cli/commands/guard.test.ts tests/core/briefing.test.ts.",
+    "Additional validation used pnpm run typecheck, pnpm run build, node dist/cli/index.js guard docs hazard, and pnpm test.",
+    "The fallback uses guidance.hazardRecency to limit recent scorecards and dedupes repeated scorecard warning text after sorting newest first."
+  ],
+  "slope_factors": [
+    "agent_dx",
+    "guard_signals",
+    "hazard_detection"
+  ]
+}

--- a/src/cli/guards/docs.ts
+++ b/src/cli/guards/docs.ts
@@ -24,8 +24,8 @@ export const GUARD_DOCS: Record<string, GuardDoc> = {
   hazard: {
     purpose: 'Warns about known issues and recurring patterns in file areas being edited. Prevents the agent from repeating past mistakes.',
     triggers: 'PreToolUse on Edit, Write. Fires when the agent is about to modify a file.',
-    behavior: 'Advisory — injects context with relevant hazards from common-issues.json and recent scorecard hazards for the file area being edited.',
-    configuration: 'guidance.hazardRecency (default: 5) controls how many sprints back to look for hazards. Disable: add "hazard" to guidance.disabled.',
+    behavior: 'Advisory — injects context with relevant hazards for the file area being edited. Source precedence is common-issues.json first, recent scorecard shot hazards and bunker locations second, then compact cached guard state.',
+    configuration: 'guidance.hazardRecency (default: 5) controls how many recent scorecards the fallback source reads. Disable: add "hazard" to guidance.disabled.',
     level: 'full',
   },
   'commit-nudge': {

--- a/src/cli/guards/hazard.ts
+++ b/src/cli/guards/hazard.ts
@@ -2,7 +2,8 @@ import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { loadConfig } from '../config.js';
-import type { CommonIssuesFile } from '../../core/index.js';
+import { loadScorecards } from '../../core/index.js';
+import type { CommonIssuesFile, GolfScorecard } from '../../core/index.js';
 import { dedupGuardContext } from '../session-state.js';
 import { normalizeTouchedPath, resolveTouchedPaths } from './hook-input.js';
 
@@ -22,6 +23,8 @@ interface HazardState {
 const GUARD_STATE_DIR = '.slope/guard-state';
 const STATE_FILE = 'hazard.json';
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const DEFAULT_HAZARD_RECENCY = 5;
+const GENERIC_AREA_SEGMENTS = new Set(['src', 'test', 'tests', 'package', 'packages']);
 
 function loadHazardState(cwd: string): HazardState {
   try {
@@ -77,9 +80,28 @@ export async function hazardGuard(input: HookInput, cwd: string): Promise<GuardR
     }
   } catch { /* skip — common issues are optional */ }
 
+  const hazardRecency = config.guidance?.hazardRecency ?? DEFAULT_HAZARD_RECENCY;
+  let recentScorecards: GolfScorecard[] | null = null;
+  let scorecardSourceAvailable = false;
+  const loadRecentScorecards = (): GolfScorecard[] => {
+    if (recentScorecards) return recentScorecards;
+    try {
+      const scorecards = loadScorecards(config, cwd);
+      recentScorecards = hazardRecency > 0 ? scorecards.slice(-hazardRecency) : scorecards;
+      scorecardSourceAvailable = recentScorecards.length > 0;
+    } catch {
+      recentScorecards = [];
+      scorecardSourceAvailable = false;
+    }
+    return recentScorecards;
+  };
+
   for (const area of areas) {
     // Compute fresh warnings from common issues (ranked by recency)
-    const freshTexts = computeFreshWarnings(area, issues);
+    const commonWarnings = computeFreshWarnings(area, issues);
+    const freshTexts = commonWarnings.length > 0
+      ? commonWarnings
+      : computeScorecardWarnings(area, loadRecentScorecards());
 
     // Merge fresh warnings with any disk-cached warnings for this area
     const cached = state.entries.find(e => e.area === area);
@@ -114,7 +136,7 @@ export async function hazardGuard(input: HookInput, cwd: string): Promise<GuardR
     return { context: fullContext, metricReason: 'matched' };
   }
 
-  return { metricReason: issues ? 'no-match' : 'state-unavailable' };
+  return { metricReason: issues || scorecardSourceAvailable ? 'no-match' : 'state-unavailable' };
 }
 
 function resolveTouchedAreas(input: HookInput, cwd: string): string[] {
@@ -134,13 +156,12 @@ function resolveTouchedAreas(input: HookInput, cwd: string): string[] {
 function computeFreshWarnings(area: string, issues: CommonIssuesFile | null): string[] {
   if (!issues) return [];
 
-  const areaLower = area.toLowerCase();
   const freshWarnings: Array<{ lastSprint: number; text: string }> = [];
 
   for (const pattern of issues.recurring_patterns) {
     // Check if pattern is relevant to this area
     const text = `${pattern.title} ${pattern.description} ${pattern.prevention}`.toLowerCase();
-    if (text.includes(areaLower) || areaLower.split('/').some(seg => text.includes(seg))) {
+    if (areaMatchesText(area, text, { includeGenericSegments: true })) {
       const lastSprint = Math.max(...pattern.sprints_hit);
       freshWarnings.push({ lastSprint, text: `[${pattern.category}] ${pattern.title} (S${lastSprint}) — ${pattern.prevention.slice(0, 80)}` });
     }
@@ -149,6 +170,68 @@ function computeFreshWarnings(area: string, issues: CommonIssuesFile | null): st
   // Sort by recency (most recent first)
   freshWarnings.sort((a, b) => b.lastSprint - a.lastSprint);
   return freshWarnings.map(w => w.text);
+}
+
+function computeScorecardWarnings(area: string, scorecards: GolfScorecard[]): string[] {
+  const warnings: Array<{ sprint: number; text: string }> = [];
+
+  for (const sc of scorecards) {
+    const sprint = sc.sprint_number ?? (sc as unknown as { sprint?: number }).sprint ?? 0;
+
+    for (const shot of sc.shots ?? []) {
+      for (const hazard of shot.hazards ?? []) {
+        const description = hazard.description ?? '';
+        const haystack = `${shot.ticket_key} ${shot.title} ${hazard.type} ${description}`.toLowerCase();
+        if (!areaMatchesText(area, haystack)) continue;
+        warnings.push({
+          sprint,
+          text: `[scorecard:${hazard.type}] ${description || shot.title} (S${sprint})`,
+        });
+      }
+    }
+
+    for (const location of sc.bunker_locations ?? []) {
+      const locationText = typeof location === 'string'
+        ? location
+        : String((location as Record<string, unknown>).area ?? '');
+      if (!locationText || !areaMatchesText(area, locationText.toLowerCase())) continue;
+      warnings.push({
+        sprint,
+        text: `[scorecard:bunker] ${locationText} (S${sprint})`,
+      });
+    }
+  }
+
+  warnings.sort((a, b) => b.sprint - a.sprint);
+
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const warning of warnings) {
+    const key = warning.text.replace(/ \(S\d+\)$/, '');
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(warning.text);
+  }
+
+  return unique;
+}
+
+function areaMatchesText(
+  area: string,
+  lowerText: string,
+  opts: { includeGenericSegments?: boolean } = {},
+): boolean {
+  const areaLower = area.toLowerCase();
+  if (lowerText.includes(areaLower)) return true;
+
+  const segments = areaLower
+    .split('/')
+    .map(seg => seg.trim())
+    .filter(Boolean)
+    .filter(seg => opts.includeGenericSegments || seg.length >= 4)
+    .filter(seg => opts.includeGenericSegments || !GENERIC_AREA_SEGMENTS.has(seg));
+
+  return segments.some(seg => lowerText.includes(seg));
 }
 
 function formatHazardContext(area: string, allWarnings: string[]): string {

--- a/tests/cli/guards.test.ts
+++ b/tests/cli/guards.test.ts
@@ -73,6 +73,26 @@ function writeSprintState(sprint: number): void {
   }));
 }
 
+function writeScorecard(sprint: number, overrides: Record<string, unknown> = {}): void {
+  mkdirSync(join(tmpDir, 'docs/retros'), { recursive: true });
+  writeFileSync(join(tmpDir, `docs/retros/sprint-${sprint}.json`), JSON.stringify({
+    sprint_number: sprint,
+    theme: `Sprint ${sprint}`,
+    par: 4,
+    slope: 1,
+    score: 4,
+    score_label: 'par',
+    date: '2026-05-21',
+    shots: [],
+    conditions: [],
+    special_plays: [],
+    yardage_book_updates: [],
+    bunker_locations: [],
+    course_management_notes: [],
+    ...overrides,
+  }, null, 2));
+}
+
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'slope-guard-'));
   mockConfig.guidance = {};
@@ -220,6 +240,82 @@ describe('hazardGuard', () => {
       tmpDir,
     );
     expect(result).toEqual({ metricReason: 'no-match' });
+  });
+
+  it('falls back to scorecard shot hazards when common issues are empty', async () => {
+    mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+    writeFileSync(join(tmpDir, '.slope/common-issues.json'), JSON.stringify({ recurring_patterns: [] }));
+    writeScorecard(104, {
+      shots: [
+        {
+          ticket_key: 'S104-1',
+          title: 'Guard metrics work',
+          club: 'short_iron',
+          result: 'green',
+          hazards: [
+            { type: 'rough', description: 'src/cli/guards metric-only fields must stay out of hook output' },
+          ],
+        },
+      ],
+    });
+
+    const result = await hazardGuard(
+      makeInput({ tool_input: { file_path: join(tmpDir, 'src/cli/guards/hazard.ts') } }),
+      tmpDir,
+    );
+
+    expect(result.context).toContain('SLOPE hazards');
+    expect(result.context).toContain('[scorecard:rough]');
+    expect(result.context).toContain('metric-only fields');
+    expect(result.context).toContain('S104');
+    expect(result.metricReason).toBe('matched');
+  });
+
+  it('falls back to scorecard bunker locations and keeps newest first', async () => {
+    mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+    writeFileSync(join(tmpDir, '.slope/common-issues.json'), JSON.stringify({ recurring_patterns: [] }));
+    writeScorecard(101, {
+      bunker_locations: ['src/cli/guards: older hazard'],
+    });
+    writeScorecard(105, {
+      bunker_locations: ['src/cli/guards: newer hazard'],
+    });
+
+    const result = await hazardGuard(
+      makeInput({ tool_input: { file_path: join(tmpDir, 'src/cli/guards/hazard.ts') } }),
+      tmpDir,
+    );
+
+    expect(result.context).toContain('[scorecard:bunker]');
+    expect(result.context?.indexOf('newer hazard')).toBeLessThan(result.context?.indexOf('older hazard') ?? 0);
+  });
+
+  it('prefers common issues over scorecard fallback when both match', async () => {
+    mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+    writeFileSync(join(tmpDir, '.slope/common-issues.json'), JSON.stringify({
+      recurring_patterns: [
+        {
+          id: 1,
+          title: 'Guard common issue',
+          category: 'testing',
+          sprints_hit: [106],
+          gotcha_refs: [],
+          description: 'src/cli/guards common issue',
+          prevention: 'Use the common issue first',
+        },
+      ],
+    }));
+    writeScorecard(105, {
+      bunker_locations: ['src/cli/guards: scorecard fallback should not appear'],
+    });
+
+    const result = await hazardGuard(
+      makeInput({ tool_input: { file_path: join(tmpDir, 'src/cli/guards/hazard.ts') } }),
+      tmpDir,
+    );
+
+    expect(result.context).toContain('Guard common issue');
+    expect(result.context).not.toContain('scorecard fallback should not appear');
   });
 
   it('does not include permissionDecision (non-blocking)', async () => {


### PR DESCRIPTION
## Summary
- add scorecard-derived hazard fallback when common issues do not match
- preserve common-issues precedence and recency ordering
- document hazard guard source precedence and add sprint 106 artifacts

## Validation
- pnpm vitest run tests/cli/guards.test.ts tests/cli/commands/guard.test.ts tests/core/briefing.test.ts
- pnpm run typecheck
- pnpm run build
- node dist/cli/index.js guard docs hazard
- pnpm test
- slope validate docs/retros/sprint-106.json
- slope review recommend

Closes #397