### PR TITLE
[codex] Prepare v1.56.0 release

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -187,6 +187,14 @@
       ],
       "status": "complete",
       "note": "Close the remaining #431 acceptance gap and fix decimal sprint follow-on inference."
+    },
+    {
+      "name": "Phase 31 \u2014 Skill Awareness Release",
+      "sprints": [
+        116
+      ],
+      "status": "planned",
+      "note": "Publish the skill registry and skill-aware briefing work as v1.56.0, including roadmap cleanup for superseded S75.5 status."
     }
   ],
   "sprints": [
@@ -2264,6 +2272,45 @@
           "depends_on": [
             "S115-1",
             "S115-2"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 116,
+      "theme": "Skill Awareness Release",
+      "par": 4,
+      "slope": 2,
+      "type": "release + cleanup",
+      "status": "planned",
+      "depends_on": [
+        115
+      ],
+      "note": "Release the skill registry and skill-aware briefing work as v1.56.0, and clean up roadmap status display for superseded S75.5.",
+      "tickets": [
+        {
+          "key": "S116-1",
+          "title": "Treat superseded roadmap sprints as terminal in roadmap status",
+          "club": "wedge",
+          "complexity": "small"
+        },
+        {
+          "key": "S116-2",
+          "title": "Bump @slope-dev/slope and bundled Codex plugin to v1.56.0",
+          "club": "wedge",
+          "complexity": "small",
+          "depends_on": [
+            "S116-1"
+          ]
+        },
+        {
+          "key": "S116-3",
+          "title": "Run release validation, publish v1.56.0, and verify npm",
+          "club": "short_iron",
+          "complexity": "standard",
+          "depends_on": [
+            "S116-1",
+            "S116-2"
           ]
         }
       ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.55.14",
+  "version": "1.56.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -33,6 +33,15 @@ function parseArgs(args: string[]): Record<string, string> {
 }
 
 const DEFAULT_ROADMAP_PATH = 'docs/backlog/roadmap.json';
+const TERMINAL_ROADMAP_STATUSES = new Set(['complete', 'superseded']);
+
+function getRoadmapStatus(sprint: RoadmapSprint): string | undefined {
+  return (sprint as RoadmapSprint & { status?: string }).status;
+}
+
+function isTerminalRoadmapSprint(sprint: RoadmapSprint, completedSprints: Set<number>): boolean {
+  return completedSprints.has(sprint.id) || TERMINAL_ROADMAP_STATUSES.has(getRoadmapStatus(sprint) ?? '');
+}
 
 function resolveRoadmapPath(flags: Record<string, string>, cwd: string): string {
   if (flags.path) return flags.path;
@@ -285,19 +294,26 @@ function statusSubcommand(flags: Record<string, string>, cwd: string): void {
     }
 
     const phaseSprints = roadmap.sprints.filter(s => phase.sprints.includes(s.id));
-    const completed = phaseSprints.filter(s => completedSprints.has(s.id)).length;
+    const completed = phaseSprints.filter(s => isTerminalRoadmapSprint(s, completedSprints)).length;
     console.log(`## ${phase.name || 'Unnamed Phase'} (${completed}/${phaseSprints.length})`);
 
     for (const sprint of phaseSprints) {
-      const isCompleted = completedSprints.has(sprint.id);
+      const explicitStatus = getRoadmapStatus(sprint);
+      const isCompleted = completedSprints.has(sprint.id) || explicitStatus === 'complete';
+      const isSuperseded = explicitStatus === 'superseded';
       const isCurrent = sprint.id === currentSprint;
 
       // Check if blocked: all dependencies must be completed
-      const blockedBy = (sprint.depends_on ?? []).filter(dep => !completedSprints.has(dep));
-      const isBlocked = !isCompleted && blockedBy.length > 0;
+      const blockedBy = (sprint.depends_on ?? []).filter(dep => {
+        const dependency = roadmap.sprints.find(s => s.id === dep);
+        return dependency ? !isTerminalRoadmapSprint(dependency, completedSprints) : !completedSprints.has(dep);
+      });
+      const isBlocked = !isCompleted && !isSuperseded && blockedBy.length > 0;
 
       let status: string;
-      if (isCompleted) {
+      if (isSuperseded) {
+        status = '\u21B7 superseded';
+      } else if (isCompleted) {
         status = '\u2713 completed';
       } else if (isCurrent) {
         status = '\u25B6 active';

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.55.14",
+  "version": "1.56.0",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",

--- a/tests/cli/roadmap.test.ts
+++ b/tests/cli/roadmap.test.ts
@@ -277,6 +277,29 @@ describe('slope roadmap status', () => {
     expect(output).toContain('active');
   });
 
+  it('treats superseded sprints as terminal progress', () => {
+    const roadmap = makeRoadmapJson({
+      phases: [{ name: 'Phase 1', sprints: [7, 8, 9] }],
+      sprints: [
+        { ...makeRoadmapJson().sprints[0], status: 'complete' } as any,
+        { ...makeRoadmapJson().sprints[1], status: 'superseded' } as any,
+        { ...makeRoadmapJson().sprints[2], depends_on: [8] },
+      ],
+    });
+    writeRoadmap(tmpDir, roadmap);
+    writeConfig(tmpDir, { currentSprint: 9 });
+
+    roadmapCommand(['status']);
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('Phase 1 (2/3)');
+    expect(output).toContain('S8');
+    expect(output).toContain('\u21B7 superseded');
+    expect(output).toContain('S9');
+    expect(output).toContain('\u25B6 active');
+    expect(output).not.toContain('blocked by S8');
+  });
+
   it('shows strategic context for current sprint', () => {
     writeRoadmap(tmpDir, makeRoadmapJson());
     writeConfig(tmpDir, { currentSprint: 8 });


### PR DESCRIPTION
## Summary

Prepares the S116 `v1.56.0` release for the skill registry and skill-aware briefing work, with the requested cleanup folded in.

- Treat `superseded` roadmap sprints as terminal in `slope roadmap status`, so S75.5 no longer appears pending or blocks later work.
- Add S116/Phase 31 roadmap scope for the release cycle.
- Bump `@slope-dev/slope` and the bundled Codex plugin manifest from `1.55.14` to `1.56.0`.

## Validation

- `pnpm build`
- `pnpm vitest run tests/cli/roadmap.test.ts tests/core/roadmap.test.ts tests/cli/commands/next.test.ts`
- `node dist/cli/index.js roadmap status | rg 'Phase 15|S75\.5|Phase 31|S116|Current sprint'`
- `node dist/cli/index.js version`
- `pnpm typecheck`
- `pnpm test`
- `npm pack --dry-run`
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js roadmap validate`

## Release Plan

After this merges, I will create GitHub release `v1.56.0`, watch the trusted-publisher npm workflow, verify `npm view @slope-dev/slope version`, and record the final S116 scorecard/review with the actual publish result.
