### PR TITLE
Fix SLOPE issue batch and agent-DX recovery flows

### DIFF
--- a/docs/retros/sprint-109-review.md
+++ b/docs/retros/sprint-109-review.md
@@ -21,7 +21,7 @@
 | S109-2 | Wedge | In the Hole | - | Doctor now honors configured store_path and commonIssuesPath in linked worktrees, covering #422. |
 | S109-3 | Short Iron | Green | Rough: native SQLite imports happened too early for diagnostic status output. | Lazy-loaded better-sqlite3 and added structured recovery guidance to store status, covering #425. |
 | S109-4 | Wedge | In the Hole | - | Search output now marks direct MCP tools that are not available inside execute(), covering #424. |
-| S109-5 | Long Iron | Green | Rough: /var vs /private path normalization surfaced in macOS worktree tests. | Added persistent slope worktree start with linked config, session registration, and optional claims, covering #423. |
+| S109-5 | Long Iron | Green | Rough: /var vs /private path normalization surfaced in macOS worktree tests. Rough: initial git/gh process calls interpolated user-controlled branch/path values through the shell. | Added persistent slope worktree start with linked config, session registration, and optional claims, then replaced shell-built process calls with argument-vector execFileSync calls and a shell-metacharacter path regression test, covering #423. |
 | S109-6 | Short Iron | Green | - | Added stale workflow cleanup with dry-run support for completed or superseded sprint executions, covering #426. |
 
 ### Conditions
@@ -37,6 +37,7 @@ Known hazards for future sprints:
 
 - Fully gated sprint-state files can still exist locally after the sprint is effectively closed.
 - Linked worktrees must resolve shared state paths from config, not from literal default paths.
+- Worktree commands should pass user-controlled paths and branch names as process arguments, not interpolated shell strings.
 - Direct MCP tools should be labeled differently from execute() APIs in search output.
 - Native optional dependencies need lazy-load boundaries if status commands are expected to diagnose setup failures.
 
@@ -56,6 +57,7 @@ Known hazards for future sprints:
 
 - Focused ticket validation covered sprint-state, sprint-inference, next, session-briefing, doctor, store, MCP, worktree, workflow, and store backend suites.
 - Full validation passed with 211 test files and 3432 tests.
+- Security/code review caught shell interpolation in worktree process calls; affected worktree tests and typecheck passed after the fix.
 - pnpm run typecheck passed after the full issue batch.
 - pnpm run build passed after the native SQLite lazy-load change.
 - slope map --check reported the codebase map current.

--- a/docs/retros/sprint-109-review.md
+++ b/docs/retros/sprint-109-review.md
@@ -1,0 +1,68 @@
+## Sprint 109 Review: GitHub Issue Batch Triage and Agent-DX Hardening
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 5 |
+| Slope | 4 |
+| Score | 5 |
+| Label | Par |
+| Fairway % | 100% (6/6) |
+| GIR % | 100% (6/6) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 7 GitHub issues, 6 SLOPE shots)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S109-1 | Short Iron | Green | Rough: fully gated local sprint state could still override inferred roadmap/scorecard context. | Fixed the shared active-state check and routed session briefing through sprint inference, covering #420 and #421. |
+| S109-2 | Wedge | In the Hole | - | Doctor now honors configured store_path and commonIssuesPath in linked worktrees, covering #422. |
+| S109-3 | Short Iron | Green | Rough: native SQLite imports happened too early for diagnostic status output. | Lazy-loaded better-sqlite3 and added structured recovery guidance to store status, covering #425. |
+| S109-4 | Wedge | In the Hole | - | Search output now marks direct MCP tools that are not available inside execute(), covering #424. |
+| S109-5 | Long Iron | Green | Rough: /var vs /private path normalization surfaced in macOS worktree tests. | Added persistent slope worktree start with linked config, session registration, and optional claims, covering #423. |
+| S109-6 | Short Iron | Green | - | Added stale workflow cleanup with dry-run support for completed or superseded sprint executions, covering #426. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| rough | moderate | The batch crossed CLI inference, state guards, store backends, MCP registry output, worktree setup, workflow cleanup, and tests. |
+| wind | minor | Several issues were agent-DX bugs where the observed failure was one command but the fix belonged in shared plumbing. |
+
+### Hazards Discovered
+
+Known hazards for future sprints:
+
+- Fully gated sprint-state files can still exist locally after the sprint is effectively closed.
+- Linked worktrees must resolve shared state paths from config, not from literal default paths.
+- Direct MCP tools should be labeled differently from execute() APIs in search output.
+- Native optional dependencies need lazy-load boundaries if status commands are expected to diagnose setup failures.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Agent recovery flows need tests for stale local state, linked worktree config, and direct-vs-execute MCP boundaries. | Added focused regression tests around sprint inference, session briefing, doctor path resolution, native store status, MCP search metadata, worktree start, and stale workflow cleanup. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Focused ticket suites, full local suite, typecheck, build for the native-store slice, and map staleness check passed. |
+
+### Course Management Notes
+
+- Focused ticket validation covered sprint-state, sprint-inference, next, session-briefing, doctor, store, MCP, worktree, workflow, and store backend suites.
+- Full validation passed with 211 test files and 3432 tests.
+- pnpm run typecheck passed after the full issue batch.
+- pnpm run build passed after the native SQLite lazy-load change.
+- slope map --check reported the codebase map current.
+
+### 19th Hole
+
+- **How did it feel?** A proper agent-DX cleanup round: most shots were small on the surface, but each one protected a recovery path agents hit when context or environment gets weird.
+- **Advice for next player?** When a command reports stale context, check whether local state, roadmap inference, and scorecard closeout gates are all expressing the same lifecycle model.
+- **What surprised you?** The native SQLite issue was less about store status itself and more about when the CLI decided to load native modules.
+- **Excited about next?** The next batch of agent work should have clearer diagnostics, cleaner isolated worktree starts, and fewer stale workflow leftovers.

--- a/docs/retros/sprint-109.json
+++ b/docs/retros/sprint-109.json
@@ -1,0 +1,159 @@
+{
+  "sprint_number": 109,
+  "player": "codex",
+  "theme": "GitHub Issue Batch Triage and Agent-DX Hardening",
+  "par": 5,
+  "slope": 4,
+  "score": 5,
+  "score_label": "par",
+  "date": "2026-05-21",
+  "shots": [
+    {
+      "ticket_key": "S109-1",
+      "title": "Ignore fully closed sprint state when inferring the active sprint (#420, #421)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "A fully gated local sprint state could still look active enough to override the roadmap and latest scorecard context."
+        }
+      ],
+      "notes": "Added active-state detection that treats complete closeout gates as inactive, then routed session briefing through shared sprint inference so stale S1/S108 state no longer wins over the inferred current sprint."
+    },
+    {
+      "ticket_key": "S109-2",
+      "title": "Honor configured doctor state paths in linked worktrees (#422)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Made doctor resolve store_path and commonIssuesPath from config for both checks and --fix, so secondary worktrees using shared state no longer report missing literal local .slope paths."
+    },
+    {
+      "ticket_key": "S109-3",
+      "title": "Diagnose native SQLite setup failures without blocking status commands (#425)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Top-level better-sqlite3 imports meant even status-oriented store commands could fail before they had a chance to explain the native dependency problem."
+        }
+      ],
+      "notes": "Lazy-loaded native SQLite backends at database-open time and added structured store status recovery hints with reinstall, rebuild, and Node version guidance."
+    },
+    {
+      "ticket_key": "S109-4",
+      "title": "Mark direct MCP tools as unavailable inside execute() search results (#424)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added registry availability metadata and surfaced an MCP-tool marker in compact search output for store and testing tools that are direct MCP calls rather than execute() APIs."
+    },
+    {
+      "ticket_key": "S109-5",
+      "title": "Add a persistent worktree start command for isolated agent setup (#423)",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "macOS realpath normalization can expose /var and /private path spellings differently in worktree integration tests."
+        }
+      ],
+      "notes": "Added slope worktree start with branch/base/path/role/ide/target options, linked shared state paths back to the primary checkout, registered a secondary session, and optionally claimed a ticket or ownership area."
+    },
+    {
+      "ticket_key": "S109-6",
+      "title": "Add stale workflow cleanup for completed sprint executions (#426)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Added slope sprint workflow cleanup --stale with dry-run support, pausing running workflow executions only when their sprint has a scorecard or completed/superseded roadmap status."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 6,
+    "fairways_total": 6,
+    "greens_in_regulation": 6,
+    "greens_total": 6,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 3,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "issue batch + dx",
+  "conditions": [
+    {
+      "type": "rough",
+      "description": "The batch crossed CLI inference, state guards, store backends, MCP registry output, worktree setup, workflow cleanup, and tests.",
+      "impact": "moderate"
+    },
+    {
+      "type": "wind",
+      "description": "Several issues were agent-DX bugs where the observed failure was one command but the fix belonged in shared plumbing.",
+      "impact": "minor"
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Agent recovery flows need tests for stale local state, linked worktree config, and direct-vs-execute MCP boundaries.",
+      "outcome": "Added focused regression tests around sprint inference, session briefing, doctor path resolution, native store status, MCP search metadata, worktree start, and stale workflow cleanup."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Ran focused suites after each ticket, then ran the full local suite, typecheck, build for the native-store slice, and map staleness check.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A proper agent-DX cleanup round: most shots were small on the surface, but each one protected a recovery path agents hit when context or environment gets weird.",
+    "advice_for_next_player": "When a command reports stale context, check whether local state, roadmap inference, and scorecard closeout gates are all expressing the same lifecycle model.",
+    "what_surprised_you": "The native SQLite issue was less about store status itself and more about when the CLI decided to load native modules.",
+    "excited_about_next": "The next batch of agent work should have clearer diagnostics, cleaner isolated worktree starts, and fewer stale workflow leftovers."
+  },
+  "bunker_locations": [
+    "Fully gated sprint-state files can still exist locally after the sprint is effectively closed.",
+    "Linked worktrees must resolve shared state paths from config, not from literal default paths.",
+    "Direct MCP tools should be labeled differently from execute() APIs in search output.",
+    "Native optional dependencies need lazy-load boundaries if status commands are expected to diagnose setup failures."
+  ],
+  "yardage_book_updates": [
+    "src/cli/sprint-state.ts now exposes active-state detection that ignores complete closeout gate state.",
+    "src/cli/guards/session-briefing.ts now uses shared sprint inference for briefing context.",
+    "src/cli/commands/doctor.ts now resolves configured store and common-issues paths.",
+    "src/store/index.ts and src/store/sqlite-memory-backend.ts now lazy-load better-sqlite3.",
+    "src/cli/commands/store.ts now emits native SQLite recovery guidance in JSON status output.",
+    "src/mcp/registry.ts now records direct MCP-tool availability metadata.",
+    "src/cli/commands/worktree.ts now implements slope worktree start for persistent secondary worktrees.",
+    "src/cli/commands/sprint.ts now implements stale workflow cleanup."
+  ],
+  "course_management_notes": [
+    "Focused ticket validation covered sprint-state, sprint-inference, next, session-briefing, doctor, store, MCP, worktree, workflow, and store backend suites.",
+    "Full validation passed with 211 test files and 3432 tests.",
+    "pnpm run typecheck passed after the full issue batch.",
+    "pnpm run build passed after the native SQLite lazy-load change.",
+    "slope map --check reported the codebase map current."
+  ],
+  "slope_factors": [
+    "cli",
+    "state",
+    "mcp",
+    "worktrees",
+    "store",
+    "workflow"
+  ]
+}

--- a/docs/retros/sprint-109.json
+++ b/docs/retros/sprint-109.json
@@ -62,9 +62,14 @@
           "type": "rough",
           "severity": "minor",
           "description": "macOS realpath normalization can expose /var and /private path spellings differently in worktree integration tests."
+        },
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "The first worktree start implementation built git commands through the shell, which could interpret metacharacters in user-supplied paths or branch names."
         }
       ],
-      "notes": "Added slope worktree start with branch/base/path/role/ide/target options, linked shared state paths back to the primary checkout, registered a secondary session, and optionally claimed a ticket or ownership area."
+      "notes": "Added slope worktree start with branch/base/path/role/ide/target options, linked shared state paths back to the primary checkout, registered a secondary session, and optionally claimed a ticket or ownership area. Review replaced shell-built process calls with argument-vector execFileSync calls and added a shell-metacharacter path regression test."
     },
     {
       "ticket_key": "S109-6",
@@ -82,7 +87,7 @@
     "greens_total": 6,
     "putts": 0,
     "penalties": 0,
-    "hazards_hit": 3,
+    "hazards_hit": 4,
     "hazard_penalties": 0,
     "miss_directions": {
       "long": 0,
@@ -128,6 +133,7 @@
   "bunker_locations": [
     "Fully gated sprint-state files can still exist locally after the sprint is effectively closed.",
     "Linked worktrees must resolve shared state paths from config, not from literal default paths.",
+    "Worktree commands should pass user-controlled paths and branch names as process arguments, not interpolated shell strings.",
     "Direct MCP tools should be labeled differently from execute() APIs in search output.",
     "Native optional dependencies need lazy-load boundaries if status commands are expected to diagnose setup failures."
   ],
@@ -138,12 +144,13 @@
     "src/store/index.ts and src/store/sqlite-memory-backend.ts now lazy-load better-sqlite3.",
     "src/cli/commands/store.ts now emits native SQLite recovery guidance in JSON status output.",
     "src/mcp/registry.ts now records direct MCP-tool availability metadata.",
-    "src/cli/commands/worktree.ts now implements slope worktree start for persistent secondary worktrees.",
+    "src/cli/commands/worktree.ts now implements slope worktree start for persistent secondary worktrees and avoids shell interpolation for git/gh calls with user-controlled branch and path values.",
     "src/cli/commands/sprint.ts now implements stale workflow cleanup."
   ],
   "course_management_notes": [
     "Focused ticket validation covered sprint-state, sprint-inference, next, session-briefing, doctor, store, MCP, worktree, workflow, and store backend suites.",
     "Full validation passed with 211 test files and 3432 tests.",
+    "Security/code review caught shell interpolation in worktree process calls; affected worktree tests and typecheck passed after the fix.",
     "pnpm run typecheck passed after the full issue batch.",
     "pnpm run build passed after the native SQLite lazy-load change.",
     "slope map --check reported the codebase map current."

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -128,6 +128,25 @@ function checkConfig(cwd: string, originalCwd = cwd): DoctorCheck {
   }
 }
 
+function readSlopeConfig(cwd: string): Record<string, unknown> | null {
+  const configPath = join(cwd, '.slope', 'config.json');
+  if (!existsSync(configPath)) return null;
+  try {
+    return JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function configuredPath(cwd: string, key: string, fallback: string): { configured: string; path: string } {
+  const config = readSlopeConfig(cwd);
+  const raw = config?.[key];
+  const configured = typeof raw === 'string' && raw.trim()
+    ? raw
+    : fallback;
+  return { configured, path: resolve(cwd, configured) };
+}
+
 function checkGitignore(cwd: string): DoctorCheck {
   const gitignorePath = join(cwd, '.gitignore');
   if (!existsSync(gitignorePath)) {
@@ -184,19 +203,19 @@ function checkGitignoreNoise(cwd: string): DoctorCheck[] {
 }
 
 function checkStore(cwd: string, originalCwd = cwd): DoctorCheck {
-  const dbPath = join(cwd, '.slope', 'slope.db');
+  const { configured, path: dbPath } = configuredPath(cwd, 'store_path', '.slope/slope.db');
   if (!existsSync(dbPath)) {
-    return { name: 'store', status: 'warn', message: '.slope/slope.db missing — sessions and events will not be tracked', fixable: true };
+    return { name: 'store', status: 'warn', message: `${configured} missing — sessions and events will not be tracked`, fixable: true };
   }
-  return { name: 'store', status: 'ok', message: `.slope/slope.db exists${stateNote(cwd, originalCwd)}` };
+  return { name: 'store', status: 'ok', message: `${configured} exists${stateNote(cwd, originalCwd)}` };
 }
 
 function checkCommonIssues(cwd: string, originalCwd = cwd): DoctorCheck {
-  const path = join(cwd, '.slope', 'common-issues.json');
+  const { configured, path } = configuredPath(cwd, 'commonIssuesPath', '.slope/common-issues.json');
   if (!existsSync(path)) {
-    return { name: 'common-issues', status: 'warn', message: '.slope/common-issues.json missing', fixable: true };
+    return { name: 'common-issues', status: 'warn', message: `${configured} missing`, fixable: true };
   }
-  return { name: 'common-issues', status: 'ok', message: `.slope/common-issues.json exists${stateNote(cwd, originalCwd)}` };
+  return { name: 'common-issues', status: 'ok', message: `${configured} exists${stateNote(cwd, originalCwd)}` };
 }
 
 function checkRetrosDir(cwd: string): DoctorCheck {
@@ -797,18 +816,20 @@ export async function runDoctorFixes(cwd: string, checks: DoctorCheck[]): Promis
       case 'store': {
         try {
           const { createStore } = await import('../../store/index.js');
-          const store = createStore({ storePath: '.slope/slope.db', cwd });
+          const { configured: storePath } = configuredPath(cwd, 'store_path', '.slope/slope.db');
+          const store = createStore({ storePath, cwd });
           store.close();
-          fixed.push('Created .slope/slope.db');
+          fixed.push(`Created ${storePath}`);
         } catch (err) {
           console.error(`  Could not create store: ${(err as Error).message}`);
         }
         break;
       }
       case 'common-issues': {
-        mkdirSync(join(cwd, '.slope'), { recursive: true });
-        writeFileSync(join(cwd, '.slope', 'common-issues.json'), JSON.stringify({ recurring_patterns: [] }, null, 2) + '\n');
-        fixed.push('Created .slope/common-issues.json');
+        const { configured, path } = configuredPath(cwd, 'commonIssuesPath', '.slope/common-issues.json');
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, JSON.stringify({ recurring_patterns: [] }, null, 2) + '\n');
+        fixed.push(`Created ${configured}`);
         break;
       }
       case 'retros-dir': {

--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -13,8 +13,8 @@ import {
   type GateName,
   type SprintPhase,
 } from '../sprint-state.js';
-import { WorkflowEngine, loadWorkflow, resolveVariables, validateWorkflow, loadConfig } from '../../core/index.js';
-import type { WorkflowDefinition, WorkflowExecution } from '../../core/index.js';
+import { WorkflowEngine, loadWorkflow, resolveVariables, validateWorkflow, loadConfig, loadScorecards, parseRoadmap, castRoadmapStructure } from '../../core/index.js';
+import type { RoadmapSprint, WorkflowDefinition, WorkflowExecution } from '../../core/index.js';
 import { createHash } from 'node:crypto';
 
 /** Get workflow definition from execution snapshot (preferred) or disk (fallback for old executions) */
@@ -34,7 +34,7 @@ function getDefinition(exec: WorkflowExecution, cwd: string): { def: WorkflowDef
   // Fallback for old executions without snapshot
   return { def: loadWorkflow(exec.workflow_name, cwd), drifted: false };
 }
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { createStore } from '../../store/index.js';
 
@@ -532,6 +532,90 @@ async function workflowStatusCommand(args: string[], cwd: string): Promise<void>
   }
 }
 
+interface StaleWorkflowExecution {
+  exec: WorkflowExecution;
+  reason: string;
+}
+
+function completedRoadmapSprintIds(cwd: string, config: ReturnType<typeof loadConfig>): Set<number> {
+  if (!config.roadmapPath) return new Set();
+  const roadmapPath = join(cwd, config.roadmapPath);
+  if (!existsSync(roadmapPath)) return new Set();
+  try {
+    const raw = JSON.parse(readFileSync(roadmapPath, 'utf8'));
+    const parsed = parseRoadmap(raw);
+    const roadmap = parsed.roadmap ?? castRoadmapStructure(raw);
+    if (!roadmap) return new Set();
+    return new Set(
+      roadmap.sprints
+        .filter(sprint => {
+          const status = (sprint as RoadmapSprint & { status?: string }).status;
+          return status === 'complete' || status === 'superseded';
+        })
+        .map(sprint => sprint.id),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+async function findStaleWorkflowExecutions(cwd: string, store: ReturnType<typeof createStore>): Promise<StaleWorkflowExecution[]> {
+  const config = loadConfig(cwd);
+  const scorecardSprintIds = new Set(loadScorecards(config, cwd).map(card => card.sprint_number));
+  const roadmapDoneIds = completedRoadmapSprintIds(cwd, config);
+  const running = await store.listExecutions({ status: 'running' });
+  const stale: StaleWorkflowExecution[] = [];
+
+  for (const exec of running) {
+    const sprint = sprintNumberFromId(exec.sprint_id);
+    if (sprint === null) continue;
+    const reasons: string[] = [];
+    if (scorecardSprintIds.has(sprint)) reasons.push('scorecard exists');
+    if (roadmapDoneIds.has(sprint)) reasons.push('roadmap complete/superseded');
+    if (reasons.length > 0) {
+      stale.push({ exec, reason: reasons.join(', ') });
+    }
+  }
+
+  return stale;
+}
+
+async function workflowCleanupCommand(args: string[], cwd: string): Promise<void> {
+  const action = args[0];
+  const dryRun = args.includes('--dry-run');
+  const staleOnly = args.includes('--stale');
+
+  if (action !== 'cleanup' || !staleOnly) {
+    console.error('Usage: slope sprint workflow cleanup --stale [--dry-run]');
+    process.exit(1);
+  }
+
+  const store = getStore(cwd);
+  try {
+    const stale = await findStaleWorkflowExecutions(cwd, store);
+    if (stale.length === 0) {
+      console.log('No stale running workflow executions found.');
+      return;
+    }
+
+    const engine = new WorkflowEngine();
+    for (const { exec, reason } of stale) {
+      const label = exec.sprint_id ?? exec.id;
+      if (dryRun) {
+        console.log(`[dry-run] Would pause ${label} (${exec.workflow_name}) at ${exec.current_phase}/${exec.current_step} — ${reason}`);
+      } else {
+        await engine.pause(exec.id, store);
+        console.log(`Paused ${label} (${exec.workflow_name}) at ${exec.current_phase}/${exec.current_step} — ${reason}`);
+      }
+    }
+
+    const suffix = dryRun ? 'would be paused' : 'paused';
+    console.log(`\n${stale.length} stale workflow execution(s) ${suffix}.`);
+  } finally {
+    store.close();
+  }
+}
+
 function printExecution(exec: { id: string; workflow_name: string; sprint_id?: string; current_phase?: string; current_step?: string; status: string; completed_steps: unknown[]; started_at: string }): void {
   console.log(`  Execution: ${exec.id}`);
   console.log(`  Workflow:  ${exec.workflow_name}`);
@@ -834,6 +918,9 @@ export async function sprintCommand(args: string[]): Promise<void> {
     case 'run':
       await runWorkflowCommand(args.slice(1), cwd);
       break;
+    case 'workflow':
+      await workflowCleanupCommand(args.slice(1), cwd);
+      break;
     case 'resume':
       await resumeCommand(args.slice(1), cwd);
       break;
@@ -867,6 +954,7 @@ Workflow commands:
   slope sprint status [sprint_id]    Show workflow execution progress
   slope sprint resume <sprint_id>    Resume a paused workflow execution
   slope sprint pause <sprint_id>     Pause a running workflow execution
+  slope sprint workflow cleanup --stale [--dry-run]         Pause stale completed/superseded executions
   slope sprint skip <id> --step=<s> --reason="..."          Skip a blocking step
 `);
       if (sub) process.exit(1);

--- a/src/cli/commands/store.ts
+++ b/src/cli/commands/store.ts
@@ -1,8 +1,9 @@
-import { existsSync, copyFileSync } from 'node:fs';
+import { existsSync, copyFileSync, readFileSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
-import Database from 'better-sqlite3';
+import { createRequire } from 'node:module';
+import type DatabaseConstructor from 'better-sqlite3';
+import type { Database as DatabaseType } from 'better-sqlite3';
 import { resolveStore, getStoreInfo } from '../store.js';
-import { LATEST_SCHEMA_VERSION } from '../../store/index.js';
 
 function parseArgs(args: string[]): Record<string, string> {
   const result: Record<string, string> = {};
@@ -11,6 +12,63 @@ function parseArgs(args: string[]): Record<string, string> {
     if (match) result[match[1]] = match[2] ?? 'true';
   }
   return result;
+}
+
+function loadDatabaseConstructor(): typeof DatabaseConstructor {
+  const esmRequire = createRequire(import.meta.url);
+  return esmRequire('better-sqlite3') as typeof DatabaseConstructor;
+}
+
+function detectInstallCommand(cwd: string): string {
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm install';
+  if (existsSync(join(cwd, 'package-lock.json'))) return 'npm ci';
+  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn install';
+  if (existsSync(join(cwd, 'bun.lockb')) || existsSync(join(cwd, 'bun.lock'))) return 'bun install';
+  return 'npm install';
+}
+
+function detectExpectedNode(cwd: string): string | null {
+  for (const file of ['.nvmrc', '.node-version']) {
+    const path = join(cwd, file);
+    if (existsSync(path)) {
+      const version = readFileSync(path, 'utf8').trim();
+      if (version) return `${file} (${version})`;
+    }
+  }
+  const packagePath = join(cwd, 'package.json');
+  if (existsSync(packagePath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(packagePath, 'utf8')) as { engines?: { node?: unknown } };
+      if (typeof pkg.engines?.node === 'string' && pkg.engines.node.trim()) {
+        return `package.json engines.node (${pkg.engines.node})`;
+      }
+    } catch { /* ignore malformed package.json here */ }
+  }
+  return null;
+}
+
+function isNativeSqliteSetupError(message: string): boolean {
+  return /better[-_]sqlite3|better_sqlite3|NODE_MODULE_VERSION|ERR_DLOPEN_FAILED|compiled against a different Node\.js version|Cannot find module.*better-sqlite3/i.test(message);
+}
+
+export function storeRecoverySuggestions(message: string, cwd: string): string[] {
+  if (!isNativeSqliteSetupError(message)) return [];
+
+  const suggestions: string[] = [];
+  const installCommand = detectInstallCommand(cwd);
+  if (!existsSync(join(cwd, 'node_modules'))) {
+    suggestions.push(`Install this worktree's dependencies first: ${installCommand}.`);
+  } else {
+    suggestions.push(`Rebuild or reinstall native dependencies for the active Node version: ${installCommand}.`);
+  }
+
+  const expectedNode = detectExpectedNode(cwd);
+  if (expectedNode) {
+    suggestions.push(`Use the repo's expected Node version from ${expectedNode} before running SLOPE.`);
+  }
+
+  suggestions.push('In fresh parallel worktrees, prefer the worktree-local SLOPE binary after dependencies are installed.');
+  return suggestions;
 }
 
 export async function storeCommand(args: string[]): Promise<void> {
@@ -53,14 +111,22 @@ async function storeStatus(flags: Record<string, string>, cwd: string): Promise<
   try {
     store = await resolveStore(cwd);
   } catch (err) {
+    const message = (err as Error).message;
+    const recovery = storeRecoverySuggestions(message, cwd);
     if (jsonMode) {
-      console.log(JSON.stringify({ ...info, error: (err as Error).message }));
+      console.log(JSON.stringify({ ...info, error: message, ...(recovery.length > 0 ? { recovery } : {}) }));
     } else {
       console.log(`\nStore type:     ${info.type}`);
       if (info.path) console.log(`Path:           ${info.path}`);
       if (info.sanitizedUrl) console.log(`URL:            ${info.sanitizedUrl}`);
       if (info.projectId) console.log(`Project ID:     ${info.projectId}`);
-      console.log(`Status:         ERROR — ${(err as Error).message}`);
+      console.log(`Status:         ERROR — ${message}`);
+      if (recovery.length > 0) {
+        console.log(`Recovery:`);
+        for (const suggestion of recovery) {
+          console.log(`  - ${suggestion}`);
+        }
+      }
     }
     return;
   }
@@ -109,6 +175,7 @@ Usage:
   const store = await resolveStore(cwd);
   try {
     const version = await store.getSchemaVersion();
+    const { LATEST_SCHEMA_VERSION } = await import('../../store/index.js');
     console.log(`\nCurrent schema version: ${version}`);
     console.log(`Total migrations:       ${LATEST_SCHEMA_VERSION}`);
     if (version >= LATEST_SCHEMA_VERSION) {
@@ -157,8 +224,9 @@ async function backupStore(flags: Record<string, string>, cwd: string): Promise<
   }
 
   // Checkpoint WAL to flush pending writes before copying
-  let db: ReturnType<typeof Database>;
+  let db: DatabaseType;
   try {
+    const Database = loadDatabaseConstructor();
     db = new Database(dbPath);
   } catch (err) {
     console.error(`Error: Cannot open database for backup: ${(err as Error).message}`);
@@ -204,6 +272,7 @@ async function restoreStore(flags: Record<string, string>, cwd: string): Promise
 
   // Validate the backup file is a valid SLOPE database
   try {
+    const Database = loadDatabaseConstructor();
     const db = new Database(fromPath, { readonly: true });
     let validationError: string | null = null;
     try {

--- a/src/cli/commands/worktree.ts
+++ b/src/cli/commands/worktree.ts
@@ -3,7 +3,7 @@
 //   slope worktree start --branch=<name> [--base=<ref>] [--path=<path>] [--role=secondary] [--ide=<id>] [--target=<claim>]
 //   slope worktree cleanup [--path=<path>] [--all] [--dry-run]
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
@@ -61,8 +61,8 @@ function parseFlagArgs(args: string[]): { flags: Record<string, string>; boolean
   return { flags, booleans };
 }
 
-function shellQuote(value: string): string {
-  return JSON.stringify(value);
+function formatShellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function branchSlug(branch: string): string {
@@ -111,13 +111,13 @@ function isInsideWorktree(cwd: string): boolean {
   }
 }
 
-function gitOutput(cwd: string, command: string): string {
-  return execSync(command, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+function gitOutput(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
 }
 
 function findProjectRoot(cwd: string): string {
   try {
-    return gitOutput(cwd, 'git rev-parse --show-toplevel');
+    return gitOutput(cwd, ['rev-parse', '--show-toplevel']);
   } catch {
     return cwd;
   }
@@ -125,12 +125,12 @@ function findProjectRoot(cwd: string): string {
 
 function resolveDefaultBase(projectRoot: string): string {
   try {
-    const head = gitOutput(projectRoot, 'git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null');
+    const head = gitOutput(projectRoot, ['symbolic-ref', 'refs/remotes/origin/HEAD']);
     if (head) return head.replace('refs/remotes/', '');
   } catch { /* try fallbacks */ }
   for (const ref of ['origin/main', 'main', 'HEAD']) {
     try {
-      execSync(`git rev-parse --verify ${shellQuote(ref)} 2>/dev/null`, { cwd: projectRoot, stdio: 'ignore' });
+      execFileSync('git', ['rev-parse', '--verify', ref], { cwd: projectRoot, stdio: 'ignore' });
       return ref;
     } catch { /* try next */ }
   }
@@ -186,14 +186,14 @@ async function startCommand(args: string[]): Promise<void> {
 
   const dryRun = booleans.has('dry-run');
   if (dryRun) {
-    console.log(`[dry-run] git worktree add ${shellQuote(worktreePath)} -b ${shellQuote(branch)} ${shellQuote(base)}`);
+    console.log(`[dry-run] git worktree add ${formatShellArg(worktreePath)} -b ${formatShellArg(branch)} ${formatShellArg(base)}`);
     console.log(`[dry-run] register session role=${flags.role ?? 'secondary'} ide=${flags.ide ?? process.env.SLOPE_IDE ?? 'unknown'} branch=${branch}`);
     if (flags.target) console.log(`[dry-run] claim ${flags.target} (${flags.scope ?? 'ticket'})`);
     return;
   }
 
   mkdirSync(dirname(worktreePath), { recursive: true });
-  execSync(`git worktree add ${shellQuote(worktreePath)} -b ${shellQuote(branch)} ${shellQuote(base)}`, {
+  execFileSync('git', ['worktree', 'add', worktreePath, '-b', branch, base], {
     cwd: projectRoot,
     stdio: 'pipe',
   });
@@ -255,7 +255,7 @@ async function startCommand(args: string[]): Promise<void> {
     if (linkedConfig) console.log(`  Config:  linked .slope/config.json to primary state paths`);
     if (claim) console.log(`  Claim:   ${claim.target} (${claim.scope}) sprint ${claim.sprint_number}`);
     console.log(`\nNext:`);
-    console.log(`  cd ${shellQuote(worktreePath)}`);
+    console.log(`  cd ${formatShellArg(worktreePath)}`);
     console.log('');
   } finally {
     store.close();
@@ -265,7 +265,7 @@ async function startCommand(args: string[]): Promise<void> {
 /** Check if gh CLI is available */
 function hasGhCli(): boolean {
   try {
-    execSync('gh --version', { encoding: 'utf8', stdio: 'pipe' });
+    execFileSync('gh', ['--version'], { encoding: 'utf8', stdio: 'pipe' });
     return true;
   } catch {
     return false;
@@ -275,8 +275,9 @@ function hasGhCli(): boolean {
 /** Check if a branch's PR is merged */
 function isPrMerged(branch: string): boolean {
   try {
-    const result = execSync(
-      `gh pr list --head "${branch}" --state merged --json url --limit 1`,
+    const result = execFileSync(
+      'gh',
+      ['pr', 'list', '--head', branch, '--state', 'merged', '--json', 'url', '--limit', '1'],
       { encoding: 'utf8', stdio: 'pipe' },
     );
     const prs = JSON.parse(result);
@@ -308,7 +309,7 @@ function cleanupWorktree(wt: WorktreeInfo, dryRun: boolean, ghAvailable: boolean
 
   // Remove worktree
   try {
-    execSync(`git worktree remove "${wt.path}" --force`, { encoding: 'utf8', stdio: 'pipe' });
+    execFileSync('git', ['worktree', 'remove', wt.path, '--force'], { encoding: 'utf8', stdio: 'pipe' });
     console.log(`  Removed worktree: ${wt.path}`);
   } catch (err) {
     console.error(`  Error removing worktree ${wt.path}: ${(err as Error).message}`);
@@ -318,13 +319,13 @@ function cleanupWorktree(wt: WorktreeInfo, dryRun: boolean, ghAvailable: boolean
   // Delete local branch
   if (branch) {
     try {
-      execSync(`git branch -d "${branch}"`, { encoding: 'utf8', stdio: 'pipe' });
+      execFileSync('git', ['branch', '-d', branch], { encoding: 'utf8', stdio: 'pipe' });
       console.log(`  Deleted branch: ${branch}`);
     } catch { /* branch already deleted or not fully merged — ignore */ }
 
     // Delete remote branch
     try {
-      execSync(`git push origin --delete "${branch}"`, { encoding: 'utf8', stdio: 'pipe' });
+      execFileSync('git', ['push', 'origin', '--delete', branch], { encoding: 'utf8', stdio: 'pipe' });
       console.log(`  Deleted remote branch: origin/${branch}`);
     } catch { /* remote branch already gone — ignore */ }
   }

--- a/src/cli/commands/worktree.ts
+++ b/src/cli/commands/worktree.ts
@@ -1,7 +1,18 @@
-// slope worktree cleanup — Clean up stale git worktrees
-// Usage: slope worktree cleanup [--path=<path>] [--all] [--dry-run]
+// slope worktree — Manage persistent git worktrees
+// Usage:
+//   slope worktree start --branch=<name> [--base=<ref>] [--path=<path>] [--role=secondary] [--ide=<id>] [--target=<claim>]
+//   slope worktree cleanup [--path=<path>] [--all] [--dry-run]
 
 import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { checkConflicts } from '../../core/index.js';
+import { STALE_SESSION_THRESHOLD_MS } from '../../core/constants.js';
+import type { ClaimScope, SprintClaim } from '../../core/index.js';
+import { loadConfig } from '../config.js';
+import { inferSprintContext } from '../sprint-inference.js';
+import { resolveStore } from '../store.js';
 
 interface WorktreeInfo {
   path: string;
@@ -33,6 +44,29 @@ function parseArgs(args: string[]): {
   }
 
   return { subcommand, targetPath, all, dryRun };
+}
+
+function parseFlagArgs(args: string[]): { flags: Record<string, string>; booleans: Set<string> } {
+  const flags: Record<string, string> = {};
+  const booleans = new Set<string>();
+  for (const arg of args) {
+    const match = arg.match(/^--([\w-]+)(?:=(.+))?$/);
+    if (!match) continue;
+    if (match[2] === undefined) {
+      booleans.add(match[1]);
+    } else {
+      flags[match[1]] = match[2];
+    }
+  }
+  return { flags, booleans };
+}
+
+function shellQuote(value: string): string {
+  return JSON.stringify(value);
+}
+
+function branchSlug(branch: string): string {
+  return branch.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'worktree';
 }
 
 /** Parse `git worktree list --porcelain` output */
@@ -74,6 +108,157 @@ function isInsideWorktree(cwd: string): boolean {
     return gitDir !== commonDir && gitDir !== '.git';
   } catch {
     return false;
+  }
+}
+
+function gitOutput(cwd: string, command: string): string {
+  return execSync(command, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function findProjectRoot(cwd: string): string {
+  try {
+    return gitOutput(cwd, 'git rev-parse --show-toplevel');
+  } catch {
+    return cwd;
+  }
+}
+
+function resolveDefaultBase(projectRoot: string): string {
+  try {
+    const head = gitOutput(projectRoot, 'git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null');
+    if (head) return head.replace('refs/remotes/', '');
+  } catch { /* try fallbacks */ }
+  for (const ref of ['origin/main', 'main', 'HEAD']) {
+    try {
+      execSync(`git rev-parse --verify ${shellQuote(ref)} 2>/dev/null`, { cwd: projectRoot, stdio: 'ignore' });
+      return ref;
+    } catch { /* try next */ }
+  }
+  return 'HEAD';
+}
+
+function writeLinkedSlopeConfig(projectRoot: string, worktreePath: string): boolean {
+  const sourceConfigPath = join(projectRoot, '.slope', 'config.json');
+  if (!existsSync(sourceConfigPath)) return false;
+
+  const config = JSON.parse(readFileSync(sourceConfigPath, 'utf8')) as Record<string, unknown>;
+  const statePaths: Array<[string, string]> = [
+    ['store_path', '.slope/slope.db'],
+    ['commonIssuesPath', '.slope/common-issues.json'],
+  ];
+  for (const [key, fallback] of statePaths) {
+    const raw = config[key];
+    const configured = typeof raw === 'string' && raw.trim()
+      ? raw
+      : fallback;
+    const absoluteStatePath = resolve(projectRoot, configured);
+    config[key] = relative(worktreePath, absoluteStatePath);
+  }
+
+  const targetConfigPath = join(worktreePath, '.slope', 'config.json');
+  mkdirSync(dirname(targetConfigPath), { recursive: true });
+  writeFileSync(targetConfigPath, JSON.stringify(config, null, 2) + '\n');
+  return true;
+}
+
+async function startCommand(args: string[]): Promise<void> {
+  const { flags, booleans } = parseFlagArgs(args);
+  const cwd = process.cwd();
+  const projectRoot = findProjectRoot(cwd);
+
+  if (isInsideWorktree(cwd)) {
+    console.error('Error: Already inside a secondary worktree. Start new worktrees from the primary checkout.');
+    process.exit(1);
+  }
+
+  const branch = flags.branch;
+  if (!branch) {
+    console.error('Error: --branch=<name> is required');
+    process.exit(1);
+  }
+
+  const base = flags.base ?? resolveDefaultBase(projectRoot);
+  const worktreePath = resolve(projectRoot, flags.path ?? join('.slope', 'worktrees', branchSlug(branch)));
+  if (existsSync(worktreePath)) {
+    console.error(`Error: Worktree path already exists: ${worktreePath}`);
+    process.exit(1);
+  }
+
+  const dryRun = booleans.has('dry-run');
+  if (dryRun) {
+    console.log(`[dry-run] git worktree add ${shellQuote(worktreePath)} -b ${shellQuote(branch)} ${shellQuote(base)}`);
+    console.log(`[dry-run] register session role=${flags.role ?? 'secondary'} ide=${flags.ide ?? process.env.SLOPE_IDE ?? 'unknown'} branch=${branch}`);
+    if (flags.target) console.log(`[dry-run] claim ${flags.target} (${flags.scope ?? 'ticket'})`);
+    return;
+  }
+
+  mkdirSync(dirname(worktreePath), { recursive: true });
+  execSync(`git worktree add ${shellQuote(worktreePath)} -b ${shellQuote(branch)} ${shellQuote(base)}`, {
+    cwd: projectRoot,
+    stdio: 'pipe',
+  });
+  const linkedConfig = writeLinkedSlopeConfig(projectRoot, worktreePath);
+
+  const store = await resolveStore(projectRoot);
+  try {
+    await store.cleanStaleSessions(STALE_SESSION_THRESHOLD_MS);
+    const sessionId = flags['session-id'] || randomUUID();
+    const role = (flags.role ?? 'secondary') as 'primary' | 'secondary' | 'observer';
+    const ide = flags.ide ?? process.env.SLOPE_IDE ?? 'unknown';
+    const session = await store.registerSession({
+      session_id: sessionId,
+      role,
+      ide,
+      branch,
+      worktree_path: worktreePath,
+    });
+
+    let claim: SprintClaim | null = null;
+    if (flags.target) {
+      const config = loadConfig(projectRoot);
+      const sprintNumber = flags.sprint ? parseInt(flags.sprint, 10) : inferSprintContext(projectRoot, config).sprint;
+      const scope = (flags.scope ?? 'ticket') as ClaimScope;
+      const player = flags.player || process.env.USER || 'unknown';
+      const pendingClaim: SprintClaim = {
+        id: '__pending__',
+        sprint_number: sprintNumber,
+        player,
+        target: flags.target,
+        scope,
+        claimed_at: new Date().toISOString(),
+        session_id: session.session_id,
+        ...(flags.notes ? { notes: flags.notes } : {}),
+      };
+      const conflicts = checkConflicts([...(await store.list(sprintNumber)), pendingClaim]);
+      const overlaps = conflicts.filter(c => c.severity === 'overlap');
+      if (overlaps.length > 0 && !booleans.has('force')) {
+        console.error(`\nClaim blocked — overlap conflict(s) detected:`);
+        for (const c of overlaps) console.error(`  [!!] ${c.reason}`);
+        console.error(`\nWorktree and session were created. Re-run claim with --force if this overlap is intentional.`);
+      } else {
+        claim = await store.claim({
+          sprint_number: sprintNumber,
+          player,
+          target: flags.target,
+          scope,
+          session_id: session.session_id,
+          ...(flags.notes ? { notes: flags.notes } : {}),
+        });
+      }
+    }
+
+    console.log(`\nWorktree started:`);
+    console.log(`  Path:    ${worktreePath}`);
+    console.log(`  Branch:  ${branch}`);
+    console.log(`  Base:    ${base}`);
+    console.log(`  Session: ${session.session_id} [${session.role}] ${session.ide}`);
+    if (linkedConfig) console.log(`  Config:  linked .slope/config.json to primary state paths`);
+    if (claim) console.log(`  Claim:   ${claim.target} (${claim.scope}) sprint ${claim.sprint_number}`);
+    console.log(`\nNext:`);
+    console.log(`  cd ${shellQuote(worktreePath)}`);
+    console.log('');
+  } finally {
+    store.close();
   }
 }
 
@@ -219,6 +404,10 @@ async function cleanupCommand(args: string[]): Promise<void> {
 export async function worktreeCommand(args: string[]): Promise<void> {
   const sub = args[0];
 
+  if (sub === 'start') {
+    return startCommand(args.slice(1));
+  }
+
   if (sub === 'cleanup') {
     return cleanupCommand(args.slice(1));
   }
@@ -228,9 +417,22 @@ export async function worktreeCommand(args: string[]): Promise<void> {
 slope worktree — Manage git worktrees
 
 Usage:
+  slope worktree start --branch=<name> [--base=<ref>] [--path=<path>] [--role=secondary] [--ide=<id>] [--target=<claim>]
   slope worktree cleanup [--path=<path>] [--all] [--dry-run]
 
 Options:
+  start:
+    --branch=<name>      New branch name for the worktree
+    --base=<ref>         Base ref (default: origin default branch, main, or HEAD)
+    --path=<path>        Worktree path (default: .slope/worktrees/<branch>)
+    --role=<role>        Session role: primary, secondary, observer (default: secondary)
+    --ide=<id>           IDE/harness id (default: SLOPE_IDE or unknown)
+    --target=<claim>     Optional ticket or area claim to register
+    --scope=<scope>      Claim scope: ticket or area (default: ticket)
+    --sprint=<number>    Sprint number for optional claim
+    --dry-run            Preview worktree/session/claim actions
+
+  cleanup:
   --path=<path>  Target a specific worktree
   --all          Clean up all secondary worktrees
   --dry-run      Preview what would happen without making changes

--- a/src/cli/guards/session-briefing.ts
+++ b/src/cli/guards/session-briefing.ts
@@ -1,8 +1,9 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { HookInput, GuardResult, Suggestion } from '../../core/index.js';
-import { loadConfig, parseRoadmap, formatStrategicContext } from '../../core/index.js';
-import { loadSprintState } from '../sprint-state.js';
+import { loadConfig, parseRoadmap, castRoadmapStructure, formatStrategicContext } from '../../core/index.js';
+import { inferSprintContext } from '../sprint-inference.js';
+import { isActiveSprintState, loadSprintState } from '../sprint-state.js';
 import { loadSessionState, updateSessionState, setSessionMode, syncSessionModeWithSprintState } from '../session-state.js';
 
 /**
@@ -30,7 +31,7 @@ export async function sessionBriefingGuard(input: HookInput, cwd: string): Promi
   const lines: string[] = [];
 
   // Sprint state + session mode
-  const hasActiveSprint = sprintState && (sprintState.phase === 'implementing' || sprintState.phase === 'scoring');
+  const hasActiveSprint = isActiveSprintState(sprintState) && (sprintState.phase === 'implementing' || sprintState.phase === 'scoring');
   const isPlanning = sprintState && sprintState.phase === 'planning';
   if (hasActiveSprint) {
     setSessionMode(cwd, sessionId, 'sprint');
@@ -68,10 +69,13 @@ export async function sessionBriefingGuard(input: HookInput, cwd: string): Promi
       const roadmapFile = join(cwd, config.roadmapPath);
       if (existsSync(roadmapFile)) {
         const raw = JSON.parse(readFileSync(roadmapFile, 'utf8'));
-        const { roadmap } = parseRoadmap(raw);
+        const parsed = parseRoadmap(raw);
+        const roadmap = parsed.roadmap ?? castRoadmapStructure(raw);
         if (roadmap) {
-          const nextSprint = sprintState ? sprintState.sprint : 1;
-          const ctx = formatStrategicContext(roadmap, nextSprint);
+          const inferred = inferSprintContext(cwd, config);
+          const ctx = inferred.source === 'initial'
+            ? null
+            : formatStrategicContext(roadmap, inferred.sprint);
           if (ctx) lines.push(ctx);
         }
       }

--- a/src/cli/guards/worktree-check.ts
+++ b/src/cli/guards/worktree-check.ts
@@ -116,7 +116,7 @@ export async function worktreeCheckGuard(input: HookInput, cwd: string): Promise
       // Do NOT write sentinel — denied sessions should re-check next invocation
       return {
         decision: 'deny',
-        blockReason: `BLOCKED: Another session is active in this directory:\n${sessionList}\n\nYou MUST use \`EnterWorktree\` to create an isolated working copy before proceeding. Do not attempt any other tool calls until you are in a worktree.`,
+        blockReason: `BLOCKED: Another session is active in this directory:\n${sessionList}\n\nYou MUST use \`EnterWorktree\` to create an isolated working copy before proceeding. If this harness does not expose EnterWorktree, run \`slope worktree start --branch=<branch> --role=secondary --ide=<ide>\` from the primary checkout. Do not attempt implementation work until you are in a worktree.`,
       };
     }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -519,7 +519,7 @@ Usage:
   slope stats export [--pretty]                      Export stats JSON for slope-web
   slope docs generate|changelog|check                Documentation manifest and changelog
   slope sprint start|gate|status|reset               Manage sprint lifecycle state
-  slope worktree cleanup [--path|--all] [--dry-run]  Clean up stale worktrees
+  slope worktree start|cleanup [options]             Manage persistent worktrees
   slope loop status|config|run|continuous|...        Autonomous sprint execution loop
   slope doctor [--fix] [--dry-run]                   Check repo health and fix issues
   slope version                                      Show current version

--- a/src/cli/sprint-state.ts
+++ b/src/cli/sprint-state.ts
@@ -60,7 +60,7 @@ export function loadSprintState(cwd: string): SprintState | null {
 
 /** True when sprint-state represents an active workflow sprint. */
 export function isActiveSprintState(state: SprintState | null): state is SprintState {
-  return Boolean(state && state.phase !== 'complete');
+  return Boolean(state && state.phase !== 'complete' && !isSprintComplete(state));
 }
 
 function sprintStatePath(cwd: string): string {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -26,6 +26,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import { SLOPE_REGISTRY, SLOPE_TYPES } from './registry.js';
+import type { FunctionRegistryEntry } from './registry.js';
 import { runInSandbox } from './sandbox.js';
 import type { SlopeStore, SlopeConfig } from '../core/index.js';
 import { checkConflicts, loadFlows, checkFlowStaleness, checkStoreHealth, METAPHOR_SCHEMA, listMetaphors, buildInterviewContext, generateInterviewSteps, loadConfig, parseTestPlan, getAreasNeedingTest, hasEmbeddingSupport, embed, deduplicateByFile, formatContextForAgent, WorkflowEngine, loadWorkflow, listWorkflows, resolveVariables } from '../core/index.js';
@@ -114,6 +115,20 @@ export function buildSetupHint(hints: SetupHints): string | null {
   );
 }
 
+export function formatSearchResults(results: FunctionRegistryEntry[], useCompact: boolean): string {
+  if (useCompact) {
+    const compactResults = results.map(e => {
+      const availability = e.availability === 'mcp_tool'
+        ? ' [MCP tool; not available in execute()]'
+        : '';
+      return `${e.module}/${e.name}${availability}: ${e.description}`;
+    });
+    return `SLOPE API (${results.length} functions):\n${compactResults.join('\n')}\n\nUse search({ query: "name" }) or search({ module: "core", compact: false }) for full signatures and examples.`;
+  }
+
+  return JSON.stringify(results, null, 2);
+}
+
 export function createSlopeToolsServer(store?: SlopeStore, setupHints?: SetupHints, storeType?: string, config?: SlopeConfig): McpServer {
   const server = new McpServer({
     name: 'slope-tools',
@@ -161,13 +176,7 @@ export function createSlopeToolsServer(store?: SlopeStore, setupHints?: SetupHin
 
       // Compact mode: name + module + description only (default for unfiltered discovery)
       const useCompact = compact ?? (!query && !module);
-      let outputText: string;
-      if (useCompact) {
-        const compactResults = results.map(e => `${e.module}/${e.name}: ${e.description}`);
-        outputText = `SLOPE API (${results.length} functions):\n${compactResults.join('\n')}\n\nUse search({ query: "name" }) or search({ module: "core", compact: false }) for full signatures and examples.`;
-      } else {
-        outputText = JSON.stringify(results, null, 2);
-      }
+      const outputText = formatSearchResults(results, useCompact);
 
       const content: Array<{ type: 'text'; text: string }> = [
         { type: 'text' as const, text: outputText },

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -8,6 +8,7 @@ export interface FunctionRegistryEntry {
   description: string;
   signature: string;
   example: string;
+  availability?: 'execute' | 'mcp_tool';
 }
 
 export const SLOPE_REGISTRY: FunctionRegistryEntry[] = [
@@ -601,37 +602,42 @@ export const SLOPE_REGISTRY: FunctionRegistryEntry[] = [
   {
     name: 'session_status',
     module: 'store',
-    description: 'MCP tool: Returns active sessions and claims from the SlopeStore.',
+    description: 'Direct MCP tool: Returns active sessions and claims from the SlopeStore. Not available inside execute().',
     signature: 'session_status(): { sessions: SlopeSession[]; claims: SprintClaim[] }',
     example: '// Called via MCP tool, not directly',
+    availability: 'mcp_tool',
   },
   {
     name: 'acquire_claim',
     module: 'store',
-    description: 'MCP tool: Claims a ticket or area for the current sprint via SlopeStore.',
+    description: 'Direct MCP tool: Claims a ticket or area for the current sprint via SlopeStore. Not available inside execute().',
     signature: 'acquire_claim(sessionId: string, target: string, scope: ClaimScope, sprintNumber: number, player: string): SprintClaim',
     example: '// Called via MCP tool, not directly',
+    availability: 'mcp_tool',
   },
   {
     name: 'check_conflicts',
     module: 'store',
-    description: 'MCP tool: Detects overlapping and adjacent conflicts among active claims.',
+    description: 'Direct MCP tool: Detects overlapping and adjacent conflicts among active claims. Not available inside execute().',
     signature: 'check_conflicts(sprintNumber?: number): { claims: number; conflicts: SprintConflict[] }',
     example: '// Called via MCP tool, not directly',
+    availability: 'mcp_tool',
   },
   {
     name: 'store_status',
     module: 'store',
-    description: 'MCP tool: Check store health — schema version, row counts, and error status.',
+    description: 'Direct MCP tool: Check store health — schema version, row counts, and error status. Not available inside execute().',
     signature: 'store_status(): StoreHealthResult',
     example: '// Called via MCP tool, not directly',
+    availability: 'mcp_tool',
   },
   {
     name: 'context_search',
     module: 'store',
-    description: 'MCP tool: Semantic code search — returns relevant snippets instead of full files. Falls back to grep when no embedding index exists.',
+    description: 'Direct MCP tool: Semantic code search — returns relevant snippets instead of full files. Falls back to grep when no embedding index exists. Not available inside execute().',
     signature: 'context_search(query: string, top?: number, format?: "paths" | "snippets"): { text: string }',
     example: '// Called via MCP tool: context_search({ query: "guard system" })',
+    availability: 'mcp_tool',
   },
 
   // ─── Transcript ───
@@ -893,37 +899,42 @@ export const SLOPE_REGISTRY: FunctionRegistryEntry[] = [
   {
     name: 'testing_session_start',
     module: 'testing',
-    description: 'Start a manual testing session. Creates a git worktree, returns setup steps from config. One active session at a time.',
+    description: 'Direct MCP tool: Start a manual testing session. Creates a git worktree, returns setup steps from config. One active session at a time. Not available inside execute().',
     signature: 'testing_session_start({ purpose?: string, sprint?: number })',
     example: 'Call via MCP: testing_session_start({ purpose: "Test checkout flow" })',
+    availability: 'mcp_tool',
   },
   {
     name: 'testing_session_finding',
     module: 'testing',
-    description: 'Record a finding (bug, observation) during an active testing session.',
+    description: 'Direct MCP tool: Record a finding (bug, observation) during an active testing session. Not available inside execute().',
     signature: 'testing_session_finding({ description: string, severity?: "low"|"medium"|"high"|"critical", ticket?: string })',
     example: 'Call via MCP: testing_session_finding({ description: "Button unresponsive on mobile", severity: "high" })',
+    availability: 'mcp_tool',
   },
   {
     name: 'testing_session_end',
     module: 'testing',
-    description: 'End the active testing session. Returns summary of findings and cleans up worktree. Run teardown steps BEFORE calling this.',
+    description: 'Direct MCP tool: End the active testing session. Returns summary of findings and cleans up worktree. Run teardown steps BEFORE calling this. Not available inside execute().',
     signature: 'testing_session_end({ session_id?: string, skip_cleanup?: boolean })',
     example: 'Call via MCP: testing_session_end()',
+    availability: 'mcp_tool',
   },
   {
     name: 'testing_session_status',
     module: 'testing',
-    description: 'Show active testing session info and findings, or indicate no active session.',
+    description: 'Direct MCP tool: Show active testing session info and findings, or indicate no active session. Not available inside execute().',
     signature: 'testing_session_status()',
     example: 'Call via MCP: testing_session_status()',
+    availability: 'mcp_tool',
   },
   {
     name: 'testing_plan_status',
     module: 'testing',
-    description: 'Show test plan coverage summary: tested, untested, stale, and issue counts per section. Reads the markdown test plan configured in .slope/config.json testing.testPlanPath.',
+    description: 'Direct MCP tool: Show test plan coverage summary: tested, untested, stale, and issue counts per section. Reads the markdown test plan configured in .slope/config.json testing.testPlanPath. Not available inside execute().',
     signature: 'testing_plan_status()',
     example: 'Call via MCP: testing_plan_status()',
+    availability: 'mcp_tool',
   },
   // ─── Workflow Engine ───
   {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { createRequire } from 'node:module';
-import Database from 'better-sqlite3';
+import type DatabaseConstructor from 'better-sqlite3';
 import type { Database as DatabaseType } from 'better-sqlite3';
 import type { SprintClaim, GolfScorecard, SlopeEvent, EventType, WorkflowExecution, WorkflowStepResult, CompletedStep } from '../core/index.js';
 import type { CommonIssuesFile, StoreStats } from '../core/index.js';
@@ -19,6 +19,11 @@ function generateId(prefix: string): string {
 
 function nowISO(): string {
   return new Date().toISOString();
+}
+
+function loadDatabaseConstructor(): typeof DatabaseConstructor {
+  const esmRequire = createRequire(import.meta.url);
+  return esmRequire('better-sqlite3') as typeof DatabaseConstructor;
 }
 
 /** Sequential schema migrations — each runs exactly once */
@@ -219,6 +224,7 @@ export class SqliteSlopeStore implements SlopeStore, EmbeddingStore {
 
   constructor(dbPath: string) {
     mkdirSync(dirname(dbPath), { recursive: true });
+    const Database = loadDatabaseConstructor();
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('foreign_keys = ON');

--- a/src/store/sqlite-memory-backend.ts
+++ b/src/store/sqlite-memory-backend.ts
@@ -13,13 +13,19 @@
 
 import { existsSync, renameSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import Database from 'better-sqlite3';
+import { createRequire } from 'node:module';
+import type DatabaseConstructor from 'better-sqlite3';
 import type { Database as DatabaseType } from 'better-sqlite3';
 import type { MemoryBackend } from '../core/memory-backend.js';
 import type { Memory, MemoriesFile, MemoryCategory, MemorySource } from '../core/memory-types.js';
 import { validateMemoryRow } from '../core/memory-validation.js';
 
 const CURRENT_VERSION = 1;
+
+function loadDatabaseConstructor(): typeof DatabaseConstructor {
+  const esmRequire = createRequire(import.meta.url);
+  return esmRequire('better-sqlite3') as typeof DatabaseConstructor;
+}
 
 interface MemoryRow {
   id: string;
@@ -55,6 +61,7 @@ export class SqliteMemoryBackend implements MemoryBackend {
 
   constructor(cwd: string, dbPath: string) {
     this.cwd = cwd;
+    const Database = loadDatabaseConstructor();
     this.db = new Database(dbPath);
     this.ensureSchema();
     this.importJsonIfPresent();

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { chmodSync, mkdirSync, writeFileSync, rmSync, readFileSync, utimesSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import { doctorCommand, runDoctorChecks, runDoctorFixes } from '../../../src/cli/commands/doctor.js';
@@ -98,6 +98,40 @@ describe('doctor checks', () => {
         expect(checks.find(c => c.name === 'common-issues')).toMatchObject({ status: 'ok' });
         expect(checks.find(c => c.name === 'version')?.message).not.toContain('missing');
         expect(checks.find(c => c.name === 'guards')?.message).not.toContain('No hooks installed');
+      } finally {
+        execSync(`git worktree remove --force "${linked}"`, { cwd, stdio: 'ignore' });
+      }
+    });
+
+    it('honors configured shared store paths from a linked worktree config', () => {
+      setupSlopeDir(cwd);
+      writeFileSync(join(cwd, '.slope', 'slope.db'), '');
+      writeFileSync(join(cwd, 'README.md'), '# test repo\n');
+      execSync('git init', { cwd, stdio: 'ignore' });
+      execSync('git config user.email test@example.com', { cwd, stdio: 'ignore' });
+      execSync('git config user.name "Test User"', { cwd, stdio: 'ignore' });
+      execSync('git add .gitignore README.md docs/backlog/roadmap.json', { cwd, stdio: 'ignore' });
+      execSync('git commit -m init', { cwd, stdio: 'ignore' });
+
+      const linked = join(tmpdir(), `slope-doctor-linked-config-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      execSync(`git worktree add -b linked-config-test "${linked}"`, { cwd, stdio: 'ignore' });
+      try {
+        mkdirSync(join(linked, '.slope'), { recursive: true });
+        writeFileSync(join(linked, '.slope', 'config.json'), JSON.stringify({
+          scorecardDir: 'docs/retros',
+          scorecardPattern: 'sprint-*.json',
+          store_path: relative(linked, join(cwd, '.slope', 'slope.db')),
+          commonIssuesPath: relative(linked, join(cwd, '.slope', 'common-issues.json')),
+          metaphor: 'golf',
+          slopeVersion: '1.25.5',
+        }, null, 2));
+
+        const checks = runDoctorChecks(linked);
+
+        expect(checks.find(c => c.name === 'store')).toMatchObject({ status: 'ok' });
+        expect(checks.find(c => c.name === 'common-issues')).toMatchObject({ status: 'ok' });
+        expect(checks.find(c => c.name === 'store')?.message).not.toContain('.slope/slope.db missing');
+        expect(checks.find(c => c.name === 'common-issues')?.message).not.toContain('.slope/common-issues.json missing');
       } finally {
         execSync(`git worktree remove --force "${linked}"`, { cwd, stdio: 'ignore' });
       }

--- a/tests/cli/commands/next.test.ts
+++ b/tests/cli/commands/next.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { nextCommand } from '../../../src/cli/commands/next.js';
+import { createSprintState, saveSprintState } from '../../../src/cli/sprint-state.js';
 
 function makeRepo(): string {
   const cwd = mkdtempSync(join(tmpdir(), 'slope-next-'));
@@ -78,6 +79,30 @@ function writeSupersededRoadmap(cwd: string): void {
   }));
 }
 
+function writeLinearRoadmap(cwd: string): void {
+  writeFileSync(join(cwd, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+    name: 'Test',
+    phases: [{ name: 'P1', sprints: [1, 30, 31] }],
+    sprints: [
+      { id: 1, theme: 'Historical', par: 4, slope: 1, type: 'feature', status: 'complete', tickets: [
+        { key: 'S1-1', title: 'old', club: 'wedge', complexity: 'small' },
+        { key: 'S1-2', title: 'old', club: 'wedge', complexity: 'small' },
+        { key: 'S1-3', title: 'old', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 30, theme: 'Current work', par: 4, slope: 1, type: 'feature', status: 'planned', tickets: [
+        { key: 'S30-1', title: 'current', club: 'wedge', complexity: 'small' },
+        { key: 'S30-2', title: 'current', club: 'wedge', complexity: 'small' },
+        { key: 'S30-3', title: 'current', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 31, theme: 'Next work', par: 4, slope: 1, type: 'feature', status: 'planned', depends_on: [30], tickets: [
+        { key: 'S31-1', title: 'next', club: 'wedge', complexity: 'small' },
+        { key: 'S31-2', title: 'next', club: 'wedge', complexity: 'small' },
+        { key: 'S31-3', title: 'next', club: 'wedge', complexity: 'small' },
+      ] },
+    ],
+  }));
+}
+
 describe('slope next', () => {
   const repos: string[] = [];
 
@@ -129,5 +154,34 @@ describe('slope next', () => {
     expect(output).toContain('Latest scorecard: S95');
     expect(output).toContain('Next sprint: S96');
     expect(output).not.toContain('S75.5');
+  });
+
+  it('does not let fully gated scoring sprint-state reset next sprint output', () => {
+    const cwd = makeRepo();
+    repos.push(cwd);
+    writeScorecard(cwd, 29);
+    writeLinearRoadmap(cwd);
+    const state = createSprintState(1, 'scoring');
+    state.gates.tests = true;
+    state.gates.code_review = true;
+    state.gates.architect_review = true;
+    state.gates.scorecard = true;
+    state.gates.review_md = true;
+    saveSprintState(cwd, state);
+    const originalCwd = process.cwd();
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg = '') => logs.push(String(msg)));
+
+    try {
+      process.chdir(cwd);
+      nextCommand();
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const output = logs.join('\n');
+    expect(output).toContain('Latest scorecard: S29');
+    expect(output).toContain('Next sprint: S30');
+    expect(output).not.toContain('Next sprint: S1');
   });
 });

--- a/tests/cli/commands/worktree-start.test.ts
+++ b/tests/cli/commands/worktree-start.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+import { worktreeCommand } from '../../../src/cli/commands/worktree.js';
+import { resolveStore } from '../../../src/cli/store.js';
+
+let cwd: string;
+let originalCwd: string;
+
+function setupRepo(): void {
+  mkdirSync(join(cwd, '.slope'), { recursive: true });
+  mkdirSync(join(cwd, 'docs', 'retros'), { recursive: true });
+  mkdirSync(join(cwd, 'docs', 'backlog'), { recursive: true });
+  writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+    commonIssuesPath: '.slope/common-issues.json',
+    roadmapPath: 'docs/backlog/roadmap.json',
+    metaphor: 'golf',
+  }, null, 2));
+  writeFileSync(join(cwd, '.slope', 'common-issues.json'), JSON.stringify({ recurring_patterns: [] }, null, 2));
+  writeFileSync(join(cwd, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({ name: 'Test', phases: [], sprints: [] }));
+  writeFileSync(join(cwd, '.gitignore'), '.slope/\n');
+  writeFileSync(join(cwd, 'README.md'), '# test repo\n');
+  execSync('git init', { cwd, stdio: 'ignore' });
+  execSync('git config user.email test@example.com', { cwd, stdio: 'ignore' });
+  execSync('git config user.name "Test User"', { cwd, stdio: 'ignore' });
+  execSync('git add .gitignore README.md docs/backlog/roadmap.json', { cwd, stdio: 'ignore' });
+  execSync('git commit -m init', { cwd, stdio: 'ignore' });
+}
+
+describe('slope worktree start', () => {
+  beforeEach(() => {
+    cwd = join(tmpdir(), `slope-worktree-start-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(cwd, { recursive: true });
+    setupRepo();
+    originalCwd = process.cwd();
+    process.chdir(cwd);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('creates a persistent worktree, linked config, session, and optional claim', async () => {
+    await worktreeCommand([
+      'start',
+      '--branch=codex/worktree-start-test',
+      '--base=HEAD',
+      '--role=secondary',
+      '--ide=codex',
+      '--target=423',
+      '--sprint=109',
+    ]);
+
+    const worktreePath = join(cwd, '.slope', 'worktrees', 'codex-worktree-start-test');
+    expect(existsSync(worktreePath)).toBe(true);
+
+    const linkedConfig = JSON.parse(readFileSync(join(worktreePath, '.slope', 'config.json'), 'utf8'));
+    expect(resolve(worktreePath, linkedConfig.store_path)).toBe(join(cwd, '.slope', 'slope.db'));
+    expect(resolve(worktreePath, linkedConfig.commonIssuesPath)).toBe(join(cwd, '.slope', 'common-issues.json'));
+
+    const store = await resolveStore(cwd);
+    try {
+      const sessions = await store.getActiveSessions();
+      const session = sessions.find(s => s.branch === 'codex/worktree-start-test');
+      expect(session).toBeDefined();
+      expect(session!.role).toBe('secondary');
+      expect(session!.ide).toBe('codex');
+      expect(realpathSync(session!.worktree_path!)).toBe(realpathSync(worktreePath));
+
+      const claims = await store.getActiveClaims(109);
+      const claim = claims.find(c => c.target === '423');
+      expect(claim).toBeDefined();
+      expect(claim!.session_id).toBe(session!.session_id);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/tests/cli/commands/worktree-start.test.ts
+++ b/tests/cli/commands/worktree-start.test.ts
@@ -83,4 +83,21 @@ describe('slope worktree start', () => {
       store.close();
     }
   });
+
+  it('passes worktree paths as process arguments instead of shell fragments', async () => {
+    const markerPath = join(cwd, 'shell-injection-marker');
+    const worktreePath = join(cwd, '.slope', 'worktrees', `safe-$(touch ${markerPath})`);
+
+    await worktreeCommand([
+      'start',
+      '--branch=codex/worktree-shell-safe',
+      '--base=HEAD',
+      `--path=${worktreePath}`,
+      '--role=secondary',
+      '--ide=codex',
+    ]);
+
+    expect(existsSync(markerPath)).toBe(false);
+    expect(existsSync(worktreePath)).toBe(true);
+  });
 });

--- a/tests/cli/commands/worktree.test.ts
+++ b/tests/cli/commands/worktree.test.ts
@@ -86,6 +86,28 @@ describe('slope worktree cleanup', () => {
   it('prints help for --help flag', async () => {
     await worktreeCommand(['--help']);
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('slope worktree'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('start'));
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('cleanup'));
+  });
+
+  it('previews persistent worktree start with session and claim metadata', async () => {
+    mockExecSync
+      .mockReturnValueOnce('/repo' as any) // git rev-parse --show-toplevel
+      .mockReturnValueOnce('.git' as any) // git-common-dir
+      .mockReturnValueOnce('.git' as any); // git-dir
+
+    await worktreeCommand([
+      'start',
+      '--branch=codex/example',
+      '--base=HEAD',
+      '--role=secondary',
+      '--ide=codex',
+      '--target=423',
+      '--dry-run',
+    ]);
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('git worktree add'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('register session role=secondary ide=codex branch=codex/example'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('claim 423 (ticket)'));
   });
 });

--- a/tests/cli/commands/worktree.test.ts
+++ b/tests/cli/commands/worktree.test.ts
@@ -3,16 +3,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock execSync before importing the module
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { worktreeCommand } from '../../../src/cli/commands/worktree.js';
 
 const mockExecSync = vi.mocked(execSync);
+const mockExecFileSync = vi.mocked(execFileSync);
 
 describe('slope worktree cleanup', () => {
   beforeEach(() => {
     mockExecSync.mockReset();
+    mockExecFileSync.mockReset();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -58,8 +61,8 @@ describe('slope worktree cleanup', () => {
     mockExecSync
       .mockReturnValueOnce('.git' as any) // git-common-dir
       .mockReturnValueOnce('.git' as any) // git-dir
-      .mockReturnValueOnce(porcelainOutput as any) // git worktree list --porcelain
-      .mockImplementation(() => { throw new Error('no gh'); }); // gh --version fails
+      .mockReturnValueOnce(porcelainOutput as any); // git worktree list --porcelain
+    mockExecFileSync.mockImplementation(() => { throw new Error('no gh'); }); // gh --version fails
 
     await worktreeCommand(['cleanup', '--all', '--dry-run']);
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[dry-run] Would remove worktree'));
@@ -92,9 +95,9 @@ describe('slope worktree cleanup', () => {
 
   it('previews persistent worktree start with session and claim metadata', async () => {
     mockExecSync
-      .mockReturnValueOnce('/repo' as any) // git rev-parse --show-toplevel
       .mockReturnValueOnce('.git' as any) // git-common-dir
       .mockReturnValueOnce('.git' as any); // git-dir
+    mockExecFileSync.mockReturnValueOnce('/repo' as any); // git rev-parse --show-toplevel
 
     await worktreeCommand([
       'start',

--- a/tests/cli/guards/session-briefing.test.ts
+++ b/tests/cli/guards/session-briefing.test.ts
@@ -40,4 +40,64 @@ describe('sessionBriefingGuard', () => {
     expect(result).toEqual({});
     expect(loadSessionState(tmpDir).session_mode).toBe('sprint');
   });
+
+  it('uses inferred roadmap context instead of stale completed sprint-state in adhoc mode', async () => {
+    mkdirSync(join(tmpDir, 'docs', 'backlog'), { recursive: true });
+    mkdirSync(join(tmpDir, 'docs', 'retros'), { recursive: true });
+    writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+      roadmapPath: 'docs/backlog/roadmap.json',
+      scorecardDir: 'docs/retros',
+      scorecardPattern: 'sprint-*.json',
+    }));
+    writeFileSync(join(tmpDir, 'docs', 'retros', 'sprint-29.json'), JSON.stringify({
+      sprint_number: 29,
+      theme: 'Previous',
+      par: 4,
+      slope: 1,
+      score: 4,
+      score_label: 'par',
+      shots: [],
+      stats: { fairways_hit: 0, fairways_total: 0, greens_in_regulation: 0, greens_total: 0, putts: 0, penalties: 0, hazards_hit: 0, hazard_penalties: 0, miss_directions: { long: 0, short: 0, left: 0, right: 0 } },
+      conditions: [],
+      special_plays: [],
+      bunker_locations: [],
+      yardage_book_updates: [],
+      course_management_notes: [],
+    }));
+    writeFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+      name: 'Test',
+      phases: [{ name: 'P1', sprints: [1, 30, 31] }],
+      sprints: [
+        { id: 1, theme: 'Historical', par: 4, slope: 1, type: 'feature', status: 'complete', tickets: [
+          { key: 'S1-1', title: 'old', club: 'wedge', complexity: 'small' },
+          { key: 'S1-2', title: 'old', club: 'wedge', complexity: 'small' },
+          { key: 'S1-3', title: 'old', club: 'wedge', complexity: 'small' },
+        ] },
+        { id: 30, theme: 'Current work', par: 4, slope: 1, type: 'feature', status: 'planned', tickets: [
+          { key: 'S30-1', title: 'current', club: 'wedge', complexity: 'small' },
+          { key: 'S30-2', title: 'current', club: 'wedge', complexity: 'small' },
+          { key: 'S30-3', title: 'current', club: 'wedge', complexity: 'small' },
+        ] },
+        { id: 31, theme: 'Next work', par: 4, slope: 1, type: 'feature', status: 'planned', depends_on: [30], tickets: [
+          { key: 'S31-1', title: 'next', club: 'wedge', complexity: 'small' },
+          { key: 'S31-2', title: 'next', club: 'wedge', complexity: 'small' },
+          { key: 'S31-3', title: 'next', club: 'wedge', complexity: 'small' },
+        ] },
+      ],
+    }));
+    const state = createSprintState(1, 'scoring');
+    state.gates.tests = true;
+    state.gates.code_review = true;
+    state.gates.architect_review = true;
+    state.gates.scorecard = true;
+    state.gates.review_md = true;
+    saveSprintState(tmpDir, state);
+
+    const result = await sessionBriefingGuard(makeInput(), tmpDir);
+
+    const context = result.suggestion?.context ?? '';
+    expect(context).toContain('No active sprint');
+    expect(context).toContain('S30: Current work');
+    expect(context).not.toContain('S1: Historical');
+  });
 });

--- a/tests/cli/sprint-inference.test.ts
+++ b/tests/cli/sprint-inference.test.ts
@@ -39,4 +39,19 @@ describe('inferSprintContext', () => {
     expect(context.sprint).toBe(18);
     expect(context.source).toBe('config');
   });
+
+  it('ignores fully gated scoring sprint-state when inferring current work', () => {
+    const state = createSprintState(74, 'scoring');
+    state.gates.tests = true;
+    state.gates.code_review = true;
+    state.gates.architect_review = true;
+    state.gates.scorecard = true;
+    state.gates.review_md = true;
+    saveSprintState(tmpDir, state);
+
+    const context = inferSprintContext(tmpDir);
+
+    expect(context.sprint).toBe(18);
+    expect(context.source).toBe('config');
+  });
 });

--- a/tests/cli/sprint-state.test.ts
+++ b/tests/cli/sprint-state.test.ts
@@ -5,6 +5,7 @@ import {
   loadSprintState,
   saveSprintState,
   updateGate,
+  isActiveSprintState,
   isSprintComplete,
   pendingGates,
   createSprintState,
@@ -119,6 +120,26 @@ describe('isSprintComplete', () => {
     state.gates.scorecard = true;
     state.gates.review_md = true;
     expect(isSprintComplete(state)).toBe(true);
+  });
+});
+
+describe('isActiveSprintState', () => {
+  it('returns false for scoring state when every closeout gate is complete', () => {
+    const state = createSprintState(22, 'scoring');
+    state.gates.tests = true;
+    state.gates.code_review = true;
+    state.gates.architect_review = true;
+    state.gates.scorecard = true;
+    state.gates.review_md = true;
+
+    expect(isActiveSprintState(state)).toBe(false);
+  });
+
+  it('returns true for scoring state while any closeout gate is still open', () => {
+    const state = createSprintState(22, 'scoring');
+    state.gates.tests = true;
+
+    expect(isActiveSprintState(state)).toBe(true);
   });
 });
 

--- a/tests/cli/sprint-workflow.test.ts
+++ b/tests/cli/sprint-workflow.test.ts
@@ -53,6 +53,25 @@ async function startWorkflow(sprintId: string, workflowName = 'sprint-lightweigh
   }
 }
 
+function writeScorecard(sprint: number): void {
+  mkdirSync(join(tmpDir, 'docs', 'retros'), { recursive: true });
+  writeFileSync(join(tmpDir, 'docs', 'retros', `sprint-${sprint}.json`), JSON.stringify({
+    sprint_number: sprint,
+    theme: `Sprint ${sprint}`,
+    par: 4,
+    slope: 1,
+    score: 4,
+    score_label: 'par',
+    shots: [],
+    stats: { fairways_hit: 0, fairways_total: 0, greens_in_regulation: 0, greens_total: 0, putts: 0, penalties: 0, hazards_hit: 0, hazard_penalties: 0, miss_directions: { long: 0, short: 0, left: 0, right: 0 } },
+    conditions: [],
+    special_plays: [],
+    bunker_locations: [],
+    yardage_book_updates: [],
+    course_management_notes: [],
+  }));
+}
+
 describe('slope sprint run', () => {
   it('starts a workflow execution', async () => {
     const output = await captureLog(() =>
@@ -137,6 +156,49 @@ describe('slope sprint status (workflow mode)', () => {
       sprintCommand(['status'])
     );
     expect(output).toContain('No active sprint');
+  });
+});
+
+describe('slope sprint workflow cleanup', () => {
+  it('dry-runs stale running executions without pausing them', async () => {
+    await startWorkflow('S1');
+    await startWorkflow('S2');
+    writeScorecard(1);
+
+    const output = await captureLog(() =>
+      sprintCommand(['workflow', 'cleanup', '--stale', '--dry-run'])
+    );
+
+    expect(output).toContain('Would pause S1');
+    expect(output).toContain('scorecard exists');
+
+    const store = createStore({ storePath: '.slope/slope.db', cwd: tmpDir });
+    try {
+      expect(await store.getExecutionBySprint('S1')).toMatchObject({ status: 'running' });
+    } finally {
+      store.close();
+    }
+  });
+
+  it('pauses stale running executions while leaving current ones active', async () => {
+    await startWorkflow('S1');
+    await startWorkflow('S2');
+    writeScorecard(1);
+
+    const output = await captureLog(() =>
+      sprintCommand(['workflow', 'cleanup', '--stale'])
+    );
+
+    expect(output).toContain('Paused S1');
+    expect(output).toContain('1 stale workflow execution(s) paused');
+
+    const store = createStore({ storePath: '.slope/slope.db', cwd: tmpDir });
+    try {
+      expect(await store.getExecutionBySprint('S1')).toMatchObject({ status: 'paused' });
+      expect(await store.getExecutionBySprint('S2')).toMatchObject({ status: 'running' });
+    } finally {
+      store.close();
+    }
   });
 });
 

--- a/tests/cli/store.test.ts
+++ b/tests/cli/store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
 import { storeCommand } from '../../src/cli/commands/store.js';
 import { getStoreInfo } from '../../src/cli/store.js';
 import { SqliteSlopeStore } from '../../src/store/index.js';
@@ -113,6 +114,33 @@ describe('slope store status', () => {
     expect(typeof parsed.claims).toBe('number');
     expect(typeof parsed.scorecards).toBe('number');
     expect(typeof parsed.events).toBe('number');
+  });
+
+  it('--json includes recovery suggestions for native SQLite setup errors', async () => {
+    const modulePath = join(tmpDir, 'native-error-store.mjs');
+    writeFileSync(modulePath, `
+      export function createStore() {
+        throw new Error("The module '/tmp/better_sqlite3.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 127. This version of Node.js requires NODE_MODULE_VERSION 141.");
+      }
+    `);
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ engines: { node: '>=22 <23' } }));
+    writeFileSync(join(tmpDir, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+    writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+      store: pathToFileURL(modulePath).href,
+      scorecardDir: 'docs/retros',
+      scorecardPattern: 'sprint-*.json',
+      metaphor: 'golf',
+    }));
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...args) => { logs.push(args.join(' ')); });
+
+    await storeCommand(['status', '--json']);
+
+    spy.mockRestore();
+    const parsed = JSON.parse(logs.join('\n'));
+    expect(parsed.error).toContain('NODE_MODULE_VERSION');
+    expect(parsed.recovery).toContain('Install this worktree\'s dependencies first: pnpm install.');
+    expect(parsed.recovery.join('\n')).toContain('package.json engines.node (>=22 <23)');
   });
 });
 

--- a/tests/mcp/index-src.test.ts
+++ b/tests/mcp/index-src.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createSlopeToolsServer, SLOPE_MCP_TOOL_NAMES, detectSetupHints, buildSetupHint } from '../../src/mcp/index.js';
+import { createSlopeToolsServer, SLOPE_MCP_TOOL_NAMES, detectSetupHints, buildSetupHint, formatSearchResults } from '../../src/mcp/index.js';
 import type { SetupHints } from '../../src/mcp/index.js';
 import { SLOPE_REGISTRY, SLOPE_TYPES } from '../../src/mcp/registry.js';
 import { runInSandbox } from '../../src/mcp/sandbox.js';
@@ -123,6 +123,16 @@ describe('registry', () => {
     for (const name of expectedStoreTools) {
       expect(storeNames).toContain(name);
     }
+  });
+
+  it('marks testing session entries as direct MCP tools, not execute sandbox functions', () => {
+    const entry = SLOPE_REGISTRY.find(e => e.name === 'testing_session_status');
+    expect(entry).toBeDefined();
+    expect(entry!.availability).toBe('mcp_tool');
+    expect(entry!.description).toContain('Not available inside execute()');
+
+    const output = formatSearchResults([entry!], true);
+    expect(output).toContain('testing/testing_session_status [MCP tool; not available in execute()]');
   });
 
   it('SLOPE_TYPES contains key type definitions', () => {


### PR DESCRIPTION
## Summary
- Fix stale sprint-state/session-briefing inference after fully gated sprint closeout
- Honor configured doctor state paths in linked worktrees
- Add native SQLite recovery diagnostics, direct MCP tool availability markers, persistent worktree start, and stale workflow cleanup
- Harden worktree git/gh process calls to avoid shell interpolation of user-controlled branch/path values
- Record S109 scorecard and review artifacts

## Issues
Fixes #420
Fixes #421
Fixes #422
Fixes #423
Fixes #424
Fixes #425
Fixes #426

## Validation
- `pnpm test`
- `pnpm run typecheck`
- `pnpm run build`
- `slope validate`
- `slope map --check`
- `git diff --check`

## SLOPE
- Sprint: 109
- Score: 5 on par 5
- Gates complete: tests, code review, architect review, scorecard, review markdown
- Review finding fixed: worktree command process calls now use argument-vector execution instead of shell interpolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `slope sprint workflow cleanup --stale` command to pause stale running workflows with `--dry-run` support
  * Added `slope worktree start` subcommand to create isolated working copies with linked config and session management

* **Bug Fixes**
  * Improved error recovery suggestions in store command for native module setup issues
  * Enhanced sprint state detection to properly identify active vs. completed phases
  * Fixed path resolution in doctor and store commands to use configuration-driven settings

* **Documentation**
  * Added Sprint 109 retrospective documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->