### PR TITLE
fix(112): update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,17 +27,16 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_ref || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          package-manager-cache: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -14,15 +14,15 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Full history for changelog
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 
@@ -55,7 +55,7 @@ jobs:
         run: npx wrangler kv key put --namespace-id=${{ secrets.SLOPE_STATS_KV_NS_ID }} "stats" --path=stats.json --remote
 
       - name: Checkout slope-web
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: srbryers/slope-web
           token: ${{ secrets.SLOPE_WEB_PAT }}
@@ -67,7 +67,7 @@ jobs:
       # SLOPE_WEB_PAT requires repo scope (read/write) on srbryers/slope-web
       # to checkout, push commits, and create pull requests.
       - name: Create PR on slope-web
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.SLOPE_WEB_PAT }}
           path: slope-web

--- a/docs/retros/sprint-112-review.md
+++ b/docs/retros/sprint-112-review.md
@@ -1,0 +1,63 @@
+## Sprint 112 Review: GitHub Actions Node 24 Warning Cleanup
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 1 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S112-1 | Wedge | Green | Rough: first full test run hit an existing git analyzer timing boundary. | Updated CI, publish, and docs-sync workflow actions from Node 20-era pins to Node 24-era major versions: `actions/checkout@v6`, `actions/setup-node@v6`, `pnpm/action-setup@v6`, and `peter-evans/create-pull-request@v8`. Removed the stale `package-manager-cache` input from `publish.yml`. |
+
+### Outcome
+
+- `.github/workflows/ci.yml` now uses Node 24-era action majors.
+- `.github/workflows/publish.yml` now uses Node 24-era action majors and no longer passes the invalid `package-manager-cache` input.
+- `.github/workflows/sync-docs.yml` now uses Node 24-era action majors, including `peter-evans/create-pull-request@v8`.
+
+### Hazards Discovered
+
+Known hazards for future sprints:
+
+- Some local tests have tight timing limits and can require a focused rerun before the full suite settles.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Action runtime warnings are best fixed by upgrading action major versions rather than forcing runtime env vars. | Moved all local workflow JS action pins with available Node 24-era majors and removed the invalid setup-node input. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| workflow | healthy | No stale Node 20-era action pins or `package-manager-cache` input remain in `.github/workflows`. |
+| testing | healthy | `pnpm run typecheck`, `pnpm run build`, `git diff --check`, targeted git analyzer test rerun, and second full `pnpm test` passed. |
+
+### Course Management Notes
+
+- `actions/checkout` moved from `v4` to `v6` in CI, publish, and docs sync.
+- `actions/setup-node` moved from `v4` to `v6` in CI, publish, and docs sync.
+- `pnpm/action-setup` moved from `v4` to `v6` in CI, publish, and docs sync.
+- `peter-evans/create-pull-request` moved from `v7` to `v8` in docs sync.
+- Removed `package-manager-cache` from `publish.yml`.
+- First full `pnpm test` run failed on `tests/core/analyzers/git.test.ts` due a 5000ms timeout.
+- `pnpm vitest run tests/core/analyzers/git.test.ts` passed on rerun.
+- Second full `pnpm test` passed: 211 test files and 3433 tests.
+
+### 19th Hole
+
+- **How did it feel?** A tidy maintenance pass after the release repair: small YAML changes, big reduction in future CI noise.
+- **Advice for next player?** When GitHub warns about action runtimes, check each action's current major before using runner env overrides.
+- **What surprised you?** The only local turbulence was a pre-existing timeout-prone git analyzer test, not the workflow edit.
+- **Excited about next?** The next release or CI run should be quieter and closer to the upcoming GitHub runner default.

--- a/docs/retros/sprint-112.json
+++ b/docs/retros/sprint-112.json
@@ -1,0 +1,97 @@
+{
+  "sprint_number": 112,
+  "player": "codex",
+  "theme": "GitHub Actions Node 24 Warning Cleanup",
+  "par": 3,
+  "slope": 1,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-05-22",
+  "shots": [
+    {
+      "ticket_key": "S112-1",
+      "title": "Update GitHub workflow actions to Node 24-capable major versions",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The first full test run hit an existing git analyzer timing boundary, then the targeted rerun and second full suite passed."
+        }
+      ],
+      "notes": "Updated CI, publish, and docs-sync workflow actions from Node 20-era pins to Node 24-era major versions: actions/checkout@v6, actions/setup-node@v6, pnpm/action-setup@v6, and peter-evans/create-pull-request@v8. Removed the stale package-manager-cache input from publish.yml. Validation passed with typecheck, build, git diff --check, a targeted flaky-test rerun, and a second full pnpm test run."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "maintenance",
+  "conditions": [
+    {
+      "type": "rough",
+      "description": "GitHub-hosted Actions are transitioning JavaScript actions from Node 20 to Node 24, so pinned action majors need current runtime support.",
+      "impact": "low"
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Action runtime warnings are best fixed by upgrading action major versions rather than forcing runtime env vars.",
+      "outcome": "Moved all local workflow JS action pins with available Node 24-era majors and removed the invalid setup-node input."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "pnpm run typecheck, pnpm run build, git diff --check, targeted git analyzer test rerun, and second full pnpm test passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "workflow",
+      "description": "No stale Node 20-era action pins or package-manager-cache input remain in .github/workflows.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A tidy maintenance pass after the release repair: small YAML changes, big reduction in future CI noise.",
+    "advice_for_next_player": "When GitHub warns about action runtimes, check each action's current major before using runner env overrides.",
+    "what_surprised_you": "The only local turbulence was a pre-existing timeout-prone git analyzer test, not the workflow edit.",
+    "excited_about_next": "The next release or CI run should be quieter and closer to the upcoming GitHub runner default."
+  },
+  "bunker_locations": [
+    "Some local tests have tight timing limits and can require a focused rerun before the full suite settles."
+  ],
+  "yardage_book_updates": [
+    "For GitHub Actions Node runtime warnings, prefer upgrading action majors with Node 24 support and remove invalid legacy inputs."
+  ],
+  "course_management_notes": [
+    "actions/checkout moved from v4 to v6 in CI, publish, and docs sync.",
+    "actions/setup-node moved from v4 to v6 in CI, publish, and docs sync.",
+    "pnpm/action-setup moved from v4 to v6 in CI, publish, and docs sync.",
+    "peter-evans/create-pull-request moved from v7 to v8 in docs sync.",
+    "Removed package-manager-cache from publish.yml.",
+    "First full pnpm test run failed on tests/core/analyzers/git.test.ts due a 5000ms timeout.",
+    "pnpm vitest run tests/core/analyzers/git.test.ts passed on rerun.",
+    "Second full pnpm test passed: 211 test files and 3433 tests."
+  ],
+  "slope_factors": [
+    "github_actions",
+    "maintenance",
+    "ci"
+  ]
+}


### PR DESCRIPTION
## Summary
- upgrade CI, publish, and docs-sync workflows to Node 24-era action majors
- remove the stale publish workflow package-manager-cache input that setup-node@v4 rejected
- record Sprint 112 scorecard and review for the cleanup

## Validation
- git diff --check
- pnpm run typecheck
- pnpm run build
- pnpm vitest run tests/core/analyzers/git.test.ts
- pnpm test (second full run: 211 files, 3433 tests, 23 skipped)
- slope validate docs/retros/sprint-112.json

## Notes
The first full pnpm test run hit a 5000ms timeout in tests/core/analyzers/git.test.ts. The targeted rerun passed, and the second full suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow dependencies to the latest versions for enhanced compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->