### PR TITLE
Record S110 release cycle probe

### DIFF
--- a/docs/retros/sprint-110-review.md
+++ b/docs/retros/sprint-110-review.md
@@ -1,0 +1,59 @@
+## Sprint 110 Review: v1.55.14 Release Cycle Probe
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 2 |
+| Score | 4 |
+| Label | Bogey |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S110-1 | Wedge | Green | Rough: npm registry publication still depends on npm-side trusted publisher/package authorization. | Bumped package.json and the bundled Codex plugin manifest to 1.55.14, validated typecheck, build, and the full test suite locally, created GitHub release v1.55.14, and watched the publish workflow. GitHub Actions passed install/build/test/typecheck and signed npm provenance, then npm rejected publish with the same E404 permission/package authorization error. |
+
+### Hazards Discovered
+
+Known hazards for future sprints:
+
+- Creating a GitHub release is not enough; npm-side trusted publisher authorization must accept the publish.
+- Release bump commits must go through a feature branch and PR, not direct commits on main.
+- npm auto-corrected bin entries during pack, warning that bin paths without ./ were removed.
+- actions/setup-node@v4 ignored package-manager-cache, warning that the workflow input is not valid.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Release cycle probes need both local validation and live registry verification. | Validated the package bump locally, then verified the GitHub release workflow still fails at npm publish with E404 after provenance signing. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Validated pnpm run typecheck, pnpm run build, pnpm test, and git diff --check before publishing the release branch; GitHub Actions repeated install, build, test, and typecheck successfully. |
+
+### Course Management Notes
+
+- Package version bumped from 1.55.13 to 1.55.14.
+- Codex plugin template version bumped from 1.55.13 to 1.55.14.
+- Before release, npm view @slope-dev/slope version still reported 1.55.11.
+- Created GitHub release v1.55.14, which triggered Publish to npm run 26259794247.
+- Publish run passed install, build, test, typecheck, and npm 11.5.1 setup.
+- npm publish signed provenance and published to the transparency log, then failed with E404 for @slope-dev/slope@1.55.14.
+- After the failed release, npm view @slope-dev/slope version still reported 1.55.11.
+- Local validation passed with 211 test files and 3433 tests.
+
+### 19th Hole
+
+- **How did it feel?** A tiny repo change with a very real external dependency: the release machinery can be clean while npm remains the deciding green.
+- **Advice for next player?** Always verify npm view after a GitHub release; a successful release event and provenance signature are not proof that npm accepted the publish.
+- **What surprised you?** The workflow reached npm far enough to sign provenance, which makes the remaining failure very specifically package authorization or trusted-publisher access.
+- **Excited about next?** Once npm-side authorization is corrected, rerunning the release or dispatching the backfill workflow should have a much cleaner path.

--- a/docs/retros/sprint-110-review.md
+++ b/docs/retros/sprint-110-review.md
@@ -11,7 +11,7 @@
 | Fairway % | 100% (1/1) |
 | GIR % | 100% (1/1) |
 | Putts | 0 |
-| Penalties | 0 |
+| Penalties | 1 |
 
 ### Shot-by-Shot (Tickets Delivered: 1)
 
@@ -24,8 +24,8 @@
 Known hazards for future sprints:
 
 - Creating a GitHub release is not enough; npm-side trusted publisher authorization must accept the publish.
-- Release bump commits must go through a feature branch and PR, not direct commits on main.
-- npm auto-corrected bin entries during pack, warning that bin paths without ./ were removed.
+- The publish workflow can pass build/test/typecheck and provenance signing but still fail at the final npm PUT with E404.
+- npm auto-corrected bin entries during publish, warning that bin script entries were removed; local npm pack did not reproduce that warning, so investigate before the next publish attempt.
 - actions/setup-node@v4 ignored package-manager-cache, warning that the workflow input is not valid.
 
 ### Training Log
@@ -38,16 +38,17 @@ Known hazards for future sprints:
 
 | Category | Status | Notes |
 |---|---|---|
-| testing | healthy | Validated pnpm run typecheck, pnpm run build, pnpm test, and git diff --check before publishing the release branch; GitHub Actions repeated install, build, test, and typecheck successfully. |
+| testing | healthy | Validated pnpm run typecheck, pnpm run build, pnpm test, and git diff --check before creating the release; GitHub Actions repeated install, build, test, and typecheck successfully. |
 
 ### Course Management Notes
 
 - Package version bumped from 1.55.13 to 1.55.14.
 - Codex plugin template version bumped from 1.55.13 to 1.55.14.
 - Before release, npm view @slope-dev/slope version still reported 1.55.11.
+- Fast-forwarded main to 3075b3f for the 1.55.14 release bump.
 - Created GitHub release v1.55.14, which triggered Publish to npm run 26259794247.
 - Publish run passed install, build, test, typecheck, and npm 11.5.1 setup.
-- npm publish signed provenance and published to the transparency log, then failed with E404 for @slope-dev/slope@1.55.14.
+- npm publish signed provenance and published to the transparency log at logIndex 1596380075, then failed with E404 for @slope-dev/slope@1.55.14.
 - After the failed release, npm view @slope-dev/slope version still reported 1.55.11.
 - Local validation passed with 211 test files and 3433 tests.
 

--- a/docs/retros/sprint-110.json
+++ b/docs/retros/sprint-110.json
@@ -1,0 +1,93 @@
+{
+  "sprint_number": 110,
+  "player": "codex",
+  "theme": "v1.55.14 Release Cycle Probe",
+  "par": 3,
+  "slope": 2,
+  "score": 4,
+  "score_label": "bogey",
+  "date": "2026-05-21",
+  "shots": [
+    {
+      "ticket_key": "S110-1",
+      "title": "Bump v1.55.14 and run release validation for npm publish recovery (#406)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The release path is repo-clean, but npm registry publication still depends on npm-side trusted publisher/package authorization."
+        }
+      ],
+      "notes": "Bumped package.json and the bundled Codex plugin manifest to 1.55.14, validated typecheck, build, and the full test suite locally, created GitHub release v1.55.14, and watched the publish workflow. GitHub Actions passed install/build/test/typecheck and signed npm provenance, then npm rejected publish with the same E404 permission/package authorization error."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 1,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "release",
+  "conditions": [
+    {
+      "type": "rough",
+      "description": "npm still reports @slope-dev/slope latest as 1.55.11 before the release cycle, despite GitHub releases through v1.55.13.",
+      "impact": "moderate"
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Release cycle probes need both local validation and live registry verification.",
+      "outcome": "Validated the package bump locally, then verified the GitHub release workflow still fails at npm publish with E404 after provenance signing."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Validated pnpm run typecheck, pnpm run build, pnpm test, and git diff --check before publishing the release branch; GitHub Actions repeated install, build, test, and typecheck successfully.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A tiny repo change with a very real external dependency: the release machinery can be clean while npm remains the deciding green.",
+    "advice_for_next_player": "Always verify npm view after a GitHub release; a successful release event and provenance signature are not proof that npm accepted the publish.",
+    "what_surprised_you": "The workflow reached npm far enough to sign provenance, which makes the remaining failure very specifically package authorization or trusted-publisher access.",
+    "excited_about_next": "Once npm-side authorization is corrected, rerunning the release or dispatching the backfill workflow should have a much cleaner path."
+  },
+  "bunker_locations": [
+    "Creating a GitHub release is not enough; npm-side trusted publisher authorization must accept the publish.",
+    "Release bump commits must go through a feature branch and PR, not direct commits on main.",
+    "npm auto-corrected bin entries during pack, warning that bin paths without ./ were removed.",
+    "actions/setup-node@v4 ignored package-manager-cache, warning that the workflow input is not valid."
+  ],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Package version bumped from 1.55.13 to 1.55.14.",
+    "Codex plugin template version bumped from 1.55.13 to 1.55.14.",
+    "Before release, npm view @slope-dev/slope version still reported 1.55.11.",
+    "Created GitHub release v1.55.14, which triggered Publish to npm run 26259794247.",
+    "Publish run passed install, build, test, typecheck, and npm 11.5.1 setup.",
+    "npm publish signed provenance and published to the transparency log, then failed with E404 for @slope-dev/slope@1.55.14.",
+    "After the failed release, npm view @slope-dev/slope version still reported 1.55.11.",
+    "Local validation passed with 211 test files and 3433 tests."
+  ],
+  "slope_factors": [
+    "release",
+    "npm",
+    "github_actions"
+  ]
+}

--- a/docs/retros/sprint-110.json
+++ b/docs/retros/sprint-110.json
@@ -16,8 +16,8 @@
       "hazards": [
         {
           "type": "rough",
-          "severity": "minor",
-          "description": "The release path is repo-clean, but npm registry publication still depends on npm-side trusted publisher/package authorization."
+          "severity": "moderate",
+          "description": "The release path is repo-clean through provenance signing, but npm registry publication still depends on npm-side trusted publisher/package authorization."
         }
       ],
       "notes": "Bumped package.json and the bundled Codex plugin manifest to 1.55.14, validated typecheck, build, and the full test suite locally, created GitHub release v1.55.14, and watched the publish workflow. GitHub Actions passed install/build/test/typecheck and signed npm provenance, then npm rejected publish with the same E404 permission/package authorization error."
@@ -29,7 +29,7 @@
     "greens_in_regulation": 1,
     "greens_total": 1,
     "putts": 0,
-    "penalties": 0,
+    "penalties": 1,
     "hazards_hit": 1,
     "hazard_penalties": 1,
     "miss_directions": {
@@ -43,7 +43,7 @@
   "conditions": [
     {
       "type": "rough",
-      "description": "npm still reports @slope-dev/slope latest as 1.55.11 before the release cycle, despite GitHub releases through v1.55.13.",
+      "description": "npm still reports @slope-dev/slope latest as 1.55.11 before and after the v1.55.14 release cycle, despite GitHub releases through v1.55.14.",
       "impact": "moderate"
     }
   ],
@@ -58,7 +58,7 @@
   "nutrition": [
     {
       "category": "testing",
-      "description": "Validated pnpm run typecheck, pnpm run build, pnpm test, and git diff --check before publishing the release branch; GitHub Actions repeated install, build, test, and typecheck successfully.",
+      "description": "Validated pnpm run typecheck, pnpm run build, pnpm test, and git diff --check before creating the release; GitHub Actions repeated install, build, test, and typecheck successfully.",
       "status": "healthy"
     }
   ],
@@ -70,8 +70,8 @@
   },
   "bunker_locations": [
     "Creating a GitHub release is not enough; npm-side trusted publisher authorization must accept the publish.",
-    "Release bump commits must go through a feature branch and PR, not direct commits on main.",
-    "npm auto-corrected bin entries during pack, warning that bin paths without ./ were removed.",
+    "The publish workflow can pass build/test/typecheck and provenance signing but still fail at the final npm PUT with E404.",
+    "npm auto-corrected bin entries during publish, warning that bin script entries were removed; local npm pack did not reproduce that warning, so investigate before the next publish attempt.",
     "actions/setup-node@v4 ignored package-manager-cache, warning that the workflow input is not valid."
   ],
   "yardage_book_updates": [],
@@ -79,9 +79,10 @@
     "Package version bumped from 1.55.13 to 1.55.14.",
     "Codex plugin template version bumped from 1.55.13 to 1.55.14.",
     "Before release, npm view @slope-dev/slope version still reported 1.55.11.",
+    "Fast-forwarded main to 3075b3f for the 1.55.14 release bump.",
     "Created GitHub release v1.55.14, which triggered Publish to npm run 26259794247.",
     "Publish run passed install, build, test, typecheck, and npm 11.5.1 setup.",
-    "npm publish signed provenance and published to the transparency log, then failed with E404 for @slope-dev/slope@1.55.14.",
+    "npm publish signed provenance and published to the transparency log at logIndex 1596380075, then failed with E404 for @slope-dev/slope@1.55.14.",
     "After the failed release, npm view @slope-dev/slope version still reported 1.55.11.",
     "Local validation passed with 211 test files and 3433 tests."
   ],


### PR DESCRIPTION
## Summary
- Add S110 scorecard and review for the v1.55.14 release cycle probe
- Record that the GitHub release workflow passed install/build/test/typecheck and failed at npm publish with E404 after provenance signing
- Capture follow-up warnings from the publish logs

## Validation
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test`
- `slope validate`
- `git diff --check`

## Release observation
- GitHub Release: v1.55.14
- Publish run: https://github.com/srbryers/slope/actions/runs/26259794247
- npm still reports `1.55.11`
