### PR TITLE
feat: package Codex plugin bundle

### DIFF
--- a/docs/guides/codex-setup.md
+++ b/docs/guides/codex-setup.md
@@ -32,10 +32,16 @@ After installing or changing Codex hooks, restart Codex and run `/hooks`. Codex 
 `slope init --codex` creates `.codex/plugins/slope/` with:
 
 - `.codex-plugin/plugin.json`
+- `.mcp.json`
 - `hooks.json`
 - `hooks/slope-guard.sh`
+- `skills/`
 
-This bundle is metadata for future Codex `plugin_hooks` support. Keep using project or user `hooks.json` shims as the active runtime path until Codex plugin hook loading is reliable.
+It also writes `.codex/.agents/plugins/marketplace.json` so `.codex/` can be used as a local Codex marketplace root.
+
+This bundle is the named SLOPE adapter boundary for Codex. It packages SLOPE skills, MCP server metadata, hook metadata, local marketplace metadata, and a dispatcher script over the SLOPE CLI. Keep using project or user `hooks.json` shims as the active guard runtime path until Codex `plugin_hooks` is stable.
+
+`slope init --codex` updates SLOPE-owned plugin metadata on repeated runs. Existing non-SLOPE plugin manifests are left alone.
 
 ## Verification
 
@@ -47,3 +53,5 @@ codex debug prompt-input 'global hooks only parse smoke'
 ```
 
 Then run a harmless command in a SLOPE repo and confirm `.slope/guard-metrics.jsonl` receives a fresh entry.
+
+To register the project-local plugin bundle as a Codex marketplace source, run `codex plugin marketplace add .codex` from the repository root.

--- a/docs/retros/sprint-107-review.md
+++ b/docs/retros/sprint-107-review.md
@@ -1,0 +1,53 @@
+## Sprint 107 Review: Codex Plugin Packaging
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 2 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S107-1 | Long Iron | Green | - | Upgraded the Codex bundle from a metadata stub into a named local plugin package with skills, MCP metadata, generated full guard hook metadata, local marketplace metadata, install/update behavior, version-bump alignment, docs, and init regression tests. |
+
+### Hazards Discovered
+
+Known hazards for future sprints:
+
+- Codex plugin packaging needs marketplace metadata under .agents/plugins/marketplace.json; a loose plugin folder is not enough for stable marketplace discovery.
+- Codex plugin_hooks is still under development and disabled in local codex-cli 0.130.0, so SLOPE guard enforcement must continue to use project or user hooks.json shims.
+- Version bumps must update templates/codex/plugins/slope/.codex-plugin/plugin.json so the packaged plugin does not drift from @slope-dev/slope.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Codex plugin packaging has two separate surfaces: stable marketplace plugins and under-development plugin_hooks. | The SLOPE bundle now includes local marketplace metadata while keeping active guard enforcement on the stable hooks.json shim until plugin_hooks is enabled. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Plugin JSON, hook JSON, MCP JSON, dispatcher shell syntax, typecheck, build, focused Codex tests, and full Vitest suite passed. |
+
+### Course Management Notes
+
+- Validation used python3 -m json.tool on plugin.json, hooks.json, and .mcp.json plus bash -n on the plugin dispatcher.
+- Additional validation used pnpm run typecheck, pnpm run build, pnpm vitest run tests/cli/init-codex.test.ts tests/core/adapters/codex.test.ts tests/cli/commands/hook-codex.test.ts tests/cli/init-summary.test.ts, and pnpm test.
+- Local Codex CLI check used codex features list and confirmed plugins is stable while plugin_hooks remains under development and disabled.
+
+### 19th Hole
+
+- **How did it feel?** A packaging sprint more than a runtime rewrite: most of the work was making the boundary explicit, updateable, and honest about Codex's current plugin-hook limits.
+- **Advice for next player?** Keep active guard behavior on hooks.json until Codex reports plugin_hooks as stable; use marketplace metadata for plugin discovery and skills.
+- **What surprised you?** The existing bundle already existed, but without marketplace metadata or generated full guard metadata it was closer to a placeholder than an installable plugin package.
+- **Excited about next?** Once plugin_hooks stabilizes, the same bundle can become the active hook runtime without moving SLOPE guard logic out of the CLI.

--- a/docs/retros/sprint-107.json
+++ b/docs/retros/sprint-107.json
@@ -1,0 +1,74 @@
+{
+  "sprint_number": 107,
+  "player": "sebastianbryers",
+  "theme": "Codex Plugin Packaging",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-21",
+  "shots": [
+    {
+      "ticket_key": "S107-1",
+      "title": "Package SLOPE's Codex integration as a Codex plugin (#366)",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Upgraded the Codex bundle from a metadata stub into a named local plugin package with skills, MCP metadata, generated full guard hook metadata, local marketplace metadata, install/update behavior, version-bump alignment, docs, and init regression tests."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Codex plugin packaging has two separate surfaces: stable marketplace plugins and under-development plugin_hooks.",
+      "outcome": "The SLOPE bundle now includes local marketplace metadata while keeping active guard enforcement on the stable hooks.json shim until plugin_hooks is enabled."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Plugin JSON, hook JSON, MCP JSON, dispatcher shell syntax, typecheck, build, focused Codex tests, and full Vitest suite passed.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A packaging sprint more than a runtime rewrite: most of the work was making the boundary explicit, updateable, and honest about Codex's current plugin-hook limits.",
+    "advice_for_next_player": "Keep active guard behavior on hooks.json until Codex reports plugin_hooks as stable; use marketplace metadata for plugin discovery and skills.",
+    "what_surprised_you": "The existing bundle already existed, but without marketplace metadata or generated full guard metadata it was closer to a placeholder than an installable plugin package.",
+    "excited_about_next": "Once plugin_hooks stabilizes, the same bundle can become the active hook runtime without moving SLOPE guard logic out of the CLI."
+  },
+  "bunker_locations": [
+    "Codex plugin packaging needs marketplace metadata under .agents/plugins/marketplace.json; a loose plugin folder is not enough for stable marketplace discovery.",
+    "Codex plugin_hooks is still under development and disabled in local codex-cli 0.130.0, so SLOPE guard enforcement must continue to use project or user hooks.json shims.",
+    "Version bumps must update templates/codex/plugins/slope/.codex-plugin/plugin.json so the packaged plugin does not drift from @slope-dev/slope."
+  ],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Validation used python3 -m json.tool on plugin.json, hooks.json, and .mcp.json plus bash -n on the plugin dispatcher.",
+    "Additional validation used pnpm run typecheck, pnpm run build, pnpm vitest run tests/cli/init-codex.test.ts tests/core/adapters/codex.test.ts tests/cli/commands/hook-codex.test.ts tests/cli/init-summary.test.ts, and pnpm test.",
+    "Local Codex CLI check used codex features list and confirmed plugins is stable while plugin_hooks remains under development and disabled."
+  ],
+  "slope_factors": [
+    "agent_dx",
+    "codex_plugin",
+    "architecture"
+  ]
+}

--- a/docs/tech/codex-slope-hooks-handoff.md
+++ b/docs/tech/codex-slope-hooks-handoff.md
@@ -1,7 +1,7 @@
 # Codex SLOPE Hooks Handoff
 
 **Date:** 2026-05-16
-**Status:** Global Codex hooks are active locally; SLOPE plugin packaging remains blocked by Codex plugin hook discovery.
+**Status:** Global Codex hooks are active locally; SLOPE plugin runtime hooks remain blocked by Codex plugin hook discovery. SLOPE now ships a named Codex plugin bundle for skills, MCP metadata, local marketplace metadata, and future plugin hook metadata.
 
 ## Current Local State
 
@@ -32,22 +32,25 @@ Observed locally on Codex CLI `0.130.0`:
 - Config-layer hooks are discovered by `/hooks`.
 - Plugin-local hooks are not currently a reliable trust/review/runtime surface.
 
-## SLOPE Work Needed
+## SLOPE Work Completed
 
 In `/Users/sebastianbryers/Development/slope`:
 
-1. Update `src/core/adapters/codex.ts`.
-2. Change `CodexAdapter.installGuards()` so the Codex harness can install a user-level/global shim when requested.
-3. Generate a Codex plugin bundle for SLOPE with:
+1. `src/core/adapters/codex.ts` installs project or user-level hook shims.
+2. `slope init --codex` generates a Codex plugin bundle for SLOPE with:
    - `.codex-plugin/plugin.json`
    - packaged guard dispatcher script
    - bundled hook metadata for future plugin-hook support
-4. Keep the global/project `hooks.json` shim as the active runtime path until Codex plugin hook loading works.
-5. Add tests in `tests/core/adapters/codex.test.ts` for:
+   - `skills/` workflow guidance
+   - `.mcp.json` server metadata
+   - `.codex/.agents/plugins/marketplace.json` local marketplace metadata
+3. The global/project `hooks.json` shim remains the active runtime path until Codex plugin hook loading works.
+4. Tests cover:
    - top-level `{ "hooks": ... }` shape
    - current Codex matcher names (`Bash`, `Agent`, `ExitPlanMode`, `EnterWorktree`)
    - optional global install path
    - no duplicate install on repeated `slope hook add --level=full --harness=codex`
+   - `slope init --codex` plugin bundle install/update behavior
 
 ## Important Findings
 

--- a/scripts/version-bump.mjs
+++ b/scripts/version-bump.mjs
@@ -20,3 +20,16 @@ json.version = version;
 writeFileSync(pkgPath, JSON.stringify(json, null, 2) + '\n');
 
 console.log(`  @slope-dev/slope: ${old} → ${version}`);
+
+const codexPluginManifestPath = join(root, 'templates', 'codex', 'plugins', 'slope', '.codex-plugin', 'plugin.json');
+try {
+  const plugin = JSON.parse(readFileSync(codexPluginManifestPath, 'utf8'));
+  if (plugin.name === 'slope') {
+    const pluginOld = plugin.version ?? old;
+    plugin.version = version;
+    writeFileSync(codexPluginManifestPath, JSON.stringify(plugin, null, 2) + '\n');
+    console.log(`  codex plugin: ${pluginOld} → ${version}`);
+  }
+} catch {
+  // Older source trees may not have a Codex plugin template.
+}

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,11 +1,11 @@
-import { writeFileSync, mkdirSync, existsSync, cpSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { writeFileSync, mkdirSync, existsSync, cpSync, readFileSync, readdirSync, statSync, chmodSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 import { createConfig } from '../config.js';
 import { saveHooksConfig } from '../hooks-config.js';
 import { resolveMetaphor } from '../metaphor.js';
-import { detectPackageManager, createVision, analyzeStack, SLOPE_BIN_PREAMBLE, writeOrUpdateManagedScript } from '../../core/index.js';
+import { detectPackageManager, createVision, analyzeStack, SLOPE_BIN_PREAMBLE, writeOrUpdateManagedScript, GUARD_DEFINITIONS } from '../../core/index.js';
 import type { StackProfile } from '../../core/analyzers/types.js';
 import type { MetaphorDefinition } from '../../core/index.js';
 import {
@@ -547,34 +547,160 @@ function installOpenCodePlugin(cwd: string): void {
   }
 }
 
-function copyDirectoryMissing(srcDir: string, destDir: string): number {
-  if (!existsSync(srcDir)) return 0;
+type TemplateCopyResult = { copied: number; updated: number };
+
+function copyCodexPluginTemplate(srcDir: string, destDir: string, relativeDir = ''): TemplateCopyResult {
+  if (!existsSync(srcDir)) return { copied: 0, updated: 0 };
   mkdirSync(destDir, { recursive: true });
   let copied = 0;
+  let updated = 0;
   for (const entry of readdirSync(srcDir)) {
     const src = join(srcDir, entry);
     const dest = join(destDir, entry);
+    const relativePath = relativeDir ? join(relativeDir, entry) : entry;
     const stat = statSync(src);
     if (stat.isDirectory()) {
-      copied += copyDirectoryMissing(src, dest);
+      const result = copyCodexPluginTemplate(src, dest, relativePath);
+      copied += result.copied;
+      updated += result.updated;
     } else if (!existsSync(dest)) {
       cpSync(src, dest);
+      if (relativePath === join('hooks', 'slope-guard.sh')) chmodSync(dest, 0o755);
       copied++;
+    } else if (isManagedCodexPluginFile(relativePath, dest) && readFileSync(src, 'utf8') !== readFileSync(dest, 'utf8')) {
+      cpSync(src, dest, { force: true });
+      if (relativePath === join('hooks', 'slope-guard.sh')) chmodSync(dest, 0o755);
+      updated++;
     }
   }
-  return copied;
+  return { copied, updated };
+}
+
+function isManagedCodexPluginFile(relativePath: string, destPath: string): boolean {
+  const normalizedPath = relativePath.replace(/\\/g, '/');
+  if (normalizedPath === '.codex-plugin/plugin.json') return false;
+  if (!existsSync(destPath)) return false;
+  try {
+    const existing = readFileSync(destPath, 'utf8');
+    if (normalizedPath === 'hooks.json') return existing.includes('"slopePluginHooksStatus"');
+    if (normalizedPath === 'hooks/slope-guard.sh') return existing.includes('SLOPE Codex plugin dispatcher');
+    if (normalizedPath === '.mcp.json') return existing.includes('"mcpServers"') && existing.includes('"slope"');
+    if (normalizedPath.startsWith('skills/') && normalizedPath.endsWith('SKILL.md')) {
+      return existing.includes('SLOPE');
+    }
+  } catch { /* leave customized files alone */ }
+  return false;
 }
 
 function installCodexPluginBundle(cwd: string): void {
   const src = join(getTemplatesRoot(), 'codex', 'plugins', 'slope');
   const dest = join(cwd, '.codex', 'plugins', 'slope');
-  const copied = copyDirectoryMissing(src, dest);
-  if (copied > 0) {
-    console.log(`  Created Codex plugin bundle at ${dest}`);
+  if (!existsSync(src)) {
+    console.warn(`  Warning: Codex plugin template not found: ${src}`);
+    return;
+  }
+  const result = copyCodexPluginTemplate(src, dest);
+  const hooksUpdated = writeCodexPluginHooksMetadata(dest);
+  const manifestUpdated = syncCodexPluginManifest(dest);
+  const marketplaceUpdated = writeCodexPluginMarketplace(cwd);
+  if (result.copied > 0 || result.updated > 0 || hooksUpdated || manifestUpdated || marketplaceUpdated) {
+    console.log(`  Created/updated Codex plugin bundle at ${dest}`);
   } else if (existsSync(dest)) {
     console.log(`  Codex plugin bundle already exists at ${dest}`);
-  } else {
-    console.warn(`  Warning: Codex plugin template not found: ${src}`);
+  }
+}
+
+function writeCodexPluginMarketplace(cwd: string): boolean {
+  const marketplacePath = join(cwd, '.codex', '.agents', 'plugins', 'marketplace.json');
+  const slopeEntry = {
+    name: 'slope',
+    source: {
+      source: 'local',
+      path: './plugins/slope',
+    },
+    policy: {
+      installation: 'AVAILABLE',
+      authentication: 'ON_INSTALL',
+    },
+    category: 'Productivity',
+  };
+
+  let existing: Record<string, unknown> = {};
+  if (existsSync(marketplacePath)) {
+    try {
+      existing = JSON.parse(readFileSync(marketplacePath, 'utf8')) as Record<string, unknown>;
+    } catch { /* rewrite invalid local marketplace metadata */ }
+  }
+
+  const existingPlugins = Array.isArray(existing.plugins)
+    ? existing.plugins.filter(plugin => !isRecord(plugin) || plugin.name !== 'slope')
+    : [];
+  const existingInterface = isRecord(existing.interface) ? existing.interface : {};
+
+  const marketplace = {
+    ...existing,
+    name: typeof existing.name === 'string' ? existing.name : 'slope-local',
+    interface: {
+      displayName: 'SLOPE Local',
+      ...existingInterface,
+    },
+    plugins: [
+      ...existingPlugins,
+      slopeEntry,
+    ],
+  };
+
+  return writeJsonIfChanged(marketplacePath, marketplace);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function writeCodexPluginHooksMetadata(pluginRoot: string): boolean {
+  const adapter = getAdapter('codex');
+  if (!adapter) return false;
+  const generated = adapter.generateHooksConfig(GUARD_DEFINITIONS, './hooks/slope-guard.sh') as { hooks?: unknown };
+  const hooksPath = join(pluginRoot, 'hooks.json');
+  const payload = {
+    slopePluginHooksStatus: 'metadata-only',
+    note: 'Codex plugin_hooks is under development. Use user or project hooks.json shims for active SLOPE guards until plugin hook loading is stable.',
+    hooks: generated.hooks ?? {},
+  };
+  return writeJsonIfChanged(hooksPath, payload);
+}
+
+function syncCodexPluginManifest(pluginRoot: string): boolean {
+  const manifestPath = join(pluginRoot, '.codex-plugin', 'plugin.json');
+  if (!existsSync(manifestPath)) return false;
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+    if (manifest.name !== 'slope') return false;
+    const version = getSlopePackageVersion();
+    if (version) manifest.version = version;
+    manifest.skills = './skills/';
+    manifest.hooks = './hooks.json';
+    manifest.mcpServers = './.mcp.json';
+    return writeJsonIfChanged(manifestPath, manifest);
+  } catch {
+    return false;
+  }
+}
+
+function writeJsonIfChanged(filePath: string, value: unknown): boolean {
+  const next = JSON.stringify(value, null, 2) + '\n';
+  if (existsSync(filePath) && readFileSync(filePath, 'utf8') === next) return false;
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, next);
+  return true;
+}
+
+function getSlopePackageVersion(): string | null {
+  try {
+    const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', '..', 'package.json'), 'utf8')) as { version?: unknown };
+    return typeof pkg.version === 'string' ? pkg.version : null;
+  } catch {
+    return null;
   }
 }
 
@@ -772,7 +898,7 @@ function installForProvider(cwd: string, provider: InitProvider, metaphor: Metap
       installDefaultHooks(cwd, 'codex');
       console.log('\n  Codex CLI: Guards installed to .codex/hooks.json');
       console.log('  Codex CLI: AGENTS.md provides project context');
-      console.log('  Codex CLI: Plugin bundle installed to .codex/plugins/slope (metadata only until plugin_hooks works)');
+      console.log('  Codex CLI: Plugin bundle installed to .codex/plugins/slope (skills, MCP metadata, marketplace metadata, future plugin hooks)');
       console.log('  Codex CLI: MCP server configured — add to .codex/config.toml:');
       console.log('    [mcp.slope]');
       console.log('    command = "slope"');
@@ -828,7 +954,7 @@ const PROVIDER_NEXT_STEPS: Partial<Record<InitProvider, string[]>> = {
   codex: [
     'Add SLOPE MCP server to .codex/config.toml: [mcp.slope] command="slope" args=["mcp"]',
     'Guards installed to .codex/hooks.json',
-    'Plugin bundle installed to .codex/plugins/slope for future plugin_hooks support',
+    'Plugin bundle installed to .codex/plugins/slope with skills, MCP metadata, marketplace metadata, and future plugin_hooks metadata',
     'Track docs/vision.md and docs/backlog/roadmap.json as source of truth (.slope/ stays local)',
     'Branch discipline: branch-before-commit guard blocks direct main commits — use feat/<desc>',
     'First sprint: slope vision create, slope roadmap validate, slope sprint begin --sprint=1 --ticket=S1-1',
@@ -868,6 +994,13 @@ const PROVIDER_FILES: Partial<Record<InitProvider, string[]>> = {
     'AGENTS.md (project context)',
     'opencode.json (SLOPE MCP server)',
     '.opencode/plugins/slope-plugin.ts (session lifecycle plugin)',
+  ],
+  codex: [
+    'AGENTS.md (project context)',
+    '.codex/hooks.json (active guard hook shim)',
+    '.codex/hooks/ (session hooks and guard dispatcher)',
+    '.codex/.agents/plugins/marketplace.json (local Codex marketplace metadata)',
+    '.codex/plugins/slope/ (Codex plugin bundle: skills, MCP metadata, hook metadata)',
   ],
   generic: [
     'SLOPE-CHECKLIST.md (sprint checklist)',

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "slope",
-  "version": "1.55.3",
-  "description": "SLOPE sprint tracking, guard metadata, and Codex setup bundle.",
+  "version": "1.55.12",
+  "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",
     "email": "support@example.com",
@@ -16,24 +16,27 @@
     "codex",
     "hooks"
   ],
+  "skills": "./skills/",
   "hooks": "./hooks.json",
+  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "SLOPE",
-    "shortDescription": "Sprint tracking and hook metadata for Codex.",
-    "longDescription": "Bundles SLOPE guard hook metadata and a dispatcher script for future Codex plugin hook support. Runtime guard execution currently uses user or project hooks.json shims.",
+    "shortDescription": "Sprint tracking, guard hooks, and workflow skills for Codex.",
+    "longDescription": "Packages SLOPE's Codex-facing adapter boundary: guard hook metadata, a dispatcher over the SLOPE CLI, MCP server metadata, and skills for sprint setup, closeout, and guard-warning handling. Runtime guard execution uses user or project hooks.json shims until Codex plugin_hooks is stable.",
     "developerName": "SLOPE",
     "category": "Productivity",
     "capabilities": [
       "Hooks",
+      "Skills",
       "MCP"
     ],
     "websiteURL": "https://github.com/srbryers/slope",
     "privacyPolicyURL": "https://github.com/srbryers/slope",
     "termsOfServiceURL": "https://github.com/srbryers/slope",
     "defaultPrompt": [
-      "Run slope briefing and summarize current sprint risks.",
-      "Check whether SLOPE hooks are installed correctly.",
-      "Review the current sprint plan and next ticket."
+      "Set up SLOPE for this repo from Codex.",
+      "Start or inspect the current SLOPE sprint.",
+      "Close out the sprint with validation and review."
     ],
     "brandColor": "#2F6F5E"
   }

--- a/templates/codex/plugins/slope/.mcp.json
+++ b/templates/codex/plugins/slope/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "slope": {
+      "command": "slope",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/templates/codex/plugins/slope/hooks.json
+++ b/templates/codex/plugins/slope/hooks.json
@@ -1,29 +1,206 @@
 {
   "slopePluginHooksStatus": "metadata-only",
-  "note": "Codex plugin hook discovery is not a reliable runtime path yet. Use user or project hooks.json shims for active SLOPE guards.",
+  "note": "Codex plugin_hooks is under development. Use user or project hooks.json shims for active SLOPE guards until plugin hook loading is stable.",
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/slope-guard.sh branch-before-commit",
+            "command": "\"./hooks/slope-guard.sh\" explore",
             "timeout": 10,
-            "statusMessage": "SLOPE branch guard"
+            "statusMessage": "SLOPE explore"
           }
-        ]
+        ],
+        "matcher": "mcp__.*__read.*|mcp__.*__glob.*|mcp__.*__list.*|mcp__.*__search.*|mcp__.*__grep.*|apply_patch|Edit|Write"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" hazard",
+            "timeout": 10,
+            "statusMessage": "SLOPE hazard"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" scope-drift",
+            "timeout": 10,
+            "statusMessage": "SLOPE scope-drift"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" workflow-step-gate",
+            "timeout": 10,
+            "statusMessage": "SLOPE workflow-step-gate"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" stale-flows",
+            "timeout": 10,
+            "statusMessage": "SLOPE stale-flows"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" claim-required",
+            "timeout": 10,
+            "statusMessage": "SLOPE claim-required"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" roadmap-edit-shipped",
+            "timeout": 10,
+            "statusMessage": "SLOPE roadmap-edit-shipped"
+          }
+        ],
+        "matcher": "apply_patch|Edit|Write"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" subagent-gate",
+            "timeout": 10,
+            "statusMessage": "SLOPE subagent-gate"
+          }
+        ],
+        "matcher": "Agent"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" workflow-gate",
+            "timeout": 10,
+            "statusMessage": "SLOPE workflow-gate"
+          }
+        ],
+        "matcher": "ExitPlanMode"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" version-check",
+            "timeout": 10,
+            "statusMessage": "SLOPE version-check"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" branch-before-commit",
+            "timeout": 10,
+            "statusMessage": "SLOPE branch-before-commit"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" sprint-completion",
+            "timeout": 10,
+            "statusMessage": "SLOPE sprint-completion"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" worktree-merge",
+            "timeout": 10,
+            "statusMessage": "SLOPE worktree-merge"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" worktree-self-remove",
+            "timeout": 10,
+            "statusMessage": "SLOPE worktree-self-remove"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" phase-boundary",
+            "timeout": 10,
+            "statusMessage": "SLOPE phase-boundary"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" worktree-check",
+            "timeout": 10,
+            "statusMessage": "SLOPE worktree-check"
+          }
+        ],
+        "matcher": "apply_patch|Edit|Write|Bash"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" worktree-reuse",
+            "timeout": 10,
+            "statusMessage": "SLOPE worktree-reuse"
+          }
+        ],
+        "matcher": "EnterWorktree"
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/slope-guard.sh commit-nudge",
+            "command": "\"./hooks/slope-guard.sh\" commit-nudge",
             "timeout": 10,
-            "statusMessage": "SLOPE commit nudge"
+            "statusMessage": "SLOPE commit-nudge"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" review-tier",
+            "timeout": 10,
+            "statusMessage": "SLOPE review-tier"
+          }
+        ],
+        "matcher": "apply_patch|Edit|Write"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" push-nudge",
+            "timeout": 10,
+            "statusMessage": "SLOPE push-nudge"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" pr-review",
+            "timeout": 10,
+            "statusMessage": "SLOPE pr-review"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" sprint-completion",
+            "timeout": 10,
+            "statusMessage": "SLOPE sprint-completion"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" post-push",
+            "timeout": 10,
+            "statusMessage": "SLOPE post-push"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" transcript",
+            "timeout": 10,
+            "statusMessage": "SLOPE transcript"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" session-briefing",
+            "timeout": 10,
+            "statusMessage": "SLOPE session-briefing"
           }
         ]
       }
@@ -33,9 +210,33 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./hooks/slope-guard.sh stop-check",
+            "command": "\"./hooks/slope-guard.sh\" stop-check",
             "timeout": 10,
-            "statusMessage": "SLOPE stop check"
+            "statusMessage": "SLOPE stop-check"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" next-action",
+            "timeout": 10,
+            "statusMessage": "SLOPE next-action"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" sprint-completion",
+            "timeout": 10,
+            "statusMessage": "SLOPE sprint-completion"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" review-stale",
+            "timeout": 10,
+            "statusMessage": "SLOPE review-stale"
+          },
+          {
+            "type": "command",
+            "command": "\"./hooks/slope-guard.sh\" post-hole-enforcement",
+            "timeout": 10,
+            "statusMessage": "SLOPE post-hole-enforcement"
           }
         ]
       }

--- a/templates/codex/plugins/slope/hooks/slope-guard.sh
+++ b/templates/codex/plugins/slope/hooks/slope-guard.sh
@@ -12,10 +12,12 @@ fi
 
 if [ -x "$SLOPE_PROJECT_DIR/node_modules/.bin/slope" ]; then
   SLOPE_BIN="$SLOPE_PROJECT_DIR/node_modules/.bin/slope"
+elif [ -f "$SLOPE_PROJECT_DIR/dist/cli/index.js" ] && [ -f "$SLOPE_PROJECT_DIR/package.json" ] && grep -q '"name": "@slope-dev/slope"' "$SLOPE_PROJECT_DIR/package.json"; then
+  exec node "$SLOPE_PROJECT_DIR/dist/cli/index.js" guard "$@"
 elif command -v slope >/dev/null 2>&1; then
   SLOPE_BIN="$(command -v slope)"
 else
-  exit 0
+  SLOPE_BIN="npx --yes @slope-dev/slope"
 fi
 
 cd "$SLOPE_PROJECT_DIR"

--- a/templates/codex/plugins/slope/skills/slope-guard-warning/SKILL.md
+++ b/templates/codex/plugins/slope/skills/slope-guard-warning/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: slope-guard-warning
+description: Respond to SLOPE guard warnings in Codex without bypassing sprint discipline. Trigger when a SLOPE guard warns, blocks, recommends a review, asks for a claim, or reports missing sprint context.
+---
+
+# SLOPE Guard Warnings
+
+Treat guard output as operational context, not as generic text.
+
+## Triage
+
+1. Identify the guard name from the warning.
+2. Run `slope guard docs <guard-name>` when behavior or configuration is unclear.
+3. If the guard references sprint state, run `slope sprint status`.
+4. If the guard references hazards, run `slope briefing --compact` or inspect the cited scorecard/common issue.
+
+## Resolve
+
+1. For missing sprint or claim warnings, start/claim the sprint or switch to the explicitly supported ad hoc mode.
+2. For review warnings, run `slope review recommend` and complete the recommended review flow.
+3. For hazard warnings, adjust the implementation or add a note to the scorecard explaining why the hazard did not apply.
+4. Avoid disabling a guard unless the user explicitly asks for a configuration change.
+
+## Verify
+
+1. Re-run the original command when the guard is tied to a command path.
+2. Use `slope guard metrics` when diagnosing whether a guard is silent, suppressed, or missing payload data.
+3. Do not treat a silent guard as proof that no sprint workflow is required.

--- a/templates/codex/plugins/slope/skills/slope-setup/SKILL.md
+++ b/templates/codex/plugins/slope/skills/slope-setup/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: slope-setup
+description: Set up SLOPE in a Codex-managed repository without requiring the user to know CLI details. Trigger when the user asks to install, initialize, update, or verify SLOPE for Codex.
+---
+
+# SLOPE Setup For Codex
+
+Use this when the user wants SLOPE available from an agent harness.
+
+## Install Or Update
+
+1. Run `slope init --codex` from the repository root.
+2. If the repo already has SLOPE, run `slope doctor --fix` after init.
+3. Prefer one active Codex hook path:
+   - project-local: `.codex/hooks.json`
+   - user-level: `~/.codex/hooks.json`
+4. Avoid enabling both paths for the same repo unless the user explicitly wants duplicate hook firing.
+
+## Verify
+
+1. Run `slope doctor`.
+2. Run `slope hook list`.
+3. Run `python3 -m json.tool .codex/hooks.json` for project-local hooks, or `python3 -m json.tool ~/.codex/hooks.json` for user-level hooks.
+4. Run `bash -n .codex/hooks/slope-guard.sh` or `bash -n ~/.codex/hooks/slope-guard.sh`.
+5. Restart Codex and review `/hooks` after hook changes.
+
+## Explain
+
+Tell the user that the Codex plugin bundle groups SLOPE skills, MCP metadata, and future plugin-hook metadata under a named SLOPE integration. Active guard enforcement still uses the stable Codex hooks.json shim while Codex `plugin_hooks` is under development.

--- a/templates/codex/plugins/slope/skills/slope-sprint/SKILL.md
+++ b/templates/codex/plugins/slope/skills/slope-sprint/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: slope-sprint
+description: Use SLOPE from Codex to inspect, start, claim, or close a sprint in a repository with .slope state. Trigger when the user asks to set up SLOPE, register sprint work, check active sprint status, or close out sprint work.
+---
+
+# SLOPE Sprint Workflow
+
+Use these commands from the repository root.
+
+## Inspect
+
+1. Run `slope sprint status`.
+2. If no sprint is active, run `slope next` and `slope briefing --sprint=<next>`.
+3. If a sprint is active, run `slope briefing --sprint=<active>` before editing.
+
+## Start Or Claim
+
+1. Start a sprint with `slope sprint begin --sprint=<number> --ticket=<issue-or-ticket>`.
+2. If the issue is only on GitHub and not in the local roadmap, the command may report a prep lookup miss after creating sprint state and a claim. Treat that as non-blocking if `slope sprint status` shows the claim.
+3. Create a feature branch before code changes.
+
+## Work
+
+1. Commit after each meaningful feature, file group, migration, or bug fix.
+2. Push after each ticket and at least every 30 minutes.
+3. When guards produce warnings, address the warning or record why it is not applicable.
+
+## Close
+
+1. Run focused tests, then `pnpm run typecheck`, `pnpm run build`, and the relevant full test suite for the change.
+2. Run `slope review recommend`.
+3. Add or update `docs/retros/sprint-<number>.json` and `docs/retros/sprint-<number>-review.md`.
+4. Run `slope validate docs/retros/sprint-<number>.json`.
+5. Mark gates with `slope sprint gate <gate>` only after the evidence exists.

--- a/tests/cli/init-codex.test.ts
+++ b/tests/cli/init-codex.test.ts
@@ -58,18 +58,42 @@ describe('slope init --codex (GH #309)', () => {
       execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
       const pluginRoot = join(cwd, '.codex', 'plugins', 'slope');
       const manifestPath = join(pluginRoot, '.codex-plugin', 'plugin.json');
+      const marketplacePath = join(cwd, '.codex', '.agents', 'plugins', 'marketplace.json');
+      const mcpPath = join(pluginRoot, '.mcp.json');
       const hooksPath = join(pluginRoot, 'hooks.json');
       const dispatcherPath = join(pluginRoot, 'hooks', 'slope-guard.sh');
+      const skillPath = join(pluginRoot, 'skills', 'slope-sprint', 'SKILL.md');
 
       expect(existsSync(manifestPath)).toBe(true);
+      expect(existsSync(marketplacePath)).toBe(true);
+      expect(existsSync(mcpPath)).toBe(true);
       expect(existsSync(hooksPath)).toBe(true);
       expect(existsSync(dispatcherPath)).toBe(true);
+      expect(existsSync(skillPath)).toBe(true);
 
       const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+      const marketplace = JSON.parse(readFileSync(marketplacePath, 'utf8'));
+      const mcp = JSON.parse(readFileSync(mcpPath, 'utf8'));
       const hooks = JSON.parse(readFileSync(hooksPath, 'utf8'));
+      const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
       expect(manifest.name).toBe('slope');
+      expect(manifest.version).toBe(pkg.version);
+      expect(manifest.skills).toBe('./skills/');
       expect(manifest.hooks).toBe('./hooks.json');
+      expect(manifest.mcpServers).toBe('./.mcp.json');
+      expect(marketplace.plugins).toContainEqual({
+        name: 'slope',
+        source: { source: 'local', path: './plugins/slope' },
+        policy: { installation: 'AVAILABLE', authentication: 'ON_INSTALL' },
+        category: 'Productivity',
+      });
+      expect(mcp.mcpServers.slope).toEqual({ command: 'slope', args: ['mcp'] });
       expect(hooks.slopePluginHooksStatus).toBe('metadata-only');
+      const hookCommands = Object.values(hooks.hooks).flatMap((groups: any) =>
+        groups.flatMap((group: any) => group.hooks.map((hook: any) => hook.command)),
+      );
+      expect(hookCommands).toContain('"./hooks/slope-guard.sh" claim-required');
+      expect(hookCommands).toContain('"./hooks/slope-guard.sh" stop-check');
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
@@ -85,6 +109,38 @@ describe('slope init --codex (GH #309)', () => {
 
       execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
       expect(readFileSync(manifestPath, 'utf8')).toBe(sentinel);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('updates an existing SLOPE Codex plugin manifest and generated hook metadata', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-init-codex-plugin-update-'));
+    const pluginRoot = join(cwd, '.codex', 'plugins', 'slope');
+    const manifestPath = join(pluginRoot, '.codex-plugin', 'plugin.json');
+    try {
+      require('node:fs').mkdirSync(join(pluginRoot, '.codex-plugin'), { recursive: true });
+      require('node:fs').writeFileSync(manifestPath, JSON.stringify({
+        name: 'slope',
+        version: '0.0.1',
+        hooks: './old-hooks.json',
+      }, null, 2) + '\n');
+
+      execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+
+      const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+      const hooks = JSON.parse(readFileSync(join(pluginRoot, 'hooks.json'), 'utf8'));
+      const commands = Object.values(hooks.hooks).flatMap((groups: any) =>
+        groups.flatMap((group: any) => group.hooks.map((hook: any) => hook.command)),
+      );
+
+      expect(manifest.version).toBe(pkg.version);
+      expect(manifest.skills).toBe('./skills/');
+      expect(manifest.hooks).toBe('./hooks.json');
+      expect(manifest.mcpServers).toBe('./.mcp.json');
+      expect(commands).toContain('"./hooks/slope-guard.sh" claim-required');
+      expect(commands).toContain('"./hooks/slope-guard.sh" pr-review');
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/cli/init-codex.test.ts
+++ b/tests/cli/init-codex.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const REPO_ROOT = resolve(__dirname, '..', '..');
 const SLOPE_BIN = resolve(REPO_ROOT, 'dist', 'cli', 'index.js');
+
+function runSlopeInit(cwd: string, args: string[] = ['--codex']): string {
+  return execFileSync(process.execPath, [SLOPE_BIN, 'init', ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
 
 describe('slope init --codex (GH #309)', () => {
   beforeAll(() => {
@@ -17,7 +25,7 @@ describe('slope init --codex (GH #309)', () => {
   it('creates AGENTS.md with project context (#340)', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-init-codex-agents-'));
     try {
-      execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeInit(cwd);
       const agentsMd = join(cwd, 'AGENTS.md');
       expect(existsSync(agentsMd)).toBe(true);
       const stat = require('node:fs').statSync(agentsMd);
@@ -33,7 +41,7 @@ describe('slope init --codex (GH #309)', () => {
     try {
       const sentinel = '# Custom user content — do not touch\n';
       require('node:fs').writeFileSync(agentsMd, sentinel);
-      execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeInit(cwd);
       const content = require('node:fs').readFileSync(agentsMd, 'utf8');
       expect(content).toBe(sentinel);
     } finally {
@@ -44,7 +52,7 @@ describe('slope init --codex (GH #309)', () => {
   it('installs Codex hooks under .codex/hooks/', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-init-codex-'));
     try {
-      execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeInit(cwd);
       expect(existsSync(join(cwd, '.codex', 'hooks', 'slope-session-start.sh'))).toBe(true);
       expect(existsSync(join(cwd, '.codex', 'hooks', 'slope-session-end.sh'))).toBe(true);
     } finally {
@@ -55,7 +63,7 @@ describe('slope init --codex (GH #309)', () => {
   it('installs Codex plugin bundle metadata without relying on plugin hooks', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-init-codex-plugin-'));
     try {
-      execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeInit(cwd);
       const pluginRoot = join(cwd, '.codex', 'plugins', 'slope');
       const manifestPath = join(pluginRoot, '.codex-plugin', 'plugin.json');
       const marketplacePath = join(cwd, '.codex', '.agents', 'plugins', 'marketplace.json');
@@ -107,7 +115,7 @@ describe('slope init --codex (GH #309)', () => {
       const sentinel = '{"name":"custom-slope"}\n';
       require('node:fs').writeFileSync(manifestPath, sentinel);
 
-      execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeInit(cwd);
       expect(readFileSync(manifestPath, 'utf8')).toBe(sentinel);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
@@ -126,7 +134,7 @@ describe('slope init --codex (GH #309)', () => {
         hooks: './old-hooks.json',
       }, null, 2) + '\n');
 
-      execSync(`node ${SLOPE_BIN} init --codex`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeInit(cwd);
 
       const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
       const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
@@ -149,7 +157,7 @@ describe('slope init --codex (GH #309)', () => {
   it('prints Codex-specific next steps including MCP config snippet', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-init-codex-next-'));
     try {
-      const out = execSync(`node ${SLOPE_BIN} init --codex`, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+      const out = runSlopeInit(cwd);
       expect(out).toContain('Platform: codex');
       expect(out).toContain('.codex/config.toml');
       expect(out).toContain('.codex/plugins/slope');
@@ -163,7 +171,7 @@ describe('slope init --codex (GH #309)', () => {
   it('--all includes codex among the installed providers', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-init-codex-all-'));
     try {
-      execSync(`node ${SLOPE_BIN} init --all`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeInit(cwd, ['--all']);
       expect(existsSync(join(cwd, '.codex', 'hooks', 'slope-session-start.sh'))).toBe(true);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
@@ -173,7 +181,7 @@ describe('slope init --codex (GH #309)', () => {
   it('does not create .codex when other providers selected', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-init-no-codex-'));
     try {
-      execSync(`node ${SLOPE_BIN} init --claude-code`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeInit(cwd, ['--claude-code']);
       expect(existsSync(join(cwd, '.codex'))).toBe(false);
       expect(existsSync(join(cwd, '.claude'))).toBe(true);
     } finally {


### PR DESCRIPTION
## Summary
- Package the SLOPE Codex integration as a plugin bundle with manifest skills, MCP metadata, generated hook metadata, and local marketplace metadata.
- Teach `slope init --codex` to install/update SLOPE-owned plugin files while preserving custom plugin manifests.
- Keep plugin manifest version aligned during release bumps and document the stable hooks.json shim vs under-development plugin_hooks boundary.

## Validation
- `python3 -m json.tool` for plugin JSON, hook JSON, and MCP JSON
- `bash -n templates/codex/plugins/slope/hooks/slope-guard.sh`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm vitest run tests/cli/init-codex.test.ts tests/core/adapters/codex.test.ts tests/cli/commands/hook-codex.test.ts tests/cli/init-summary.test.ts`
- `pnpm test`
- `slope validate docs/retros/sprint-107.json`

Closes #366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Codex plugin bundle now includes workflow skills for setup, sprint management, and guard-warning triage, plus MCP server integration
  * Improved initialization process with automated plugin metadata synchronization and marketplace setup

* **Documentation**
  * Added comprehensive skill guides documenting Codex integration workflows
  * Expanded setup documentation with plugin packaging verification steps
  * Added sprint review documentation with validation checksums

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->