### PR TITLE
feat(S114): add skill registry MVP

### DIFF
--- a/docs/retros/sprint-114-review.md
+++ b/docs/retros/sprint-114-review.md
@@ -1,0 +1,63 @@
+## Sprint 114 Review: Skill Registry MVP
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 5 |
+| Slope | 3 |
+| Score | 5 |
+| Label | Par |
+| Fairway % | 100% (4/4) |
+| GIR % | 100% (4/4) |
+| Putts | 0 |
+| Penalties | 0 |
+| Hazard Penalties | 0.5 |
+
+### Shot-by-Shot (Tickets Delivered: 4)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S114-1 | Short Iron | In the Hole | - | Added the core skill registry schema, config defaults, persistence helpers, and exported API surface for repo-local skill metadata. |
+| S114-2 | Long Iron | Green | - | Implemented deterministic skill root scanning, YAML frontmatter parsing, agents/openai.yaml metadata capture, duplicate provider-root merging, and registry validation. |
+| S114-3 | Short Iron | Green | Rough: Self-review found that absolute --root and --output paths were being joined under cwd instead of preserved. | Added slope skills scan/list/validate, CLI dispatch, command registry metadata, smoke coverage, and absolute path regression coverage. |
+| S114-4 | Short Iron | Green | Rough: Self-review found malformed skill registry files could be loaded far enough to crash list/reference checks. | Added scorecard skill fields, builder support, structural validation, validate --skills reference checks, malformed registry rejection, and CLI regression coverage. |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Rough | S114-3 | Self-review found that absolute --root and --output paths were being joined under cwd instead of preserved. |
+| Rough | S114-4 | Self-review found malformed skill registry files could be loaded far enough to crash list/reference checks. |
+
+**Known hazards for future sprints:**
+- Any CLI path flag that accepts user filesystem input should preserve absolute paths and resolve relative paths against cwd in tests.
+- Registry loaders should reject malformed top-level shapes before downstream code maps over arrays.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | CLI path handling needs explicit absolute-path regression coverage. | Added absolute --root/--output coverage for slope skills scan and resolved explicit validate paths against cwd. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Validated targeted skill/scorecard tests, typecheck, build, built CLI smoke tests, and the full Vitest suite. |
+
+### Course Management Notes
+
+- Added src/core/skills.ts with scan, load/save, validation, duplicate merge, frontmatter parsing, and agents/openai.yaml metadata capture.
+- Added slope skills scan/list/validate and command registry metadata.
+- Added scorecard skill fields and validate --skills reference checking.
+- slope skills scan --root=.agents/skills, slope skills list, slope skills validate, and slope validate --skills smoke tests passed on the built CLI.
+- pnpm build passed.
+- Full pnpm test passed: 214 test files and 3456 tests.
+
+### 19th Hole
+
+- **How did it feel?** This was a satisfying first layer: SLOPE can now see skills as metadata without pretending to run them.
+- **Advice for next player?** Keep S114.5 deterministic. Use this registry as input to briefing recommendations before attempting smarter gap detection.
+- **What surprised you?** The useful review catches were plain path and malformed-file resilience, not the YAML parsing itself.
+- **Excited about next?** Briefing can now recommend skills from a real registry instead of relying on tribal memory.

--- a/docs/retros/sprint-114.json
+++ b/docs/retros/sprint-114.json
@@ -21,8 +21,14 @@
       "title": "Scan configured skill roots and parse SKILL.md plus agents/openai.yaml metadata",
       "club": "long_iron",
       "result": "green",
-      "hazards": [],
-      "notes": "Implemented deterministic skill root scanning, YAML frontmatter parsing, agents/openai.yaml metadata capture, duplicate provider-root merging, and registry validation."
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "CodeQL flagged slug-normalization regexes as vulnerable to slow matching on hyphen-heavy skill names."
+        }
+      ],
+      "notes": "Implemented deterministic skill root scanning, YAML frontmatter parsing, agents/openai.yaml metadata capture, duplicate provider-root merging, registry validation, and linear-time skill id normalization."
     },
     {
       "ticket_key": "S114-3",
@@ -60,7 +66,7 @@
     "greens_total": 4,
     "putts": 0,
     "penalties": 0,
-    "hazards_hit": 2,
+    "hazards_hit": 3,
     "hazard_penalties": 0.5,
     "miss_directions": {
       "long": 0,
@@ -77,6 +83,11 @@
       "type": "lessons",
       "description": "CLI path handling needs explicit absolute-path regression coverage.",
       "outcome": "Added absolute --root/--output coverage for slope skills scan and resolved explicit validate paths against cwd."
+    },
+    {
+      "type": "lessons",
+      "description": "Regex-based normalization over repo metadata can trip CodeQL even when the input looks mundane.",
+      "outcome": "Replaced skill id slug regexes with a linear scanner and added hyphen-heavy regression coverage."
     }
   ],
   "nutrition": [
@@ -99,6 +110,7 @@
   "yardage_book_updates": [
     "Skill registry files live at config.skillsPath, defaulting to .slope/skills.json.",
     "SLOPE indexes SKILL.md and optional agents/openai.yaml metadata but does not execute skills.",
+    "Skill id normalization should stay linear and avoid regex trimming over uncontrolled metadata.",
     "Scorecard skill reference fields are skills_used, skills_created, skills_recommended, and skills_skipped; validate --skills checks these against the local registry.",
     "skill_gaps_found is free-form and intentionally not registry-checked."
   ],
@@ -108,7 +120,8 @@
     "Added scorecard skill fields and validate --skills reference checking.",
     "slope skills scan --root=.agents/skills, slope skills list, slope skills validate, and slope validate --skills smoke tests passed on the built CLI.",
     "pnpm build passed.",
-    "Full pnpm test passed: 214 test files and 3456 tests."
+    "CodeQL high-severity regex alert was fixed with linear skill id normalization.",
+    "Full pnpm test passed: 214 test files and 3457 tests."
   ],
   "skills_used": [
     "slope-sprint-workflow"

--- a/docs/retros/sprint-114.json
+++ b/docs/retros/sprint-114.json
@@ -1,0 +1,127 @@
+{
+  "sprint_number": 114,
+  "player": "codex",
+  "theme": "Skill Registry MVP",
+  "par": 5,
+  "slope": 3,
+  "score": 5,
+  "score_label": "par",
+  "date": "2026-05-23",
+  "shots": [
+    {
+      "ticket_key": "S114-1",
+      "title": "Add skill registry config, types, and .slope/skills.json persistence",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added the core skill registry schema, config defaults, persistence helpers, and exported API surface for repo-local skill metadata."
+    },
+    {
+      "ticket_key": "S114-2",
+      "title": "Scan configured skill roots and parse SKILL.md plus agents/openai.yaml metadata",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Implemented deterministic skill root scanning, YAML frontmatter parsing, agents/openai.yaml metadata capture, duplicate provider-root merging, and registry validation."
+    },
+    {
+      "ticket_key": "S114-3",
+      "title": "Add slope skills scan/list/validate commands and command registry docs",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "Self-review found that absolute --root and --output paths were being joined under cwd instead of preserved."
+        }
+      ],
+      "notes": "Added slope skills scan/list/validate, CLI dispatch, command registry metadata, smoke coverage, and absolute path regression coverage."
+    },
+    {
+      "ticket_key": "S114-4",
+      "title": "Add scorecard skill fields and validate --skills reference checks",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Self-review found malformed skill registry files could be loaded far enough to crash list/reference checks."
+        }
+      ],
+      "notes": "Added scorecard skill fields, builder support, structural validation, validate --skills reference checks, malformed registry rejection, and CLI regression coverage."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 2,
+    "hazard_penalties": 0.5,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "feature",
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "CLI path handling needs explicit absolute-path regression coverage.",
+      "outcome": "Added absolute --root/--output coverage for slope skills scan and resolved explicit validate paths against cwd."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Validated targeted skill/scorecard tests, typecheck, build, built CLI smoke tests, and the full Vitest suite.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "This was a satisfying first layer: SLOPE can now see skills as metadata without pretending to run them.",
+    "advice_for_next_player": "Keep S114.5 deterministic. Use this registry as input to briefing recommendations before attempting smarter gap detection.",
+    "what_surprised_you": "The useful review catches were plain path and malformed-file resilience, not the YAML parsing itself.",
+    "excited_about_next": "Briefing can now recommend skills from a real registry instead of relying on tribal memory."
+  },
+  "bunker_locations": [
+    "Any CLI path flag that accepts user filesystem input should preserve absolute paths and resolve relative paths against cwd in tests.",
+    "Registry loaders should reject malformed top-level shapes before downstream code maps over arrays."
+  ],
+  "yardage_book_updates": [
+    "Skill registry files live at config.skillsPath, defaulting to .slope/skills.json.",
+    "SLOPE indexes SKILL.md and optional agents/openai.yaml metadata but does not execute skills.",
+    "Scorecard skill reference fields are skills_used, skills_created, skills_recommended, and skills_skipped; validate --skills checks these against the local registry.",
+    "skill_gaps_found is free-form and intentionally not registry-checked."
+  ],
+  "course_management_notes": [
+    "Added src/core/skills.ts with scan, load/save, validation, duplicate merge, frontmatter parsing, and agents/openai.yaml metadata capture.",
+    "Added slope skills scan/list/validate and command registry metadata.",
+    "Added scorecard skill fields and validate --skills reference checking.",
+    "slope skills scan --root=.agents/skills, slope skills list, slope skills validate, and slope validate --skills smoke tests passed on the built CLI.",
+    "pnpm build passed.",
+    "Full pnpm test passed: 214 test files and 3456 tests."
+  ],
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow"
+  ],
+  "skill_gaps_found": [
+    "SLOPE needed first-class skill registry and scorecard skill tracking before skill-aware briefing can be deterministic."
+  ],
+  "slope_factors": [
+    "new_area",
+    "multi_package",
+    "schema_changes"
+  ]
+}

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -60,7 +60,7 @@ function skillsList(args: string[], cwd: string, config: SlopeConfig): void {
   const output = registryPath(cwd, config, args);
   const registry = loadSkillRegistry(output);
   if (!registry) {
-    console.log('No skill registry found. Run `slope skills scan` to create .slope/skills.json.\n');
+    console.log('No valid skill registry found. Run `slope skills scan` to create .slope/skills.json.\n');
     return;
   }
 
@@ -89,7 +89,7 @@ function skillsValidate(args: string[], cwd: string, config: SlopeConfig): void 
   const output = registryPath(cwd, config, args);
   const registry = loadSkillRegistry(output);
   if (!registry) {
-    console.error('No skill registry found. Run `slope skills scan` first.');
+    console.error('No valid skill registry found. Run `slope skills scan` first.');
     process.exit(1);
   }
 

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -1,0 +1,142 @@
+// slope skills — scan and validate repo-local skill metadata.
+
+import { join } from 'node:path';
+import {
+  DEFAULT_SKILLS_PATH,
+  DEFAULT_SKILL_ROOTS,
+  loadSkillRegistry,
+  saveSkillRegistry,
+  scanSkills,
+  validateSkillRegistry,
+} from '../../core/index.js';
+import type { SlopeConfig } from '../../core/index.js';
+import { loadConfig } from '../config.js';
+
+function parseFlag(args: string[], flag: string): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === flag && i + 1 < args.length) return args[i + 1];
+    if (args[i].startsWith(`${flag}=`)) return args[i].slice(flag.length + 1);
+  }
+  return undefined;
+}
+
+function parseRepeatable(args: string[], flag: string): string[] {
+  const values: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === flag && i + 1 < args.length) {
+      values.push(args[++i]);
+    } else if (args[i].startsWith(`${flag}=`)) {
+      values.push(args[i].slice(flag.length + 1));
+    }
+  }
+  return values.flatMap(value => value.split(',')).map(value => value.trim()).filter(Boolean);
+}
+
+function registryPath(cwd: string, config: SlopeConfig, args: string[]): string {
+  return join(cwd, parseFlag(args, '--output') ?? config.skillsPath ?? DEFAULT_SKILLS_PATH);
+}
+
+function rootsFor(config: SlopeConfig, args: string[]): string[] {
+  const roots = parseRepeatable(args, '--root');
+  if (roots.length > 0) return roots;
+  return config.skillRoots && config.skillRoots.length > 0 ? config.skillRoots : [...DEFAULT_SKILL_ROOTS];
+}
+
+function skillsScan(args: string[], cwd: string, config: SlopeConfig): void {
+  const roots = rootsFor(config, args);
+  const output = registryPath(cwd, config, args);
+  const { registry, warnings } = scanSkills({ cwd, roots });
+  saveSkillRegistry(registry, output);
+
+  console.log(`Scanned ${roots.length} root(s); wrote ${registry.skills.length} skill(s) to ${output}`);
+  for (const warning of warnings) {
+    console.log(`  [WARN] ${warning}`);
+  }
+  console.log('');
+}
+
+function skillsList(args: string[], cwd: string, config: SlopeConfig): void {
+  const output = registryPath(cwd, config, args);
+  const registry = loadSkillRegistry(output);
+  if (!registry) {
+    console.log('No skill registry found. Run `slope skills scan` to create .slope/skills.json.\n');
+    return;
+  }
+
+  if (args.includes('--json')) {
+    console.log(JSON.stringify(registry.skills, null, 2));
+    return;
+  }
+
+  if (registry.skills.length === 0) {
+    console.log('Skill registry exists but contains no skills.\n');
+    return;
+  }
+
+  console.log('\nRegistered Skills\n');
+  console.log('| ID | Description | Triggers | Sources |');
+  console.log('|----|-------------|----------|---------|');
+  for (const skill of registry.skills) {
+    const description = skill.description || '—';
+    const triggers = skill.triggers.length > 0 ? skill.triggers.join(', ') : '—';
+    console.log(`| ${skill.id} | ${description} | ${triggers} | ${skill.sources.length} |`);
+  }
+  console.log(`\n${registry.skills.length} skill(s) registered.\n`);
+}
+
+function skillsValidate(args: string[], cwd: string, config: SlopeConfig): void {
+  const output = registryPath(cwd, config, args);
+  const registry = loadSkillRegistry(output);
+  if (!registry) {
+    console.error('No skill registry found. Run `slope skills scan` first.');
+    process.exit(1);
+  }
+
+  const result = validateSkillRegistry(registry, cwd);
+  console.log('\nSLOPE Skill Registry Validation\n');
+  for (const error of result.errors) {
+    console.log(`  \x1b[31m[ERROR]\x1b[0m ${error}`);
+  }
+  for (const warning of result.warnings) {
+    console.log(`  \x1b[33m[WARN]\x1b[0m ${warning}`);
+  }
+
+  if (!result.valid) {
+    console.log(`\n\x1b[31m${result.errors.length} error(s), ${result.warnings.length} warning(s)\x1b[0m\n`);
+    process.exit(1);
+  }
+
+  console.log(`\x1b[32mAll ${registry.skills.length} skill(s) valid.\x1b[0m\n`);
+}
+
+export async function skillsCommand(args: string[]): Promise<void> {
+  const cwd = process.cwd();
+  const config = loadConfig(cwd);
+  const sub = args[0];
+  const rest = args.slice(1);
+
+  switch (sub) {
+    case 'scan':
+      skillsScan(rest, cwd, config);
+      break;
+    case 'list':
+      skillsList(rest, cwd, config);
+      break;
+    case 'validate':
+      skillsValidate(rest, cwd, config);
+      break;
+    default:
+      console.log(`
+slope skills — Repo-local Agent Skills registry
+
+Usage:
+  slope skills scan [--root=<path>] [--output=<path>]  Scan skill roots into .slope/skills.json
+  slope skills list [--json] [--output=<path>]         List registered skills
+  slope skills validate [--output=<path>]              Validate registry metadata and source paths
+
+SLOPE indexes, recommends, and validates skill metadata. It does not execute skills.
+`);
+      if (sub) process.exit(1);
+      break;
+  }
+}

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -1,6 +1,6 @@
 // slope skills — scan and validate repo-local skill metadata.
 
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import {
   DEFAULT_SKILLS_PATH,
   DEFAULT_SKILL_ROOTS,
@@ -33,7 +33,8 @@ function parseRepeatable(args: string[], flag: string): string[] {
 }
 
 function registryPath(cwd: string, config: SlopeConfig, args: string[]): string {
-  return join(cwd, parseFlag(args, '--output') ?? config.skillsPath ?? DEFAULT_SKILLS_PATH);
+  const output = parseFlag(args, '--output') ?? config.skillsPath ?? DEFAULT_SKILLS_PATH;
+  return isAbsolute(output) ? output : join(cwd, output);
 }
 
 function rootsFor(config: SlopeConfig, args: string[]): string[] {

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -1,16 +1,32 @@
 import { readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { validateScorecard } from '../../core/index.js';
+import { isAbsolute, join } from 'node:path';
+import { DEFAULT_SKILLS_PATH, loadSkillRegistry, skillIds, validateScorecard } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { updateGate } from '../sprint-state.js';
 
-export function validateCommand(path?: string): void {
+export function validateCommand(input?: string | string[]): void {
+  const args = Array.isArray(input) ? input : input ? [input] : [];
+  const validateSkills = args.includes('--skills');
+  const path = args.find(arg => !arg.startsWith('--'));
   const cwd = process.cwd();
   const config = loadConfig();
   const files: string[] = [];
+  let knownSkillIds: Set<string> | null = null;
+  let registryAvailable = true;
+
+  if (validateSkills) {
+    const registryPath = join(cwd, config.skillsPath ?? DEFAULT_SKILLS_PATH);
+    const registry = loadSkillRegistry(registryPath);
+    if (!registry) {
+      console.log(`\n✗ Skill registry not found at ${registryPath}. Run \`slope skills scan\` first.`);
+      registryAvailable = false;
+    } else {
+      knownSkillIds = skillIds(registry);
+    }
+  }
 
   if (path) {
-    files.push(path);
+    files.push(isAbsolute(path) ? path : join(cwd, path));
   } else {
     // Validate all scorecards matching config
     const dir = join(cwd, config.scorecardDir);
@@ -52,7 +68,7 @@ export function validateCommand(path?: string): void {
     }
 
     const card = { ...raw, sprint_number: raw.sprint_number ?? raw.sprint };
-    const result = validateScorecard(card);
+    const result = validateScorecard(card, knownSkillIds ? { knownSkillIds } : {});
 
     const sprintLabel = card.sprint_number ? `Sprint ${card.sprint_number}` : file;
 
@@ -78,9 +94,9 @@ export function validateCommand(path?: string): void {
   console.log('');
 
   // Mark scorecard gate complete on successful validation
-  if (allValid) {
+  if (allValid && registryAvailable) {
     updateGate(cwd, 'scorecard', true);
   }
 
-  process.exit(allValid ? 0 : 1);
+  process.exit(allValid && registryAvailable ? 0 : 1);
 }

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -18,7 +18,7 @@ export function validateCommand(input?: string | string[]): void {
     const registryPath = join(cwd, config.skillsPath ?? DEFAULT_SKILLS_PATH);
     const registry = loadSkillRegistry(registryPath);
     if (!registry) {
-      console.log(`\n✗ Skill registry not found at ${registryPath}. Run \`slope skills scan\` first.`);
+      console.log(`\n✗ Skill registry not found or invalid at ${registryPath}. Run \`slope skills scan\` first.`);
       registryAvailable = false;
     } else {
       knownSkillIds = skillIds(registry);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -74,6 +74,7 @@ import { worktreeCommand } from './commands/worktree.js';
 import { orgCommand } from './commands/org.js';
 import { memoryCommand } from './commands/memory.js';
 import { phaseCommand } from './commands/phase.js';
+import { skillsCommand } from './commands/skills.js';
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -93,6 +94,7 @@ Usage:
   slope card --player=<name>                Show handicap for a specific player
   slope card --team                         Show per-player comparison table
   slope validate [path]                     Validate scorecard(s)
+  slope skills scan|list|validate           Manage repo-local skill registry
   slope review [path] [--plain]             Format sprint review markdown
   slope briefing                            Pre-round briefing
   slope version                             Show current version
@@ -127,7 +129,7 @@ switch (subcommand) {
     cardCommand(process.argv.slice(3));
     break;
   case 'validate':
-    validateCommand(process.argv[3]);
+    validateCommand(process.argv.slice(3));
     break;
   case 'review': {
     const reviewArgs = process.argv.slice(3);
@@ -413,6 +415,12 @@ switch (subcommand) {
       process.exit(1);
     });
     break;
+  case 'skills':
+    skillsCommand(process.argv.slice(3)).catch(err => {
+      console.error('Error:', err.message);
+      process.exit(1);
+    });
+    break;
   case 'doctor':
     doctorCommand(process.argv.slice(3)).catch(err => {
       console.error('Error:', err.message);
@@ -467,6 +475,7 @@ Usage:
   slope card --player=<name>                Show handicap for a specific player
   slope card --team                         Show per-player comparison table
   slope validate [path]                     Validate scorecard(s)
+  slope validate [path] --skills            Validate scorecard skill references
   slope review [path] [--plain]             Format sprint review markdown
   slope review start [--rounds=N|--tier=T]  Start plan review lifecycle
   slope review round                        Record a completed review round
@@ -511,6 +520,7 @@ Usage:
   slope transcript list|show|stats          View session transcript data
   slope metaphor list|set|show              Manage metaphor display themes
   slope plugin list|validate                Manage custom plugins
+  slope skills scan|list|validate           Manage repo-local skill registry
   slope initiative create|status|next|advance|review  Multi-sprint initiative orchestration
   slope index [--full|--status|--prune]               Semantic embedding index
   slope context "query" [options]                     Semantic context search

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -139,7 +139,10 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
   },
   {
     cmd: 'validate', desc: 'Validate scorecard(s)', category: 'scoring',
-    flags: [{ flag: '<path>', desc: 'Scorecard JSON file to validate' }],
+    flags: [
+      { flag: '<path>', desc: 'Scorecard JSON file to validate' },
+      { flag: '--skills', desc: 'Check scorecard skill references against .slope/skills.json' },
+    ],
   },
   {
     cmd: 'review', desc: 'Format sprint review or manage review state', category: 'scoring',
@@ -349,6 +352,22 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
       { name: 'link', desc: 'Link inspiration to a sprint', flags: [
         { flag: '--id=<id>', desc: 'Inspiration ID (required)' },
         { flag: '--sprint=<N>', desc: 'Sprint number (required)' },
+      ]},
+    ],
+  },
+  {
+    cmd: 'skills', desc: 'Manage repo-local Agent Skills registry', category: 'tooling',
+    subcommands: [
+      { name: 'scan', desc: 'Scan configured skill roots into .slope/skills.json', flags: [
+        { flag: '--root=<path>', desc: 'Skill root to scan (repeatable or comma-separated)' },
+        { flag: '--output=<path>', desc: 'Registry output path (default: .slope/skills.json)' },
+      ]},
+      { name: 'list', desc: 'List registered skills', flags: [
+        { flag: '--json', desc: 'Output raw skill entries as JSON' },
+        { flag: '--output=<path>', desc: 'Registry path to read' },
+      ]},
+      { name: 'validate', desc: 'Validate registry metadata and source paths', flags: [
+        { flag: '--output=<path>', desc: 'Registry path to read' },
       ]},
     ],
   },

--- a/src/core/builder.ts
+++ b/src/core/builder.ts
@@ -169,6 +169,11 @@ export interface ScorecardInput {
   bunker_locations?: string[];
   yardage_book_updates?: string[];
   course_management_notes?: string[];
+  skills_used?: string[];
+  skills_created?: string[];
+  skills_recommended?: string[];
+  skills_skipped?: string[];
+  skill_gaps_found?: string[];
 
   // Multi-agent (swarm) sprints
   agents?: AgentBreakdown[];
@@ -221,6 +226,11 @@ export function buildScorecard(input: ScorecardInput): GolfScorecard {
     bunker_locations: input.bunker_locations ?? [],
     yardage_book_updates: input.yardage_book_updates ?? [],
     course_management_notes: input.course_management_notes ?? [],
+    ...(input.skills_used ? { skills_used: input.skills_used } : {}),
+    ...(input.skills_created ? { skills_created: input.skills_created } : {}),
+    ...(input.skills_recommended ? { skills_recommended: input.skills_recommended } : {}),
+    ...(input.skills_skipped ? { skills_skipped: input.skills_skipped } : {}),
+    ...(input.skill_gaps_found ? { skill_gaps_found: input.skill_gaps_found } : {}),
     ...(input.agents ? { agents: input.agents } : {}),
     ...(input.inspired_by ? { inspired_by: input.inspired_by } : {}),
   };

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -14,6 +14,8 @@ export interface SlopeConfig {
   roadmapPath: string;
   flowsPath: string;
   inspirationsPath: string;
+  skillsPath: string;
+  skillRoots?: string[];
   visionPath: string;
   repoProfilePath: string;
   transcriptsPath: string;
@@ -93,6 +95,7 @@ const DEFAULT_CONFIG: SlopeConfig = {
   roadmapPath: 'docs/backlog/roadmap.json',
   flowsPath: '.slope/flows.json',
   inspirationsPath: '.slope/inspirations.json',
+  skillsPath: '.slope/skills.json',
   visionPath: '.slope/vision.json',
   repoProfilePath: '.slope/repo-profile.json',
   transcriptsPath: '.slope/transcripts',

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -497,6 +497,28 @@ export type {
   InspirationValidationResult,
 } from './inspirations.js';
 
+// Skills
+export {
+  DEFAULT_SKILLS_PATH,
+  DEFAULT_SKILL_ROOTS,
+  resolveSkillRoots,
+  parseSkillMarkdown,
+  scanSkills,
+  validateSkillRegistry,
+  loadSkillRegistry,
+  saveSkillRegistry,
+  skillIds,
+} from './skills.js';
+export type {
+  SkillMetadataSource,
+  SkillSource,
+  SkillDefinition,
+  SkillRegistryFile,
+  SkillScanResult,
+  SkillRegistryValidationResult,
+  ParsedSkillMarkdown,
+} from './skills.js';
+
 // Imports (blast radius)
 export {
   parseImports,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -85,6 +85,7 @@ export type {
   ScorecardValidationError,
   ScorecardValidationWarning,
   ScorecardValidationResult,
+  ScorecardValidationOptions,
 } from './validation.js';
 
 // Dispersion

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -1,7 +1,7 @@
 // Skill registry — index repo-local Agent Skills metadata without executing skills.
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { basename, dirname, join, relative } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import type { SlopeConfig } from './config.js';
 
@@ -72,7 +72,7 @@ export function resolveSkillRoots(config: SlopeConfig, cwd: string = process.cwd
   const roots = config.skillRoots && config.skillRoots.length > 0
     ? config.skillRoots
     : [...DEFAULT_SKILL_ROOTS];
-  return roots.map(root => join(cwd, root));
+  return roots.map(root => isAbsolute(root) ? root : join(cwd, root));
 }
 
 export function parseSkillMarkdown(content: string): ParsedSkillMarkdown {
@@ -119,7 +119,7 @@ export function scanSkills(opts: {
   const byId = new Map<string, SkillDefinition>();
 
   for (const configuredRoot of roots) {
-    const absoluteRoot = join(cwd, configuredRoot);
+    const absoluteRoot = isAbsolute(configuredRoot) ? configuredRoot : join(cwd, configuredRoot);
     if (!existsSync(absoluteRoot)) continue;
 
     for (const skillPath of findSkillMarkdownFiles(absoluteRoot)) {

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -342,11 +342,36 @@ function mergeSkill(target: SkillDefinition, source: SkillDefinition): void {
 }
 
 function normalizeSkillId(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, '-')
-    .replace(/^-+|-+$/g, '') || 'skill';
+  let slug = '';
+  let lastReplacement = false;
+
+  for (const char of value.trim().toLowerCase()) {
+    if (isSkillIdChar(char)) {
+      slug += char;
+      lastReplacement = false;
+    } else if (!lastReplacement) {
+      slug += '-';
+      lastReplacement = true;
+    }
+  }
+
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug[start] === '-') start += 1;
+  while (end > start && slug[end - 1] === '-') end -= 1;
+
+  return slug.slice(start, end) || 'skill';
+}
+
+function isSkillIdChar(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return (
+    (code >= 97 && code <= 122)
+    || (code >= 48 && code <= 57)
+    || char === '.'
+    || char === '_'
+    || char === '-'
+  );
 }
 
 function firstString(...values: unknown[]): string | undefined {

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -1,0 +1,378 @@
+// Skill registry — index repo-local Agent Skills metadata without executing skills.
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, relative } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { SlopeConfig } from './config.js';
+
+export const DEFAULT_SKILLS_PATH = '.slope/skills.json';
+export const DEFAULT_SKILL_ROOTS = [
+  '.agents/skills',
+  '.claude/skills',
+  '.pi/skills',
+  '.codex/plugins',
+  'skills',
+] as const;
+
+export type SkillMetadataSource = 'SKILL.md' | 'agents/openai.yaml';
+
+export interface SkillSource {
+  path: string;
+  directory: string;
+  root: string;
+  metadata_sources: SkillMetadataSource[];
+  openai_metadata_path?: string;
+}
+
+export interface SkillDefinition {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  directory: string;
+  root: string;
+  sources: SkillSource[];
+  triggers: string[];
+  context_files?: string[];
+  version?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  openai?: Record<string, unknown>;
+}
+
+export interface SkillRegistryFile {
+  version: '1';
+  generated_at: string;
+  roots: string[];
+  skills: SkillDefinition[];
+  warnings?: string[];
+}
+
+export interface SkillScanResult {
+  registry: SkillRegistryFile;
+  warnings: string[];
+}
+
+export interface SkillRegistryValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface ParsedSkillMarkdown {
+  metadata: Record<string, unknown>;
+  body: string;
+  warnings: string[];
+}
+
+const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'coverage']);
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+export function resolveSkillRoots(config: SlopeConfig, cwd: string = process.cwd()): string[] {
+  const roots = config.skillRoots && config.skillRoots.length > 0
+    ? config.skillRoots
+    : [...DEFAULT_SKILL_ROOTS];
+  return roots.map(root => join(cwd, root));
+}
+
+export function parseSkillMarkdown(content: string): ParsedSkillMarkdown {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) {
+    return {
+      metadata: {},
+      body: content,
+      warnings: ['SKILL.md has no YAML frontmatter'],
+    };
+  }
+
+  try {
+    const parsed = parseYaml(match[1]) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return {
+        metadata: parsed as Record<string, unknown>,
+        body: content.slice(match[0].length),
+        warnings: [],
+      };
+    }
+    return {
+      metadata: {},
+      body: content.slice(match[0].length),
+      warnings: ['SKILL.md frontmatter is not an object'],
+    };
+  } catch (err) {
+    return {
+      metadata: {},
+      body: content.slice(match[0].length),
+      warnings: [`Failed to parse SKILL.md frontmatter: ${err instanceof Error ? err.message : String(err)}`],
+    };
+  }
+}
+
+export function scanSkills(opts: {
+  cwd?: string;
+  roots?: string[];
+  generatedAt?: string;
+} = {}): SkillScanResult {
+  const cwd = opts.cwd ?? process.cwd();
+  const roots = opts.roots ?? [...DEFAULT_SKILL_ROOTS];
+  const warnings: string[] = [];
+  const byId = new Map<string, SkillDefinition>();
+
+  for (const configuredRoot of roots) {
+    const absoluteRoot = join(cwd, configuredRoot);
+    if (!existsSync(absoluteRoot)) continue;
+
+    for (const skillPath of findSkillMarkdownFiles(absoluteRoot)) {
+      const scanned = readSkill(skillPath, absoluteRoot, cwd);
+      warnings.push(...scanned.warnings);
+      if (!scanned.skill) continue;
+
+      const existing = byId.get(scanned.skill.id);
+      if (!existing) {
+        byId.set(scanned.skill.id, scanned.skill);
+        continue;
+      }
+
+      mergeSkill(existing, scanned.skill);
+      warnings.push(`Merged duplicate skill id "${scanned.skill.id}" from ${scanned.skill.path}`);
+    }
+  }
+
+  const skills = [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+  const registry: SkillRegistryFile = {
+    version: '1',
+    generated_at: opts.generatedAt ?? new Date().toISOString(),
+    roots,
+    skills,
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+
+  return { registry, warnings };
+}
+
+export function validateSkillRegistry(registry: SkillRegistryFile, cwd: string = process.cwd()): SkillRegistryValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (registry.version !== '1') {
+    errors.push(`Unsupported skills registry version: ${registry.version}`);
+  }
+  if (!Array.isArray(registry.skills)) {
+    errors.push('skills registry must contain a skills array');
+    return { valid: false, errors, warnings };
+  }
+
+  const seen = new Set<string>();
+  for (const skill of registry.skills) {
+    if (!skill.id || typeof skill.id !== 'string') {
+      errors.push('Skill entry is missing a string id');
+      continue;
+    }
+    if (seen.has(skill.id)) {
+      errors.push(`Duplicate skill id: "${skill.id}"`);
+    }
+    seen.add(skill.id);
+
+    if (!skill.name || typeof skill.name !== 'string') {
+      errors.push(`Skill "${skill.id}" is missing a string name`);
+    }
+    if (!skill.description || typeof skill.description !== 'string') {
+      warnings.push(`Skill "${skill.id}" has no description`);
+    }
+    if (!Array.isArray(skill.triggers)) {
+      errors.push(`Skill "${skill.id}" triggers must be an array`);
+    } else if (skill.triggers.length === 0) {
+      warnings.push(`Skill "${skill.id}" has no triggers`);
+    } else if (skill.triggers.some(trigger => typeof trigger !== 'string')) {
+      errors.push(`Skill "${skill.id}" triggers must be strings`);
+    }
+
+    const paths = new Set<string>([skill.path, ...(skill.sources ?? []).map(source => source.path)]);
+    for (const path of paths) {
+      if (!path || typeof path !== 'string') {
+        errors.push(`Skill "${skill.id}" has an invalid source path`);
+        continue;
+      }
+      if (!existsSync(join(cwd, path))) {
+        errors.push(`Skill "${skill.id}" source not found: ${path}`);
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+export function loadSkillRegistry(registryPath: string): SkillRegistryFile | null {
+  if (!existsSync(registryPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(registryPath, 'utf8')) as unknown;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    return raw as SkillRegistryFile;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSkillRegistry(registry: SkillRegistryFile, registryPath: string): string {
+  const dir = dirname(registryPath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(registryPath, JSON.stringify(registry, null, 2) + '\n');
+  return registryPath;
+}
+
+export function skillIds(registry: SkillRegistryFile | null): Set<string> {
+  return new Set((registry?.skills ?? []).map(skill => skill.id));
+}
+
+function readSkill(skillPath: string, absoluteRoot: string, cwd: string): { skill: SkillDefinition | null; warnings: string[] } {
+  const warnings: string[] = [];
+  const relativePath = toRelativePath(cwd, skillPath);
+  const directory = toRelativePath(cwd, dirname(skillPath));
+  const root = toRelativePath(cwd, absoluteRoot);
+  const content = readFileSync(skillPath, 'utf8');
+  const parsed = parseSkillMarkdown(content);
+  warnings.push(...parsed.warnings.map(warning => `${relativePath}: ${warning}`));
+
+  const openai = readOpenAiMetadata(dirname(skillPath), cwd);
+  warnings.push(...openai.warnings.map(warning => `${relativePath}: ${warning}`));
+
+  const name = firstString(parsed.metadata.name, parsed.metadata.title, openai.metadata?.name, openai.metadata?.title)
+    ?? basename(dirname(skillPath));
+  const id = normalizeSkillId(firstString(parsed.metadata.id, openai.metadata?.id, name) ?? basename(dirname(skillPath)));
+  const description = firstString(parsed.metadata.description, openai.metadata?.description, firstMarkdownParagraph(parsed.body)) ?? '';
+  const triggers = uniqueStrings([
+    ...toStringArray(parsed.metadata.triggers),
+    ...toStringArray(openai.metadata?.triggers),
+  ]);
+  const contextFiles = uniqueStrings(toStringArray(parsed.metadata.context_files));
+  const tags = uniqueStrings([...toStringArray(parsed.metadata.tags), ...toStringArray(openai.metadata?.tags)]);
+  const version = firstString(parsed.metadata.version, openai.metadata?.version);
+  const sources: SkillSource[] = [{
+    path: relativePath,
+    directory,
+    root,
+    metadata_sources: openai.metadata ? ['SKILL.md', 'agents/openai.yaml'] : ['SKILL.md'],
+    ...(openai.path ? { openai_metadata_path: openai.path } : {}),
+  }];
+
+  return {
+    skill: {
+      id,
+      name,
+      description,
+      path: relativePath,
+      directory,
+      root,
+      sources,
+      triggers,
+      ...(contextFiles.length > 0 ? { context_files: contextFiles } : {}),
+      ...(version ? { version } : {}),
+      ...(tags.length > 0 ? { tags } : {}),
+      ...(Object.keys(parsed.metadata).length > 0 ? { metadata: parsed.metadata } : {}),
+      ...(openai.metadata ? { openai: openai.metadata } : {}),
+    },
+    warnings,
+  };
+}
+
+function readOpenAiMetadata(skillDir: string, cwd: string): { metadata?: Record<string, unknown>; path?: string; warnings: string[] } {
+  const openaiPath = join(skillDir, 'agents', 'openai.yaml');
+  if (!existsSync(openaiPath)) return { warnings: [] };
+
+  try {
+    const parsed = parseYaml(readFileSync(openaiPath, 'utf8')) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return { metadata: parsed as Record<string, unknown>, path: toRelativePath(cwd, openaiPath), warnings: [] };
+    }
+    return { path: toRelativePath(cwd, openaiPath), warnings: ['agents/openai.yaml metadata is not an object'] };
+  } catch (err) {
+    return {
+      path: toRelativePath(cwd, openaiPath),
+      warnings: [`Failed to parse agents/openai.yaml: ${err instanceof Error ? err.message : String(err)}`],
+    };
+  }
+}
+
+function findSkillMarkdownFiles(root: string): string[] {
+  const found: string[] = [];
+  const visit = (dir: string): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries.sort()) {
+      if (SKIP_DIRS.has(entry)) continue;
+      const fullPath = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        visit(fullPath);
+      } else if (entry === 'SKILL.md') {
+        found.push(fullPath);
+      }
+    }
+  };
+  visit(root);
+  return found.sort();
+}
+
+function mergeSkill(target: SkillDefinition, source: SkillDefinition): void {
+  target.sources.push(...source.sources);
+  target.triggers = uniqueStrings([...target.triggers, ...source.triggers]);
+  if (!target.description && source.description) target.description = source.description;
+  if (!target.version && source.version) target.version = source.version;
+  if (source.context_files) {
+    target.context_files = uniqueStrings([...(target.context_files ?? []), ...source.context_files]);
+  }
+  if (source.tags) {
+    target.tags = uniqueStrings([...(target.tags ?? []), ...source.tags]);
+  }
+}
+
+function normalizeSkillId(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'skill';
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim();
+  }
+  return undefined;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function firstMarkdownParagraph(body: string): string | undefined {
+  for (const line of body.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('```')) continue;
+    return trimmed.replace(/^[-*]\s+/, '');
+  }
+  return undefined;
+}
+
+function toRelativePath(cwd: string, path: string): string {
+  const rel = relative(cwd, path);
+  return rel === '' ? '.' : rel.split('\\').join('/');
+}

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -207,6 +207,10 @@ export function loadSkillRegistry(registryPath: string): SkillRegistryFile | nul
   try {
     const raw = JSON.parse(readFileSync(registryPath, 'utf8')) as unknown;
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const candidate = raw as Partial<SkillRegistryFile>;
+    if (candidate.version !== '1' || !Array.isArray(candidate.roots) || !Array.isArray(candidate.skills)) {
+      return null;
+    }
     return raw as SkillRegistryFile;
   } catch {
     return null;
@@ -221,7 +225,8 @@ export function saveSkillRegistry(registry: SkillRegistryFile, registryPath: str
 }
 
 export function skillIds(registry: SkillRegistryFile | null): Set<string> {
-  return new Set((registry?.skills ?? []).map(skill => skill.id));
+  const skills = Array.isArray(registry?.skills) ? registry.skills : [];
+  return new Set(skills.map(skill => skill.id));
 }
 
 function readSkill(skillPath: string, absoluteRoot: string, cwd: string): { skill: SkillDefinition | null; warnings: string[] } {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -146,6 +146,16 @@ export interface GolfScorecard extends HoleScore {
   bunker_locations: string[];
   course_management_notes: string[];
   nineteenth_hole?: NineteenthHole;
+  /** Skill IDs used during this sprint */
+  skills_used?: string[];
+  /** Skill IDs created or materially updated during this sprint */
+  skills_created?: string[];
+  /** Skill IDs recommended during planning or review */
+  skills_recommended?: string[];
+  /** Skill IDs considered but intentionally skipped */
+  skills_skipped?: string[];
+  /** Repeated work patterns that may need a future skill */
+  skill_gaps_found?: string[];
   /** Per-agent breakdowns for multi-agent (swarm) sprints */
   agents?: AgentBreakdown[];
   /** External inspiration sources that influenced this sprint */

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -20,6 +20,10 @@ export interface ScorecardValidationResult {
   warnings: ScorecardValidationWarning[];
 }
 
+export interface ScorecardValidationOptions {
+  knownSkillIds?: Set<string> | string[];
+}
+
 // --- Helpers ---
 
 const MISS_RESULTS: Record<string, 'long' | 'short' | 'left' | 'right'> = {
@@ -30,6 +34,8 @@ const MISS_RESULTS: Record<string, 'long' | 'short' | 'left' | 'right'> = {
 };
 
 const GOOD_RESULTS = new Set<ShotResult>(['fairway', 'green', 'in_the_hole']);
+const SKILL_REFERENCE_FIELDS = ['skills_used', 'skills_created', 'skills_recommended', 'skills_skipped'] as const;
+const SKILL_NOTE_FIELDS = ['skill_gaps_found'] as const;
 
 function isValidISODate(s: string): boolean {
   const d = new Date(s);
@@ -42,9 +48,17 @@ function isValidISODate(s: string): boolean {
  * Validate a SLOPE scorecard for internal consistency.
  * Accepts either `sprint_number` (TypeScript type) or `sprint` (retro JSON field name).
  */
-export function validateScorecard(card: GolfScorecard & { sprint?: number }): ScorecardValidationResult {
+export function validateScorecard(
+  card: GolfScorecard & { sprint?: number },
+  options: ScorecardValidationOptions = {},
+): ScorecardValidationResult {
   const errors: ScorecardValidationError[] = [];
   const warnings: ScorecardValidationWarning[] = [];
+  const knownSkillIds = options.knownSkillIds
+    ? options.knownSkillIds instanceof Set
+      ? options.knownSkillIds
+      : new Set(options.knownSkillIds)
+    : null;
 
   // Normalize sprint field — retro JSONs use "sprint", TS type uses "sprint_number"
   const sprintNumber = card.sprint_number ?? card.sprint;
@@ -62,6 +76,8 @@ export function validateScorecard(card: GolfScorecard & { sprint?: number }): Sc
   if (sprintNumber == null || typeof sprintNumber !== 'number' || sprintNumber <= 0) {
     errors.push({ code: 'MISSING_SPRINT', message: 'sprint_number (or sprint) is required and must be > 0', field: 'sprint_number' });
   }
+
+  validateSkillFields(card as unknown as Record<string, unknown>, errors, knownSkillIds);
 
   // Rule 1: score_label matches computeScoreLabel(score, par)
   if (typeof card.score === 'number' && card.score > 0 && [3, 4, 5].includes(card.par)) {
@@ -172,4 +188,50 @@ export function validateScorecard(card: GolfScorecard & { sprint?: number }): Sc
     errors,
     warnings,
   };
+}
+
+function validateSkillFields(
+  card: Record<string, unknown>,
+  errors: ScorecardValidationError[],
+  knownSkillIds: Set<string> | null,
+): void {
+  for (const field of [...SKILL_REFERENCE_FIELDS, ...SKILL_NOTE_FIELDS]) {
+    const value = card[field];
+    if (value == null) continue;
+    if (!Array.isArray(value)) {
+      errors.push({
+        code: 'INVALID_SKILL_FIELD',
+        message: `${field} must be an array of strings`,
+        field,
+      });
+      continue;
+    }
+
+    for (const item of value) {
+      if (typeof item !== 'string' || item.trim().length === 0) {
+        errors.push({
+          code: 'INVALID_SKILL_FIELD',
+          message: `${field} must contain only non-empty strings`,
+          field,
+        });
+      }
+    }
+  }
+
+  if (!knownSkillIds) return;
+
+  for (const field of SKILL_REFERENCE_FIELDS) {
+    const values = card[field];
+    if (!Array.isArray(values)) continue;
+    for (const value of values) {
+      if (typeof value !== 'string' || value.trim().length === 0) continue;
+      if (!knownSkillIds.has(value)) {
+        errors.push({
+          code: 'UNKNOWN_SKILL_REFERENCE',
+          message: `${field} references unknown skill "${value}"`,
+          field,
+        });
+      }
+    }
+  }
 }

--- a/tests/cli/skills.test.ts
+++ b/tests/cli/skills.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+let tmpDir: string;
+let exitCode: number | undefined;
+
+vi.spyOn(process, 'cwd').mockImplementation(() => tmpDir);
+vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
+  exitCode = code as number;
+  throw new Error(`process.exit(${code})`);
+});
+
+import { skillsCommand } from '../../src/cli/commands/skills.js';
+
+function writeConfig(): void {
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+    minSprint: 1,
+    skillsPath: '.slope/skills.json',
+    skillRoots: ['.agents/skills'],
+  }));
+}
+
+function writeSkill(): void {
+  const dir = join(tmpDir, '.agents', 'skills', 'review-helper');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'SKILL.md'), `---
+name: review-helper
+description: Review pull requests.
+triggers:
+  - review
+---
+
+Review pull requests.
+`);
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-cli-skills-'));
+  writeConfig();
+  exitCode = undefined;
+});
+
+afterEach(() => {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('slope skills scan', () => {
+  it('creates .slope/skills.json from configured roots', async () => {
+    writeSkill();
+
+    await skillsCommand(['scan']);
+
+    const registryPath = join(tmpDir, '.slope', 'skills.json');
+    expect(existsSync(registryPath)).toBe(true);
+    const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+    expect(registry.skills[0].id).toBe('review-helper');
+    expect(registry.skills[0].path).toBe('.agents/skills/review-helper/SKILL.md');
+  });
+
+  it('accepts explicit repeated roots', async () => {
+    writeSkill();
+
+    await skillsCommand(['scan', '--root=.agents/skills']);
+
+    const registry = JSON.parse(readFileSync(join(tmpDir, '.slope', 'skills.json'), 'utf8'));
+    expect(registry.roots).toEqual(['.agents/skills']);
+  });
+});
+
+describe('slope skills list', () => {
+  it('prints registered skills', async () => {
+    writeSkill();
+    await skillsCommand(['scan']);
+
+    const logged: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logged.push(args.join(' '));
+    });
+    await skillsCommand(['list']);
+    spy.mockRestore();
+
+    expect(logged.some(line => line.includes('review-helper'))).toBe(true);
+    expect(logged.some(line => line.includes('1 skill(s) registered'))).toBe(true);
+  });
+
+  it('prints JSON with --json', async () => {
+    writeSkill();
+    await skillsCommand(['scan']);
+
+    const logged: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logged.push(args.join(' '));
+    });
+    await skillsCommand(['list', '--json']);
+    spy.mockRestore();
+
+    const parsed = JSON.parse(logged.join('\n'));
+    expect(parsed[0].id).toBe('review-helper');
+  });
+});
+
+describe('slope skills validate', () => {
+  it('passes for a valid registry', async () => {
+    writeSkill();
+    await skillsCommand(['scan']);
+
+    const logged: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logged.push(args.join(' '));
+    });
+    await skillsCommand(['validate']);
+    spy.mockRestore();
+
+    expect(logged.some(line => line.includes('All 1 skill(s) valid'))).toBe(true);
+  });
+
+  it('exits 1 when registry is missing', async () => {
+    await expect(skillsCommand(['validate'])).rejects.toThrow('process.exit(1)');
+    expect(exitCode).toBe(1);
+  });
+});

--- a/tests/cli/skills.test.ts
+++ b/tests/cli/skills.test.ts
@@ -70,6 +70,18 @@ describe('slope skills scan', () => {
     const registry = JSON.parse(readFileSync(join(tmpDir, '.slope', 'skills.json'), 'utf8'));
     expect(registry.roots).toEqual(['.agents/skills']);
   });
+
+  it('honors absolute root and output paths', async () => {
+    writeSkill();
+    const root = join(tmpDir, '.agents', 'skills');
+    const output = join(tmpDir, 'custom', 'skills.json');
+
+    await skillsCommand(['scan', `--root=${root}`, `--output=${output}`]);
+
+    expect(existsSync(output)).toBe(true);
+    const registry = JSON.parse(readFileSync(output, 'utf8'));
+    expect(registry.skills[0].id).toBe('review-helper');
+  });
 });
 
 describe('slope skills list', () => {

--- a/tests/cli/validate-skills.test.ts
+++ b/tests/cli/validate-skills.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildScorecard } from '../../src/core/builder.js';
+import type { SkillRegistryFile } from '../../src/core/skills.js';
+
+let tmpDir: string;
+let exitCode: number | undefined;
+
+vi.spyOn(process, 'cwd').mockImplementation(() => tmpDir);
+vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
+  exitCode = code as number;
+  throw new Error(`process.exit(${code})`);
+});
+
+import { validateCommand } from '../../src/cli/commands/validate.js';
+
+function writeConfig(): void {
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+    minSprint: 1,
+    skillsPath: '.slope/skills.json',
+  }));
+}
+
+function writeRegistry(ids: string[]): void {
+  const registry: SkillRegistryFile = {
+    version: '1',
+    generated_at: '2026-05-23T00:00:00.000Z',
+    roots: ['.agents/skills'],
+    skills: ids.map(id => ({
+      id,
+      name: id,
+      description: `${id} description`,
+      path: `.agents/skills/${id}/SKILL.md`,
+      directory: `.agents/skills/${id}`,
+      root: '.agents/skills',
+      sources: [{
+        path: `.agents/skills/${id}/SKILL.md`,
+        directory: `.agents/skills/${id}`,
+        root: '.agents/skills',
+        metadata_sources: ['SKILL.md'],
+      }],
+      triggers: ['test'],
+    })),
+  };
+  writeFileSync(join(tmpDir, '.slope', 'skills.json'), JSON.stringify(registry, null, 2));
+}
+
+function writeScorecard(skillsUsed: string[]): string {
+  const retrosDir = join(tmpDir, 'docs', 'retros');
+  mkdirSync(retrosDir, { recursive: true });
+  const card = buildScorecard({
+    sprint_number: 1,
+    theme: 'Skill validation',
+    par: 3,
+    slope: 1,
+    date: '2026-05-23',
+    player: 'test',
+    shots: [{
+      ticket_key: 'S1-1',
+      title: 'Test',
+      club: 'wedge',
+      result: 'in_the_hole',
+      hazards: [],
+    }],
+    training: [{ type: 'lessons', description: 'test', outcome: 'ok' }],
+    nutrition: [{ category: 'hydration', description: 'test', status: 'healthy' }],
+    bunker_locations: ['none'],
+    skills_used: skillsUsed,
+  });
+  const path = join(retrosDir, 'sprint-1.json');
+  writeFileSync(path, JSON.stringify(card, null, 2));
+  return 'docs/retros/sprint-1.json';
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-validate-skills-'));
+  writeConfig();
+  exitCode = undefined;
+});
+
+afterEach(() => {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('slope validate --skills', () => {
+  it('passes when scorecard skill references exist in the registry', () => {
+    writeRegistry(['slope-sprint-workflow']);
+    const path = writeScorecard(['slope-sprint-workflow']);
+
+    expect(() => validateCommand([path, '--skills'])).toThrow('process.exit(0)');
+    expect(exitCode).toBe(0);
+  });
+
+  it('fails when scorecard skill references are unknown', () => {
+    writeRegistry(['slope-sprint-workflow']);
+    const path = writeScorecard(['missing-skill']);
+
+    expect(() => validateCommand([path, '--skills'])).toThrow('process.exit(1)');
+    expect(exitCode).toBe(1);
+  });
+
+  it('fails when --skills is used before scanning a registry', () => {
+    const path = writeScorecard(['slope-sprint-workflow']);
+
+    expect(() => validateCommand([path, '--skills'])).toThrow('process.exit(1)');
+    expect(exitCode).toBe(1);
+  });
+});

--- a/tests/core/skills.test.ts
+++ b/tests/core/skills.test.ts
@@ -106,6 +106,21 @@ Set up the repo.
     expect(result.registry.skills[0].id).toBe('setup');
   });
 
+  it('normalizes hyphen-heavy skill names in linear time', () => {
+    const paddedName = `${'-'.repeat(5000)}Skill Name${'-'.repeat(5000)}`;
+    writeSkill('.agents/skills', 'slow-name', `---
+name: ${JSON.stringify(paddedName)}
+description: Normalize safely.
+---
+
+Use this skill.
+`);
+
+    const result = scanSkills({ cwd: tmpDir, roots: ['.agents/skills'] });
+
+    expect(result.registry.skills[0].id).toBe('skill-name');
+  });
+
   it('merges duplicate skill ids across provider roots', () => {
     const skill = `---
 name: slope-sprint-workflow

--- a/tests/core/skills.test.ts
+++ b/tests/core/skills.test.ts
@@ -91,6 +91,21 @@ context_files:
     });
   });
 
+  it('honors absolute scan roots', () => {
+    writeSkill('custom-skills', 'setup', `---
+name: setup
+description: Configure a project.
+---
+
+Set up the repo.
+`);
+
+    const result = scanSkills({ cwd: tmpDir, roots: [join(tmpDir, 'custom-skills')] });
+
+    expect(result.registry.skills).toHaveLength(1);
+    expect(result.registry.skills[0].id).toBe('setup');
+  });
+
   it('merges duplicate skill ids across provider roots', () => {
     const skill = `---
 name: slope-sprint-workflow

--- a/tests/core/skills.test.ts
+++ b/tests/core/skills.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  parseSkillMarkdown,
+  scanSkills,
+  validateSkillRegistry,
+  saveSkillRegistry,
+  loadSkillRegistry,
+  skillIds,
+} from '../../src/core/skills.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-skills-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeSkill(root: string, name: string, content: string, openaiYaml?: string): void {
+  const dir = join(tmpDir, root, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'SKILL.md'), content);
+  if (openaiYaml) {
+    mkdirSync(join(dir, 'agents'), { recursive: true });
+    writeFileSync(join(dir, 'agents', 'openai.yaml'), openaiYaml);
+  }
+}
+
+describe('parseSkillMarkdown', () => {
+  it('parses YAML frontmatter and body', () => {
+    const parsed = parseSkillMarkdown(`---
+name: slope-sprint-workflow
+version: "1.0"
+description: Sprint lifecycle orchestration.
+triggers:
+  - sprint
+---
+
+# Skill
+
+Use this for sprint work.
+`);
+
+    expect(parsed.metadata.name).toBe('slope-sprint-workflow');
+    expect(parsed.metadata.version).toBe('1.0');
+    expect(parsed.body).toContain('Use this for sprint work');
+    expect(parsed.warnings).toHaveLength(0);
+  });
+
+  it('warns when frontmatter is missing', () => {
+    const parsed = parseSkillMarkdown('# Skill only');
+    expect(parsed.metadata).toEqual({});
+    expect(parsed.warnings[0]).toContain('no YAML frontmatter');
+  });
+});
+
+describe('scanSkills', () => {
+  it('scans configured roots and parses SKILL.md metadata', () => {
+    writeSkill('.agents/skills', 'slope-sprint-workflow', `---
+name: slope-sprint-workflow
+description: Sprint lifecycle orchestration.
+triggers:
+  - sprint
+context_files:
+  - CODEBASE.md
+---
+
+# SLOPE Sprint Workflow
+`);
+
+    const result = scanSkills({
+      cwd: tmpDir,
+      roots: ['.agents/skills'],
+      generatedAt: '2026-05-23T00:00:00.000Z',
+    });
+
+    expect(result.registry.generated_at).toBe('2026-05-23T00:00:00.000Z');
+    expect(result.registry.skills).toHaveLength(1);
+    expect(result.registry.skills[0]).toMatchObject({
+      id: 'slope-sprint-workflow',
+      name: 'slope-sprint-workflow',
+      description: 'Sprint lifecycle orchestration.',
+      path: '.agents/skills/slope-sprint-workflow/SKILL.md',
+      triggers: ['sprint'],
+      context_files: ['CODEBASE.md'],
+    });
+  });
+
+  it('merges duplicate skill ids across provider roots', () => {
+    const skill = `---
+name: slope-sprint-workflow
+description: Sprint lifecycle orchestration.
+triggers:
+  - sprint
+---
+
+Guide.
+`;
+    writeSkill('.agents/skills', 'slope-sprint-workflow', skill);
+    writeSkill('.claude/skills', 'slope-sprint-workflow', skill);
+
+    const result = scanSkills({ cwd: tmpDir, roots: ['.agents/skills', '.claude/skills'] });
+
+    expect(result.registry.skills).toHaveLength(1);
+    expect(result.registry.skills[0].sources).toHaveLength(2);
+    expect(result.warnings.some(w => w.includes('Merged duplicate skill id'))).toBe(true);
+  });
+
+  it('parses agents/openai.yaml metadata without making it executable', () => {
+    writeSkill(
+      '.agents/skills',
+      'review-helper',
+      `---
+name: review-helper
+description: Review PRs.
+---
+
+Review pull requests.
+`,
+      `name: review-helper
+triggers:
+  - code review
+tags:
+  - github
+`,
+    );
+
+    const result = scanSkills({ cwd: tmpDir, roots: ['.agents/skills'] });
+    const skill = result.registry.skills[0];
+
+    expect(skill.triggers).toEqual(['code review']);
+    expect(skill.tags).toEqual(['github']);
+    expect(skill.sources[0].metadata_sources).toEqual(['SKILL.md', 'agents/openai.yaml']);
+    expect(skill.sources[0].openai_metadata_path).toBe('.agents/skills/review-helper/agents/openai.yaml');
+    expect(skill.openai?.name).toBe('review-helper');
+  });
+});
+
+describe('skill registry persistence and validation', () => {
+  it('saves and loads .slope/skills.json', () => {
+    writeSkill('.agents/skills', 'setup', `---
+name: setup
+description: Configure a project.
+---
+
+Set up the repo.
+`);
+    const { registry } = scanSkills({ cwd: tmpDir, roots: ['.agents/skills'] });
+    const path = saveSkillRegistry(registry, join(tmpDir, '.slope', 'skills.json'));
+
+    const loaded = loadSkillRegistry(path);
+    expect(loaded?.skills[0].id).toBe('setup');
+    expect(skillIds(loaded).has('setup')).toBe(true);
+  });
+
+  it('validates duplicate ids and missing source paths', () => {
+    writeSkill('.agents/skills', 'setup', `---
+name: setup
+description: Configure a project.
+triggers:
+  - setup
+---
+
+Set up the repo.
+`);
+    const { registry } = scanSkills({ cwd: tmpDir, roots: ['.agents/skills'] });
+    registry.skills.push({ ...registry.skills[0], path: '.agents/skills/missing/SKILL.md' });
+
+    const result = validateSkillRegistry(registry, tmpDir);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Duplicate skill id'))).toBe(true);
+    expect(result.errors.some(e => e.includes('source not found'))).toBe(true);
+  });
+});

--- a/tests/core/skills.test.ts
+++ b/tests/core/skills.test.ts
@@ -173,6 +173,15 @@ Set up the repo.
     expect(skillIds(loaded).has('setup')).toBe(true);
   });
 
+  it('returns null for malformed registry files', () => {
+    const path = join(tmpDir, '.slope', 'skills.json');
+    mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+    writeFileSync(path, JSON.stringify({ version: '1', roots: [], skills: null }));
+
+    expect(loadSkillRegistry(path)).toBeNull();
+    expect(skillIds(null)).toEqual(new Set());
+  });
+
   it('validates duplicate ids and missing source paths', () => {
     writeSkill('.agents/skills', 'setup', `---
 name: setup

--- a/tests/core/validation.test.ts
+++ b/tests/core/validation.test.ts
@@ -261,6 +261,44 @@ describe('validateScorecard - basic fields', () => {
   });
 });
 
+describe('validateScorecard - skill fields', () => {
+  it('accepts skill tracking fields with known skill ids', () => {
+    const result = validateScorecard(makeCard({
+      skills_used: ['slope-sprint-workflow'],
+      skills_recommended: ['slope-sprint-workflow'],
+      skills_skipped: ['slope-api-reference'],
+      skills_created: ['skill-registry'],
+      skill_gaps_found: ['release triage skill gap'],
+    }), {
+      knownSkillIds: ['slope-sprint-workflow', 'slope-api-reference', 'skill-registry'],
+    });
+
+    expect(result.errors.filter(e => e.code === 'INVALID_SKILL_FIELD')).toHaveLength(0);
+    expect(result.errors.filter(e => e.code === 'UNKNOWN_SKILL_REFERENCE')).toHaveLength(0);
+  });
+
+  it('fails when skill fields are not arrays of strings', () => {
+    const result = validateScorecard(makeCard({
+      skills_used: 'slope-sprint-workflow' as any,
+      skill_gaps_found: [42] as any,
+    }));
+
+    expect(result.errors.filter(e => e.code === 'INVALID_SKILL_FIELD')).toHaveLength(2);
+  });
+
+  it('fails when referenced skills are not registered', () => {
+    const result = validateScorecard(makeCard({
+      skills_used: ['missing-skill'],
+      skill_gaps_found: ['missing-skill'],
+    }), {
+      knownSkillIds: ['slope-sprint-workflow'],
+    });
+
+    expect(result.errors.some(e => e.code === 'UNKNOWN_SKILL_REFERENCE' && e.field === 'skills_used')).toBe(true);
+    expect(result.errors.some(e => e.code === 'UNKNOWN_SKILL_REFERENCE' && e.field === 'skill_gaps_found')).toBe(false);
+  });
+});
+
 // --- Sprint field normalization ---
 
 describe('validateScorecard - sprint field normalization', () => {


### PR DESCRIPTION
## Summary\n- add a core skill registry for repo-local SKILL.md metadata plus optional agents/openai.yaml capture\n- add slope skills scan/list/validate and command registry/help wiring\n- add scorecard skill tracking fields and validate --skills registry reference checks\n- add S114 scorecard and review artifacts\n\n## Verification\n- pnpm build\n- pnpm test (214 files, 3456 tests passed, 23 skipped)\n- pnpm vitest run tests/core/skills.test.ts tests/cli/skills.test.ts tests/cli/validate-skills.test.ts\n- slope skills scan --root=.agents/skills\n- slope skills list\n- slope skills validate\n- slope validate docs/retros/sprint-114.json --skills\n- git diff --check main...HEAD\n\nRefs #431