### PR TITLE
[codex] Harden worktree-check guard

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -201,8 +201,8 @@
       "sprints": [
         117
       ],
-      "status": "planned",
-      "note": "Use the SLOPE-generated local backlog to harden the worktree-check guard against recurring multi-session and payload-shape hazards."
+      "status": "complete",
+      "note": "Used the SLOPE-generated local backlog to harden the worktree-check guard against recurring multi-session and payload-shape hazards."
     }
   ],
   "sprints": [
@@ -2331,7 +2331,9 @@
       "par": 3,
       "slope": 2,
       "type": "guard hardening",
-      "status": "planned",
+      "status": "complete",
+      "score": 3,
+      "score_label": "par",
       "depends_on": [
         116
       ],

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -195,6 +195,14 @@
       ],
       "status": "complete",
       "note": "Published the skill registry and skill-aware briefing work as v1.56.0, including roadmap cleanup for superseded S75.5 status."
+    },
+    {
+      "name": "Phase 32 \u2014 Worktree Guard Hardening",
+      "sprints": [
+        117
+      ],
+      "status": "planned",
+      "note": "Use the SLOPE-generated local backlog to harden the worktree-check guard against recurring multi-session and payload-shape hazards."
     }
   ],
   "sprints": [
@@ -2314,6 +2322,26 @@
             "S116-1",
             "S116-2"
           ]
+        }
+      ]
+    },
+    {
+      "id": 117,
+      "theme": "Worktree Guard Hardening",
+      "par": 3,
+      "slope": 2,
+      "type": "guard hardening",
+      "status": "planned",
+      "depends_on": [
+        116
+      ],
+      "note": "Address the SLOPE-generated S-LOCAL-117 backlog item by hardening src/cli/guards/worktree-check.ts and adding regression coverage.",
+      "tickets": [
+        {
+          "key": "S117-1",
+          "title": "Harden worktree-check guard recovery command and git probing paths",
+          "club": "short_iron",
+          "complexity": "standard"
         }
       ]
     }

--- a/docs/retros/sprint-117-review.md
+++ b/docs/retros/sprint-117-review.md
@@ -1,0 +1,63 @@
+## Sprint 117 Review: Worktree Guard Hardening
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 2 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+| Hazard Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S117-1 | Short Iron | In the Hole | - | Replaced per-call random fallback session ids with stable anonymous ids, expanded recovery command parsing to include Codex-style cmd payloads, and moved git rev-parse probes to execFileSync argv calls with regression coverage. |
+
+### Hazards Discovered
+
+No hazards recorded.
+
+**Known hazards for future sprints:**
+- Missing hook session_id must not create a fresh guard identity on every invocation.
+- Worktree recovery command detection should read command text from command, cmd, and input payload fields.
+- Guard git probes should use argv-based child process calls instead of shell strings.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Hook payloads can omit session_id; guard fallback ids must be stable across invocations. | worktree-check now derives anonymous ids from transcript_path or cwd so one unidentified session does not look like many concurrent sessions. |
+| Lessons | Guard recovery commands need to account for harness payload shape differences. | worktree-check now reads command text from command, cmd, or input fields before deciding whether to allow worktree recovery. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Focused worktree/stop-check guard tests, typecheck, build, and the full pnpm test suite passed. |
+| workflow | healthy | S117 came from the SLOPE-generated local backlog after GitHub reported no open issues. |
+
+### Course Management Notes
+
+- GitHub issue queue was empty, so S117 used slope-loop/backlog.json item S-LOCAL-117.
+- Added a cmd-payload recovery regression for git worktree add.
+- Updated missing-session regression to prove the anonymous fallback is stable and sentinel caching prevents repeated self-registration.
+- pnpm vitest run tests/cli/guards/worktree-check.test.ts tests/cli/guards/stop-check.test.ts passed: 38 tests.
+- pnpm typecheck passed.
+- pnpm build passed.
+- pnpm test passed: 214 test files and 3472 tests.
+- node dist/cli/index.js map --check passed before scorecard creation: Overall CURRENT.
+- node dist/cli/index.js roadmap validate passed as structurally valid with only standing roadmap warnings plus expected branch-local S117 warnings before the PR reaches main.
+
+### 19th Hole
+
+- **How did it feel?** Small but useful: the local backlog pointed at exactly the kind of guard edge case that only shows up in real agent traffic.
+- **Advice for next player?** When a guard tracks session identity, test missing-id behavior across repeated invocations, not only the first call.
+- **What surprised you?** The old random fallback was meant to be safe, but it could turn a single anonymous session into a false multi-session conflict.
+- **Excited about next?** The worktree guard is a little more tolerant of Codex-shaped payloads and less dependent on shell parsing.

--- a/docs/retros/sprint-117.json
+++ b/docs/retros/sprint-117.json
@@ -1,0 +1,104 @@
+{
+  "sprint_number": 117,
+  "player": "codex",
+  "theme": "Worktree Guard Hardening",
+  "par": 3,
+  "slope": 2,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-05-23",
+  "shots": [
+    {
+      "ticket_key": "S117-1",
+      "title": "Harden worktree-check guard recovery command and git probing paths",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Replaced per-call random fallback session ids with stable anonymous ids, expanded recovery command parsing to include Codex-style cmd payloads, and moved git rev-parse probes to execFileSync argv calls with regression coverage."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "guard hardening",
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Hook payloads can omit session_id; guard fallback ids must be stable across invocations.",
+      "outcome": "worktree-check now derives anonymous ids from transcript_path or cwd so one unidentified session does not look like many concurrent sessions."
+    },
+    {
+      "type": "lessons",
+      "description": "Guard recovery commands need to account for harness payload shape differences.",
+      "outcome": "worktree-check now reads command text from command, cmd, or input fields before deciding whether to allow worktree recovery."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused worktree/stop-check guard tests, typecheck, build, and the full pnpm test suite passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "workflow",
+      "description": "S117 came from the SLOPE-generated local backlog after GitHub reported no open issues.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Small but useful: the local backlog pointed at exactly the kind of guard edge case that only shows up in real agent traffic.",
+    "advice_for_next_player": "When a guard tracks session identity, test missing-id behavior across repeated invocations, not only the first call.",
+    "what_surprised_you": "The old random fallback was meant to be safe, but it could turn a single anonymous session into a false multi-session conflict.",
+    "excited_about_next": "The worktree guard is a little more tolerant of Codex-shaped payloads and less dependent on shell parsing."
+  },
+  "bunker_locations": [
+    "Missing hook session_id must not create a fresh guard identity on every invocation.",
+    "Worktree recovery command detection should read command text from command, cmd, and input payload fields.",
+    "Guard git probes should use argv-based child process calls instead of shell strings."
+  ],
+  "yardage_book_updates": [
+    "src/cli/guards/worktree-check.ts now resolves stable anonymous session ids from transcript_path or cwd.",
+    "src/cli/guards/worktree-check.ts now parses recovery commands from command, cmd, and input hook payload keys.",
+    "src/cli/guards/worktree-check.ts now uses execFileSync('git', ['rev-parse', ...]) for git-common-dir and branch probes."
+  ],
+  "course_management_notes": [
+    "GitHub issue queue was empty, so S117 used slope-loop/backlog.json item S-LOCAL-117.",
+    "Added a cmd-payload recovery regression for git worktree add.",
+    "Updated missing-session regression to prove the anonymous fallback is stable and sentinel caching prevents repeated self-registration.",
+    "pnpm vitest run tests/cli/guards/worktree-check.test.ts tests/cli/guards/stop-check.test.ts passed: 38 tests.",
+    "pnpm typecheck passed.",
+    "pnpm build passed.",
+    "pnpm test passed: 214 test files and 3472 tests.",
+    "node dist/cli/index.js map --check passed before scorecard creation: Overall CURRENT.",
+    "node dist/cli/index.js roadmap validate passed as structurally valid with only standing roadmap warnings plus expected branch-local S117 warnings before the PR reaches main."
+  ],
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "slope-api-reference",
+    "slope-performance-analysis"
+  ],
+  "skill_gaps_found": [],
+  "slope_factors": [
+    "worktree_guard",
+    "hook_payload_shapes",
+    "multi_session_safety"
+  ]
+}

--- a/src/cli/guards/worktree-check.ts
+++ b/src/cli/guards/worktree-check.ts
@@ -1,12 +1,14 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, writeFileSync, mkdirSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { STALE_SESSION_THRESHOLD_MS } from '../../core/constants.js';
 import { SlopeStoreError } from '../../core/store.js';
 import { resolveStore } from '../store.js';
+
+const COMMAND_TEXT_KEYS = ['command', 'cmd', 'input'] as const;
 
 /** Get the sentinel file path for a session (persists across process invocations) */
 function sentinelPath(sessionId: string): string {
@@ -37,8 +39,9 @@ export function resetWorktreeCheckState(sessionId = ''): void {
 export async function worktreeCheckGuard(input: HookInput, cwd: string): Promise<GuardResult> {
   if (isWorktreeRecoveryInput(input)) return {};
 
-  // Use stable session ID, or generate one for unidentified sessions
-  const sessionId = input.session_id || randomUUID();
+  // Use a stable ID; hook payloads can omit session_id, and a fresh random
+  // value on every invocation makes one session look like many sessions.
+  const sessionId = resolveSessionId(input, cwd);
   const sentinel = sentinelPath(sessionId);
   // Only fire once per session on pass — denied sessions re-check next time
   if (existsSync(sentinel)) return {};
@@ -47,7 +50,7 @@ export async function worktreeCheckGuard(input: HookInput, cwd: string): Promise
   // or a path like '../../.git' for a worktree
   let gitCommonDir: string;
   try {
-    gitCommonDir = execSync('git rev-parse --git-common-dir 2>/dev/null', { cwd, encoding: 'utf8' }).trim();
+    gitCommonDir = gitRevParse(cwd, '--git-common-dir');
   } catch {
     // Not a git repo — allow
     return {};
@@ -59,7 +62,7 @@ export async function worktreeCheckGuard(input: HookInput, cwd: string): Promise
   // Get current branch for session registration
   let branch: string;
   try {
-    branch = execSync('git rev-parse --abbrev-ref HEAD 2>/dev/null', { cwd, encoding: 'utf8' }).trim();
+    branch = gitRevParse(cwd, '--abbrev-ref', 'HEAD');
   } catch {
     branch = 'unknown';
   }
@@ -134,11 +137,37 @@ export async function worktreeCheckGuard(input: HookInput, cwd: string): Promise
 function isWorktreeRecoveryInput(input: HookInput): boolean {
   if (input.tool_name === 'EnterWorktree') return true;
 
-  const command = typeof input.tool_input?.command === 'string'
-    ? input.tool_input.command.trim()
-    : '';
+  const command = extractCommandText(input);
 
   return command === 'EnterWorktree'
     || /^git\s+worktree\s+add(?:\s|$)/.test(command)
     || /^git\s+-C\s+(?:"[^"]+"|'[^']+'|\S+)\s+worktree\s+add(?:\s|$)/.test(command);
+}
+
+function gitRevParse(cwd: string, ...args: string[]): string {
+  return execFileSync('git', ['rev-parse', ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
+
+function resolveSessionId(input: HookInput, cwd: string): string {
+  const explicit = typeof input.session_id === 'string' ? input.session_id.trim() : '';
+  if (explicit) return explicit;
+
+  const source = typeof input.transcript_path === 'string' && input.transcript_path.trim()
+    ? `transcript:${input.transcript_path.trim()}`
+    : `cwd:${cwd}`;
+  const digest = createHash('sha256').update(source).digest('hex').slice(0, 16);
+  return `anonymous-${digest}`;
+}
+
+function extractCommandText(input: HookInput): string {
+  const toolInput = input.tool_input ?? {};
+  for (const key of COMMAND_TEXT_KEYS) {
+    const value = toolInput[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return '';
 }

--- a/tests/cli/guards/worktree-check.test.ts
+++ b/tests/cli/guards/worktree-check.test.ts
@@ -6,7 +6,7 @@ import { SlopeStoreError } from '../../../src/core/store.js';
 import type { SlopeStore, SlopeSession } from '../../../src/core/store.js';
 
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 // Track sentinel files in memory instead of real filesystem
@@ -41,11 +41,11 @@ vi.mock('../../../src/cli/store.js', () => ({
   resolveStore: vi.fn(),
 }));
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { resolveStore } from '../../../src/cli/store.js';
 
-const mockExecSync = vi.mocked(execSync);
+const mockExecFileSync = vi.mocked(execFileSync);
 const mockResolveStore = vi.mocked(resolveStore);
 const mockWriteFileSync = vi.mocked(writeFileSync);
 
@@ -70,9 +70,9 @@ function makeSession(overrides: Partial<SlopeSession> = {}): SlopeSession {
   };
 }
 
-/** Set up execSync to return main repo on a given branch */
+/** Set up execFileSync to return main repo on a given branch */
 function mockGitMainRepo(branch = 'feat/foo'): void {
-  mockExecSync
+  mockExecFileSync
     .mockReturnValueOnce('.git' as never)       // git-common-dir
     .mockReturnValueOnce(branch as never);       // branch
 }
@@ -94,7 +94,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('denies when concurrent session exists in same repo', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)         // git-common-dir
       .mockReturnValueOnce('feat/foo' as never);     // branch
 
@@ -143,8 +143,19 @@ describe('worktreeCheckGuard', () => {
     expect(mockResolveStore).not.toHaveBeenCalled();
   });
 
+  it('allows git worktree add recovery commands from cmd payloads', async () => {
+    const result = await worktreeCheckGuard({
+      ...makeInput(),
+      tool_name: 'Bash',
+      tool_input: { cmd: 'git worktree add /tmp/slope-worktree HEAD' },
+    }, '/tmp/test');
+
+    expect(result).toEqual({});
+    expect(mockResolveStore).not.toHaveBeenCalled();
+  });
+
   it('allows when other session has worktree_path (isolated)', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('feat/foo' as never);
 
@@ -158,7 +169,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('allows when current session is alone', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('feat/foo' as never);
 
@@ -171,7 +182,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('allows when in a worktree (already isolated)', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('../../.git' as never); // git-common-dir != '.git'
 
     const result = await worktreeCheckGuard(makeInput(), '/tmp/test');
@@ -181,7 +192,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('silently passes on store resolve error (#263)', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('feat/foo' as never);
 
@@ -192,7 +203,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('silently passes on store query error (#263)', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('feat/foo' as never);
 
@@ -203,7 +214,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('fires on feature branch (no longer gated to main/master)', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('feat/worktree-guard' as never);
 
@@ -217,7 +228,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('cleans stale sessions before checking', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('main' as never);
 
@@ -230,7 +241,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('handles SESSION_CONFLICT on register (session already exists)', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('main' as never);
 
@@ -247,7 +258,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('closes store in finally block even on error', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('main' as never);
 
@@ -258,7 +269,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('closes store on successful path', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('main' as never);
 
@@ -334,13 +345,13 @@ describe('worktreeCheckGuard', () => {
       makeSession({ session_id: 'session-b' }),
     ]);
 
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('main' as never);
     const first = await worktreeCheckGuard(makeInput('session-a'), '/tmp/test');
     expect(first.decision).toBe('deny');
 
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('main' as never);
     const second = await worktreeCheckGuard(makeInput('session-b'), '/tmp/test');
@@ -348,7 +359,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('resets state correctly via unlinkSync', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('main' as never);
 
@@ -361,7 +372,7 @@ describe('worktreeCheckGuard', () => {
 
     resetWorktreeCheckState('reset-test');
 
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)
       .mockReturnValueOnce('main' as never);
     const result = await worktreeCheckGuard(makeInput('reset-test'), '/tmp/test');
@@ -369,7 +380,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('returns empty when not a git repo', async () => {
-    mockExecSync.mockImplementation(() => { throw new Error('not a git repo'); });
+    mockExecFileSync.mockImplementation(() => { throw new Error('not a git repo'); });
     const result = await worktreeCheckGuard(makeInput(), '/tmp/test');
     expect(result).toEqual({});
   });
@@ -427,15 +438,17 @@ describe('worktreeCheckGuard', () => {
     expect(result.decision).toBe('deny');
   });
 
-  it('generates random session ID when input has none', async () => {
+  it('uses a stable anonymous session ID when input has none', async () => {
     mockGitMainRepo();
     (mockStore.getActiveSessions as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
     await worktreeCheckGuard(makeInput(''), '/tmp/test');
     const call = (mockStore.registerSession as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(call.session_id).not.toBe('unknown');
-    expect(call.session_id).not.toBe('');
-    expect(call.session_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(call.session_id).toMatch(/^anonymous-[0-9a-f]{16}$/);
+
+    const second = await worktreeCheckGuard(makeInput(''), '/tmp/test');
+    expect(second).toEqual({});
+    expect(mockStore.registerSession).toHaveBeenCalledTimes(1);
   });
 
   it('recovers swarm_id via SESSION_CONFLICT and still allows same-swarm', async () => {
@@ -466,7 +479,7 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('uses branch unknown fallback when git branch fails', async () => {
-    mockExecSync
+    mockExecFileSync
       .mockReturnValueOnce('.git' as never)                              // git-common-dir
       .mockImplementationOnce(() => { throw new Error('detached'); });    // branch fails
 


### PR DESCRIPTION
## Summary
- add Phase 32 / S117 to the roadmap from the SLOPE-generated local backlog
- harden worktree-check guard session fallback so missing `session_id` uses a stable anonymous id instead of a per-call UUID
- recognize Codex-style `cmd` recovery payloads for `git worktree add`
- replace shell-form `git rev-parse` probes with argv-based `execFileSync` calls
- add S117 scorecard and review closeout artifacts

## Validation
- `pnpm vitest run tests/cli/guards/worktree-check.test.ts tests/cli/guards/stop-check.test.ts` (38 tests)
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (214 files, 3472 tests, 23 skipped)
- `node dist/cli/index.js validate docs/retros/sprint-117.json --skills`
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js map --check`
- `git diff --check`