### PR TITLE
[codex] Prepare v1.56.1 release

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -203,6 +203,14 @@
       ],
       "status": "complete",
       "note": "Used the SLOPE-generated local backlog to harden the worktree-check guard against recurring multi-session and payload-shape hazards."
+    },
+    {
+      "name": "Phase 33 \u2014 Guard Hardening Release",
+      "sprints": [
+        118
+      ],
+      "status": "planned",
+      "note": "Publish the S117 worktree-check guard hardening as v1.56.1 and verify the trusted-publisher npm release."
     }
   ],
   "sprints": [
@@ -2344,6 +2352,35 @@
           "title": "Harden worktree-check guard recovery command and git probing paths",
           "club": "short_iron",
           "complexity": "standard"
+        }
+      ]
+    },
+    {
+      "id": 118,
+      "theme": "Guard Hardening Release",
+      "par": 3,
+      "slope": 1,
+      "type": "release",
+      "status": "planned",
+      "depends_on": [
+        117
+      ],
+      "note": "Release the S117 worktree-check guard hardening as v1.56.1 via GitHub trusted publishing and verify npm.",
+      "tickets": [
+        {
+          "key": "S118-1",
+          "title": "Bump @slope-dev/slope and bundled Codex plugin to v1.56.1",
+          "club": "wedge",
+          "complexity": "small"
+        },
+        {
+          "key": "S118-2",
+          "title": "Run release validation, publish v1.56.1, and verify npm",
+          "club": "short_iron",
+          "complexity": "standard",
+          "depends_on": [
+            "S118-1"
+          ]
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
## Summary
- add S118 release sprint planning to the roadmap
- bump @slope-dev/slope and bundled Codex plugin to v1.56.1

## Validation
- pnpm build
- pnpm typecheck
- pnpm vitest run tests/cli/guards/worktree-check.test.ts tests/cli/guards/stop-check.test.ts
- pnpm test
- npm pack --dry-run
- node dist/cli/index.js validate --skills
- node dist/cli/index.js roadmap validate
- node dist/cli/index.js map --check
- git diff --check
- npm view @slope-dev/slope version --registry https://registry.npmjs.org -> 1.56.0

## Release Plan
After merge, create GitHub release v1.56.1 and verify the trusted-publisher npm publish before closing S118.