### PR TITLE
[codex] Close skill-aware briefing #431

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -179,6 +179,14 @@
       ],
       "status": "complete",
       "note": "Add repo-local skill registry, skill validation, scorecard skill fields, and skill-aware briefing for #431."
+    },
+    {
+      "name": "Phase 30 \u2014 Skill Awareness Closeout",
+      "sprints": [
+        115
+      ],
+      "status": "planned",
+      "note": "Close the remaining #431 acceptance gap and fix decimal sprint follow-on inference."
     }
   ],
   "sprints": [
@@ -2214,6 +2222,48 @@
             "S114.5-1",
             "S114.5-2",
             "S114.5-3"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 115,
+      "theme": "Skill Awareness Closeout",
+      "par": 3,
+      "slope": 2,
+      "type": "fix + feature",
+      "status": "planned",
+      "depends_on": [
+        114.5
+      ],
+      "note": "Close #431 by adding changed/claimed file matching to skill-aware briefing and fixing next-sprint inference after inserted decimal sprints.",
+      "tickets": [
+        {
+          "key": "S115-1",
+          "title": "Fix slope next fallback after decimal inserted sprint scorecards",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 431
+        },
+        {
+          "key": "S115-2",
+          "title": "Include claimed/changed file paths in skill-aware briefing recommendations",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 431,
+          "depends_on": [
+            "S115-1"
+          ]
+        },
+        {
+          "key": "S115-3",
+          "title": "Record closeout and close #431",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 431,
+          "depends_on": [
+            "S115-1",
+            "S115-2"
           ]
         }
       ]

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -185,7 +185,7 @@
       "sprints": [
         115
       ],
-      "status": "planned",
+      "status": "complete",
       "note": "Close the remaining #431 acceptance gap and fix decimal sprint follow-on inference."
     }
   ],
@@ -2232,7 +2232,7 @@
       "par": 3,
       "slope": 2,
       "type": "fix + feature",
-      "status": "planned",
+      "status": "complete",
       "depends_on": [
         114.5
       ],

--- a/docs/retros/sprint-115-review.md
+++ b/docs/retros/sprint-115-review.md
@@ -1,0 +1,71 @@
+## Sprint 115 Review: Skill Awareness Closeout
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 2 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (3/3) |
+| GIR % | 100% (3/3) |
+| Putts | 0 |
+| Penalties | 0 |
+| Hazard Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 3)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S115-1 | Wedge | In the Hole | - | Added nextCanonicalSprintId so scorecard fallbacks advance from inserted decimal sprints such as S114.5 to the canonical next sprint, S115. |
+| S115-2 | Short Iron | In the Hole | - | Threaded active claims and changedFiles into buildSkillBriefing so Recommended Skills can cite changed file paths as an explainable ranking signal. |
+| S115-3 | Wedge | Green | Rough: The first full-suite run exposed that the git analyzer commits-per-week fixture could exceed Vitest's default 5s timeout on a busy local machine. | Hardened the timing-sensitive git analyzer fixture, reran the full suite successfully, and recorded the S115 closeout artifacts. |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Rough | S115-3 | The first full-suite run exposed that the git analyzer commits-per-week fixture could exceed Vitest's default 5s timeout on a busy local machine. |
+
+**Known hazards for future sprints:**
+- Next-sprint fallback must use canonical sprint math, not raw numeric +1 after inserted sprint ids.
+- Skill-aware briefing should include active claims and changed file paths before considering #431 complete.
+- Git fixture tests that create multiple real commits can need explicit timeout headroom in full-suite runs.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Inserted decimal scorecards need canonical fallback math. | nextCanonicalSprintId now centralizes sprint fallback behavior for integer, decimal, and encoded inserted sprint ids. |
+| Lessons | Issue acceptance lists should be re-read before closure. | The remaining #431 changed-files signal was added after comparing the implemented briefing flow against the original issue body. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Focused regressions, typecheck, build, built CLI smoke checks, git analyzer fixture rerun, and full pnpm test suite passed. |
+| docs | healthy | Recorded S115 roadmap, scorecard, and review artifacts for #431 closeout. |
+
+### Course Management Notes
+
+- Added nextCanonicalSprintId coverage for integer, decimal inserted, and encoded inserted sprint ids.
+- Added slope next regression coverage proving S114.5 scorecards advance to S115 rather than S115.5.
+- Added skill briefing regression coverage for claimed and changed file path recommendation signals.
+- Hardened the git analyzer commits-per-week fixture timeout after an initial full-suite timing failure.
+- pnpm vitest run tests/core/briefing.test.ts tests/core/roadmap.test.ts tests/core/loader.test.ts tests/cli/sprint-inference.test.ts tests/cli/commands/next.test.ts passed: 159 tests.
+- pnpm vitest run tests/core/analyzers/git.test.ts passed: 24 tests.
+- pnpm typecheck passed.
+- pnpm build passed.
+- pnpm test passed: 214 test files and 3470 tests.
+- node dist/cli/index.js validate docs/retros/sprint-115.json --skills passed with no errors or warnings.
+- node dist/cli/index.js validate --skills passed, including S115 with no errors or warnings.
+- node dist/cli/index.js review recommend --sprint=115 required architect review and recommended ML-engineer review; local architect, code, and ML sanity reviews found no additional findings.
+- node dist/cli/index.js map --check passed: Overall CURRENT.
+
+### 19th Hole
+
+- **How did it feel?** Small, tidy, and useful: this was the final pass that made the skill workflow feel operational instead of merely documented.
+- **Advice for next player?** When an issue spans multiple sprints, compare the latest implementation against the original issue wording before closing.
+- **What surprised you?** The most valuable closeout catch was not another command; it was the missing file-path recommendation signal hidden in the acceptance text.
+- **Excited about next?** Skill-aware planning now has the hooks needed to recommend local discipline before edits begin.

--- a/docs/retros/sprint-115.json
+++ b/docs/retros/sprint-115.json
@@ -1,0 +1,129 @@
+{
+  "sprint_number": 115,
+  "player": "codex",
+  "theme": "Skill Awareness Closeout",
+  "par": 3,
+  "slope": 2,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-05-23",
+  "shots": [
+    {
+      "ticket_key": "S115-1",
+      "title": "Fix slope next fallback after decimal inserted sprint scorecards",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added nextCanonicalSprintId so scorecard fallbacks advance from inserted decimal sprints such as S114.5 to the canonical next sprint, S115."
+    },
+    {
+      "ticket_key": "S115-2",
+      "title": "Include claimed/changed file paths in skill-aware briefing recommendations",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Threaded active claims and changedFiles into buildSkillBriefing so Recommended Skills can cite changed file paths as an explainable ranking signal."
+    },
+    {
+      "ticket_key": "S115-3",
+      "title": "Record closeout and close #431",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The first full-suite run exposed that the git analyzer commits-per-week fixture could exceed Vitest's default 5s timeout on a busy local machine."
+        }
+      ],
+      "notes": "Hardened the timing-sensitive git analyzer fixture, reran the full suite successfully, and recorded the S115 closeout artifacts."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 3,
+    "fairways_total": 3,
+    "greens_in_regulation": 3,
+    "greens_total": 3,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "fix + feature",
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Inserted decimal scorecards need canonical fallback math.",
+      "outcome": "nextCanonicalSprintId now centralizes sprint fallback behavior for integer, decimal, and encoded inserted sprint ids."
+    },
+    {
+      "type": "lessons",
+      "description": "Issue acceptance lists should be re-read before closure.",
+      "outcome": "The remaining #431 changed-files signal was added after comparing the implemented briefing flow against the original issue body."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused regressions, typecheck, build, built CLI smoke checks, git analyzer fixture rerun, and full pnpm test suite passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "Recorded S115 roadmap, scorecard, and review artifacts for #431 closeout.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Small, tidy, and useful: this was the final pass that made the skill workflow feel operational instead of merely documented.",
+    "advice_for_next_player": "When an issue spans multiple sprints, compare the latest implementation against the original issue wording before closing.",
+    "what_surprised_you": "The most valuable closeout catch was not another command; it was the missing file-path recommendation signal hidden in the acceptance text.",
+    "excited_about_next": "Skill-aware planning now has the hooks needed to recommend local discipline before edits begin."
+  },
+  "bunker_locations": [
+    "Next-sprint fallback must use canonical sprint math, not raw numeric +1 after inserted sprint ids.",
+    "Skill-aware briefing should include active claims and changed file paths before considering #431 complete.",
+    "Git fixture tests that create multiple real commits can need explicit timeout headroom in full-suite runs."
+  ],
+  "yardage_book_updates": [
+    "nextCanonicalSprintId owns fallback sprint math for integer, decimal inserted, and encoded inserted sprint ids.",
+    "resolveCurrentSprint, inferSprintFromScorecards, and slope next now share canonical next-sprint behavior.",
+    "buildSkillBriefing accepts claims and changedFiles, adds those paths to context tokens, and reports changed files as a recommendation reason.",
+    "Full and compact briefing paths pass active claims into skill-aware recommendations."
+  ],
+  "course_management_notes": [
+    "Added nextCanonicalSprintId coverage for integer, decimal inserted, and encoded inserted sprint ids.",
+    "Added slope next regression coverage proving S114.5 scorecards advance to S115 rather than S115.5.",
+    "Added skill briefing regression coverage for claimed and changed file path recommendation signals.",
+    "Hardened the git analyzer commits-per-week fixture timeout after an initial full-suite timing failure.",
+    "pnpm vitest run tests/core/briefing.test.ts tests/core/roadmap.test.ts tests/core/loader.test.ts tests/cli/sprint-inference.test.ts tests/cli/commands/next.test.ts passed: 159 tests.",
+    "pnpm vitest run tests/core/analyzers/git.test.ts passed: 24 tests.",
+    "pnpm typecheck passed.",
+    "pnpm build passed.",
+    "pnpm test passed: 214 test files and 3470 tests.",
+    "node dist/cli/index.js validate docs/retros/sprint-115.json --skills passed with no errors or warnings.",
+    "node dist/cli/index.js validate --skills passed, including S115 with no errors or warnings.",
+    "node dist/cli/index.js review recommend --sprint=115 required architect review and recommended ML-engineer review; local architect, code, and ML sanity reviews found no additional findings.",
+    "node dist/cli/index.js map --check passed: Overall CURRENT."
+  ],
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow"
+  ],
+  "skill_gaps_found": [],
+  "slope_factors": [
+    "skill_awareness_closeout",
+    "decimal_sprint_fallback",
+    "release_hardening"
+  ]
+}

--- a/src/cli/commands/briefing.ts
+++ b/src/cli/commands/briefing.ts
@@ -154,6 +154,7 @@ export async function briefingCommand(args: string[]): Promise<void> {
       filter,
       roadmap,
       currentSprint: sprintNumber,
+      claims,
     });
     const skillSummary = skillBriefing.recommendations.map(r => r.id).slice(0, 3).join(', ');
 

--- a/src/cli/commands/next.ts
+++ b/src/cli/commands/next.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from '../config.js';
 import { inferSprintContext } from '../sprint-inference.js';
+import { formatSprintLabel, nextCanonicalSprintId } from '../../core/index.js';
 
 export function nextCommand(): void {
   const config = loadConfig();
@@ -18,8 +19,8 @@ export function nextCommand(): void {
     console.log(`  (set explicitly in .slope/config.json)`);
   } else if (context.source === 'roadmap') {
     console.log(`  (selected from pending roadmap sprint${context.roadmapSprint?.theme ? `: ${context.roadmapSprint.theme}` : ''})`);
-    if (context.latestScorecard > 0 && context.sprint !== context.latestScorecard + 1) {
-      console.log(`  (roadmap state overrides scorecard fallback to S${context.latestScorecard + 1})`);
+    if (context.latestScorecard > 0 && context.sprint !== nextCanonicalSprintId(context.latestScorecard)) {
+      console.log(`  (roadmap state overrides scorecard fallback to ${formatSprintLabel(nextCanonicalSprintId(context.latestScorecard))})`);
     }
   } else {
     console.log(`  (auto-detected from scorecards)`);

--- a/src/cli/sprint-inference.ts
+++ b/src/cli/sprint-inference.ts
@@ -8,6 +8,7 @@ import {
   isEncodedInsertedSprintId,
   isRoadmapSprintPending,
   loadScorecards,
+  nextCanonicalSprintId,
   parseRoadmap,
   sprintOrderValue,
 } from '../core/index.js';
@@ -65,7 +66,7 @@ export function inferSprintContext(cwd: string = process.cwd(), config: SlopeCon
     })
     .sort((a, b) => compareSprintIds(a.id, b.id)) ?? [];
 
-  const scorecardNext = latestScorecard > 0 ? latestScorecard + 1 : 1;
+  const scorecardNext = latestScorecard > 0 ? nextCanonicalSprintId(latestScorecard) : 1;
   const pending = choosePendingSprint(pendingSprints, latestScorecard, scorecardNext);
 
   if (pending) {

--- a/src/core/briefing.ts
+++ b/src/core/briefing.ts
@@ -244,10 +244,12 @@ export function buildSkillBriefing(opts: {
   filter?: BriefingFilter;
   roadmap?: RoadmapDefinition;
   currentSprint?: number;
+  claims?: SprintClaim[];
+  changedFiles?: string[];
   maxRecommendations?: number;
   maxGaps?: number;
 }): SkillBriefingResult {
-  const { registry, scorecards, commonIssues, filter, roadmap, currentSprint } = opts;
+  const { registry, scorecards, commonIssues, filter, roadmap, currentSprint, claims, changedFiles } = opts;
   if (!registry || !Array.isArray(registry.skills) || registry.skills.length === 0) {
     return { recommendations: [], gaps: [] };
   }
@@ -268,16 +270,21 @@ export function buildSkillBriefing(opts: {
     ...recentHazards.map(h => `${h.type} ${h.ticket} ${h.description}`),
     ...hazardIndex.bunker_locations.slice(-10).map(b => b.location),
   ].join(' '));
+  const changedFilesText = normalizeSearchText([
+    ...(claims ?? []).map(c => c.target),
+    ...(changedFiles ?? []),
+  ].join(' '));
   const historicalSkillIds = collectScorecardSkillIds(scorecards);
 
   const contextTokens = new Set([
     ...tokensFromText(sprintText),
     ...tokensFromText(filterText),
     ...tokensFromText(hazardText),
+    ...tokensFromText(changedFilesText),
   ]);
 
   const recommendations = registry.skills
-    .map(skill => scoreSkill(skill, { sprintText, filterText, hazardText, contextTokens, historicalSkillIds }))
+    .map(skill => scoreSkill(skill, { sprintText, filterText, hazardText, changedFilesText, contextTokens, historicalSkillIds }))
     .filter((rec): rec is SkillBriefingRecommendation => rec != null)
     .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
     .slice(0, opts.maxRecommendations ?? 5);
@@ -378,6 +385,7 @@ export function formatBriefing(opts: {
     filter: effectiveFilter,
     roadmap,
     currentSprint,
+    claims,
   });
 
   if (skillBriefing.recommendations.length > 0 || skillBriefing.gaps.length > 0) {
@@ -599,6 +607,7 @@ function scoreSkill(
     sprintText: string;
     filterText: string;
     hazardText: string;
+    changedFilesText: string;
     contextTokens: Set<string>;
     historicalSkillIds: Set<string>;
   },
@@ -626,6 +635,11 @@ function scoreSkill(
       score += 3;
       matchedTerms.add(phrase);
       addReason(reasons, 'recent hazards');
+    }
+    if (containsPhrase(context.changedFilesText, normalized)) {
+      score += 4;
+      matchedTerms.add(phrase);
+      addReason(reasons, 'changed files');
     }
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -176,6 +176,7 @@ export {
   formatStrategicContext,
   formatSprintLabel,
   formatSprintNumber,
+  nextCanonicalSprintId,
   parseSprintNumber,
   findNextPlannedSprint,
   isEncodedInsertedSprintId,

--- a/src/core/loader.ts
+++ b/src/core/loader.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import type { GolfScorecard } from './types.js';
 import type { SlopeConfig } from './config.js';
 import { normalizeStats } from './builder.js';
-import { compareSprintIds } from './roadmap.js';
+import { compareSprintIds, nextCanonicalSprintId } from './roadmap.js';
 
 /**
  * Load SLOPE scorecards from the configured directory.
@@ -68,7 +68,7 @@ export function detectLatestSprint(config: SlopeConfig, cwd: string = process.cw
 export function resolveCurrentSprint(config: SlopeConfig, cwd: string = process.cwd()): number {
   if (config.currentSprint) return config.currentSprint;
   const latest = detectLatestSprint(config, cwd);
-  return latest + 1;
+  return latest > 0 ? nextCanonicalSprintId(latest) : 1;
 }
 
 /**

--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -123,6 +123,17 @@ export function compareSprintIds(a: number, b: number): number {
   return sprintOrderValue(a) - sprintOrderValue(b);
 }
 
+/** Return the next canonical sprint id after a completed sprint/inserted sprint. */
+export function nextCanonicalSprintId(id: number): number {
+  if (isEncodedInsertedSprintId(id)) {
+    return Math.floor(id / 10) + 1;
+  }
+  if (!Number.isInteger(id)) {
+    return Math.floor(id) + 1;
+  }
+  return id + 1;
+}
+
 /** Return true when a roadmap sprint should still be considered selectable work. */
 export function isRoadmapSprintPending(sprint: RoadmapSprint): boolean {
   const status = (sprint as RoadmapSprint & { status?: string }).status;

--- a/tests/cli/commands/next.test.ts
+++ b/tests/cli/commands/next.test.ts
@@ -184,4 +184,25 @@ describe('slope next', () => {
     expect(output).toContain('Next sprint: S30');
     expect(output).not.toContain('Next sprint: S1');
   });
+
+  it('falls back to the next canonical sprint after a decimal inserted scorecard', () => {
+    const cwd = makeRepo();
+    repos.push(cwd);
+    writeScorecard(cwd, 114.5);
+    const originalCwd = process.cwd();
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg = '') => logs.push(String(msg)));
+
+    try {
+      process.chdir(cwd);
+      nextCommand();
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const output = logs.join('\n');
+    expect(output).toContain('Latest scorecard: S114.5');
+    expect(output).toContain('Next sprint: S115');
+    expect(output).not.toContain('Next sprint: S115.5');
+  });
 });

--- a/tests/core/analyzers/git.test.ts
+++ b/tests/core/analyzers/git.test.ts
@@ -66,7 +66,7 @@ describe('analyzeGit', () => {
 
     const result = await analyzeGit(tmpDir);
     expect(result.commitsPerWeek).toBeGreaterThan(0);
-  });
+  }, 10000);
 
   it('parses contributors', async () => {
     gitInit(tmpDir);

--- a/tests/core/briefing.test.ts
+++ b/tests/core/briefing.test.ts
@@ -1175,6 +1175,20 @@ describe('buildSkillBriefing', () => {
     expect(result.recommendations[0].score).toBeGreaterThan(0);
   });
 
+  it('recommends registered skills from claimed and changed file paths', () => {
+    const result = buildSkillBriefing({
+      registry: makeSkillRegistry(),
+      scorecards: [],
+      commonIssues: makeIssues([]),
+      claims: [makeClaim({ target: 'docs/pull-request-review.md' })],
+      changedFiles: ['docs/review-checklist.md'],
+    });
+
+    const reviewRec = result.recommendations.find(r => r.id === 'review-helper');
+    expect(reviewRec).toBeDefined();
+    expect(reviewRec?.reason).toContain('changed files');
+  });
+
   it('surfaces repeated relevant topics that have no matching registered skill', () => {
     const result = buildSkillBriefing({
       registry: makeSkillRegistry(),

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -7,6 +7,7 @@ import {
   formatRoadmapSummary,
   formatStrategicContext,
   formatSprintLabel,
+  nextCanonicalSprintId,
   parseSprintNumber,
   sprintOrderValue,
   findNextPlannedSprint,
@@ -70,6 +71,12 @@ describe('sprint id formatting', () => {
     expect(parseSprintNumber('S114.5')).toBe(114.5);
     expect(parseSprintNumber('114abc')).toBeNull();
     expect(parseSprintNumber('114.')).toBeNull();
+  });
+
+  it('computes the next canonical sprint after inserted sprint ids', () => {
+    expect(nextCanonicalSprintId(114)).toBe(115);
+    expect(nextCanonicalSprintId(114.5)).toBe(115);
+    expect(nextCanonicalSprintId(435)).toBe(44);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #431 by finishing the remaining skill-aware briefing acceptance gap and fixing the follow-on sprint inference uncovered after S114.5.

- Add canonical next-sprint fallback behavior after inserted decimal and encoded sprint ids.
- Include active claims and changed file paths in skill-aware briefing recommendation scoring, with an explainable `changed files` reason.
- Harden the timing-sensitive git analyzer fixture and record the S115/Phase 30 closeout artifacts.

## Validation

- `pnpm vitest run tests/core/briefing.test.ts tests/core/roadmap.test.ts tests/core/loader.test.ts tests/cli/sprint-inference.test.ts tests/cli/commands/next.test.ts`
- `pnpm vitest run tests/core/analyzers/git.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `node dist/cli/index.js validate docs/retros/sprint-115.json --skills`
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js review recommend --sprint=115`
- `node dist/cli/index.js map --check`

## SLOPE

Sprint 115 closed at par: tests, code review, architect review, scorecard, and review-md gates complete.

Closes #431
