### PR TITLE
fix: add npm publish backfill dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      publish_ref:
+        description: Release tag ref to check out and publish, e.g. refs/tags/v1.55.12
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -11,7 +17,19 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Validate manual publish ref
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          PUBLISH_REF: ${{ inputs.publish_ref }}
+        run: |
+          if ! printf '%s\n' "$PUBLISH_REF" | grep -Eq '^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::publish_ref must be a release tag ref like refs/tags/v1.55.12"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_ref || github.ref }}
 
       - uses: actions/setup-node@v4
         with:

--- a/docs/guides/npm-publishing.md
+++ b/docs/guides/npm-publishing.md
@@ -32,13 +32,25 @@ If a GitHub release exists but npm is behind:
    npm view @slope-dev/slope version --registry https://registry.npmjs.org
    ```
 2. Confirm the trusted publisher settings above on npmjs.com.
-3. Re-run the failed `Publish to npm` workflow for the release tag.
-4. Verify npm now reports the release version:
+3. If the release tag already contains the current trusted-publishing workflow, re-run the failed `Publish to npm` workflow for the release tag.
+4. If the release tag predates a publish workflow repair, dispatch the current workflow from `main` and pass the release tag ref as the package checkout ref:
+   ```sh
+   gh workflow run publish.yml --ref main -f publish_ref=refs/tags/vX.Y.Z
+   gh run watch
+   ```
+   This loads the repaired workflow from `main` while publishing the package contents from the historical tag.
+5. Verify npm now reports the release version:
    ```sh
    npm view @slope-dev/slope version --registry https://registry.npmjs.org
    ```
 
-For the `v1.55.12` incident, npm reported `1.55.11` after the GitHub release was published. After trusted publishing is configured, re-run the `v1.55.12` publish workflow and verify npm reports `1.55.12`.
+For the `v1.55.12` incident, npm reported `1.55.11` after the GitHub release was published, and the `v1.55.12` tag still contains the old token-based workflow. After trusted publishing is configured, dispatch the repaired workflow with:
+
+```sh
+gh workflow run publish.yml --ref main -f publish_ref=refs/tags/v1.55.12
+gh run watch
+npm view @slope-dev/slope version --registry https://registry.npmjs.org
+```
 
 ## Token Fallback
 

--- a/docs/retros/sprint-108-review.md
+++ b/docs/retros/sprint-108-review.md
@@ -1,0 +1,54 @@
+## Sprint 108 Review: npm Publish Backfill Recovery
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 1 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S108-1 | Wedge | Green | - | Added workflow_dispatch to the npm publish workflow so the repaired workflow on main can publish a historical tag such as v1.55.12, restricted the manual input to release tag refs, and updated the npm publishing guide with the exact backfill command. |
+
+### Hazards Discovered
+
+Known hazards for future sprints:
+
+- Creating a GitHub Release from a stale commit runs the workflow version at that commit, not HEAD.
+- Backfilling a failed package publish may need workflow_dispatch from main with an explicit historical checkout ref.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Rerunning a failed release workflow can reuse the workflow definition from the old tag commit. | Backfill recovery now dispatches the repaired workflow from main while explicitly checking out the historical package ref. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Validated publish.yml YAML parsing, diff whitespace, TypeScript typecheck, and required security review. |
+
+### Course Management Notes
+
+- Validation used ruby YAML parsing for .github/workflows/publish.yml.
+- Validation used git diff --check HEAD~1..HEAD.
+- Validation used pnpm run typecheck.
+- Required security review tightened the manual publish input from arbitrary refs to release tag refs only.
+- npm still reports @slope-dev/slope latest as 1.55.11 until the trusted publisher is configured and the manual backfill workflow is dispatched for v1.55.12.
+
+### 19th Hole
+
+- **How did it feel?** Small but important release plumbing: the repo fix needed a way to apply itself to the already-published GitHub release tag.
+- **Advice for next player?** For failed publish recovery, check both the current workflow and the workflow that exists on the failed release tag before choosing rerun vs workflow_dispatch.
+- **What surprised you?** The v1.55.12 tag still contains the old token-based publish workflow, so a plain rerun would not exercise the trusted-publishing repair.
+- **Excited about next?** Once npm trusted publishing is configured, v1.55.12 can be published without moving the release tag.

--- a/docs/retros/sprint-108.json
+++ b/docs/retros/sprint-108.json
@@ -1,0 +1,75 @@
+{
+  "sprint_number": 108,
+  "player": "sebastianbryers",
+  "theme": "npm Publish Backfill Recovery",
+  "par": 3,
+  "slope": 1,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-05-21",
+  "shots": [
+    {
+      "ticket_key": "S108-1",
+      "title": "Add manual publish backfill path for failed npm release (#406)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [],
+      "notes": "Added workflow_dispatch to the npm publish workflow so the repaired workflow on main can publish a historical tag such as v1.55.12, restricted the manual input to release tag refs, and updated the npm publishing guide with the exact backfill command."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Rerunning a failed release workflow can reuse the workflow definition from the old tag commit.",
+      "outcome": "Backfill recovery now dispatches the repaired workflow from main while explicitly checking out the historical package ref."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Validated publish.yml YAML parsing, diff whitespace, TypeScript typecheck, and required security review.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Small but important release plumbing: the repo fix needed a way to apply itself to the already-published GitHub release tag.",
+    "advice_for_next_player": "For failed publish recovery, check both the current workflow and the workflow that exists on the failed release tag before choosing rerun vs workflow_dispatch.",
+    "what_surprised_you": "The v1.55.12 tag still contains the old token-based publish workflow, so a plain rerun would not exercise the trusted-publishing repair.",
+    "excited_about_next": "Once npm trusted publishing is configured, v1.55.12 can be published without moving the release tag."
+  },
+  "bunker_locations": [
+    "Creating a GitHub Release from a stale commit runs the workflow version at that commit, not HEAD.",
+    "Backfilling a failed package publish may need workflow_dispatch from main with an explicit historical checkout ref."
+  ],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Validation used ruby YAML parsing for .github/workflows/publish.yml.",
+    "Validation used git diff --check HEAD~1..HEAD.",
+    "Validation used pnpm run typecheck.",
+    "Required security review tightened the manual publish input from arbitrary refs to release tag refs only.",
+    "npm still reports @slope-dev/slope latest as 1.55.11 until the trusted publisher is configured and the manual backfill workflow is dispatched for v1.55.12."
+  ],
+  "slope_factors": [
+    "release",
+    "github_actions",
+    "npm"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a manual `workflow_dispatch` path to `publish.yml` so the repaired trusted-publishing workflow on `main` can publish a historical release tag.
- Restrict manual publishing to full release tag refs like `refs/tags/v1.55.12`, avoiding arbitrary branch/SHA publication.
- Update npm publishing docs with the exact v1.55.12 backfill command.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml'); puts 'yaml ok'"`
- `git diff --check HEAD~1..HEAD`
- `pnpm run typecheck`
- `slope validate docs/retros/sprint-108.json`
- Required security review completed; manual publish input tightened to release tag refs only.

Closes #406