### PR TITLE
[codex] Address S119 skill registry follow-ups

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -211,6 +211,14 @@
       ],
       "status": "complete",
       "note": "Published the S117 worktree-check guard hardening as v1.56.1 and verified the trusted-publisher npm release."
+    },
+    {
+      "name": "Phase 34 \u2014 Skill Registry Follow-ups",
+      "sprints": [
+        119
+      ],
+      "status": "planned",
+      "note": "Address the new GitHub issue batch for skills validation, scanning, help behavior, and sprint-specific briefing recommendations."
     }
   ],
   "sprints": [
@@ -2382,6 +2390,55 @@
           "complexity": "standard",
           "depends_on": [
             "S118-1"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 119,
+      "theme": "Skill Registry Follow-ups",
+      "par": 4,
+      "slope": 3,
+      "type": "bugfix + enhancement",
+      "status": "planned",
+      "depends_on": [
+        118
+      ],
+      "note": "Fix the fresh #440-#443 GitHub issue batch around skills validation, scanning, help exit codes, and briefing recommendations.",
+      "tickets": [
+        {
+          "key": "S119-1",
+          "title": "Prevent validate --skills from crashing when stats.miss_directions is missing (#440)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 440
+        },
+        {
+          "key": "S119-2",
+          "title": "Make slope skills --help exit successfully (#443)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 443
+        },
+        {
+          "key": "S119-3",
+          "title": "Ignore worktrees, virtualenvs, dependencies, and generated folders during skills scan (#441)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 441,
+          "depends_on": [
+            "S119-1",
+            "S119-2"
+          ]
+        },
+        {
+          "key": "S119-4",
+          "title": "Honor requested sprint skill metadata in briefing recommendations (#442)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 442,
+          "depends_on": [
+            "S119-3"
           ]
         }
       ]

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -217,8 +217,8 @@
       "sprints": [
         119
       ],
-      "status": "planned",
-      "note": "Address the new GitHub issue batch for skills validation, scanning, help behavior, and sprint-specific briefing recommendations."
+      "status": "complete",
+      "note": "Closed the new GitHub issue batch for skills validation, scanning, help behavior, and sprint-specific briefing recommendations."
     }
   ],
   "sprints": [
@@ -2400,7 +2400,9 @@
       "par": 4,
       "slope": 3,
       "type": "bugfix + enhancement",
-      "status": "planned",
+      "status": "complete",
+      "score": 4,
+      "score_label": "par",
       "depends_on": [
         118
       ],

--- a/docs/retros/sprint-119-review.md
+++ b/docs/retros/sprint-119-review.md
@@ -1,0 +1,71 @@
+## Sprint 119 Review: Skill Registry Follow-ups
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 3 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (4/4) |
+| GIR % | 100% (4/4) |
+| Putts | 0 |
+| Penalties | 0 |
+| Hazard Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 4)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S119-1 | Wedge | In the Hole | - | validateScorecard now normalizes scorecard stats before reading miss_directions, so legacy or sparse scorecards report validation findings instead of throwing. |
+| S119-2 | Wedge | In the Hole | - | Added explicit skills help handling for --help and -h, preserving usage output while returning a successful CLI exit. |
+| S119-3 | Short Iron | In the Hole | - | skills scan now prunes common generated, dependency, cache, virtualenv, and worktree directories by default, uses lstat so symlinked directories are not followed, and still scans an explicitly requested root. |
+| S119-4 | Short Iron | In the Hole | - | Briefing recommendations now bias skills and gaps recorded on the requested sprint scorecard, keeping historical context useful without letting recency override an explicit sprint request. |
+
+### Hazards Discovered
+
+No new hazards were hit during S119.
+
+**Known hazards for future sprints:**
+- Repo-wide validate --skills still exits nonzero on pre-existing historical S70 and S74-S83 GIR overflow scorecards.
+- Skill scanners should default to pruning generated/dependency/worktree directories and avoid following symlinked directories.
+- Briefing fixtures need skill ids and gap terms that do not accidentally overlap unrelated registered skill metadata.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Validators should normalize sparse historical data before derived checks. | validate --skills no longer crashes when miss_directions is omitted from a scorecard stats block. |
+| Lessons | Broad filesystem scans need conservative default pruning with an explicit-root escape hatch. | skills scan avoids noisy dependency/generated/worktree trees by default while still honoring an explicitly requested scan root. |
+| Lessons | Briefing recommendations should respect the sprint the user asked about, not just the most recent scorecards. | Requested sprint skill metadata and skill gaps now receive explicit recommendation weight and evidence. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Focused validation, skills, and briefing tests passed; full pnpm test, build, typecheck, CLI smoke, map check, roadmap validation, diff check, and npm pack dry run also passed. |
+| issue_queue | healthy | Implemented the four new GitHub issues in one sprint and prepared PR closure references for #440, #441, #442, and #443. |
+
+### Course Management Notes
+
+- Created S119 from GitHub issues #440, #441, #442, and #443.
+- pnpm vitest run tests/core/validation.test.ts tests/core/skills.test.ts tests/cli/skills.test.ts tests/core/briefing.test.ts tests/cli/validate-skills.test.ts passed: 145 tests.
+- pnpm build passed.
+- pnpm typecheck passed.
+- pnpm test passed: 214 test files and 3478 tests.
+- node dist/cli/index.js skills --help passed with exit code 0.
+- node dist/cli/index.js briefing --sprint=119 --compact passed.
+- node dist/cli/index.js validate --skills docs/retros/sprint-119.json passed with no errors or warnings.
+- node dist/cli/index.js roadmap validate passed as structurally valid with standing roadmap warnings plus the expected branch-local S119 not-on-main warning.
+- node dist/cli/index.js map --check passed: Overall CURRENT.
+- git diff --check passed.
+- npm pack --dry-run passed for @slope-dev/slope@1.56.1 with 1018 files.
+- node dist/cli/index.js validate --skills against the full historical scorecard set still exits 1 because of pre-existing S70 and S74-S83 GIR overflow scorecards; S119 uses targeted scorecard and regression validation.
+
+### 19th Hole
+
+- **How did it feel?** Tidy and a little satisfying: each report mapped to a narrow product behavior, and the tests made the fixes feel well pinned down.
+- **Advice for next player?** Keep skill-registry work covered at both core and CLI boundaries; these bugs mostly hide where old scorecards or broad repo roots meet user-facing commands.
+- **What surprised you?** The broad validate command still exposes old GIR overflow scorecards even though modern scorecards are clean.
+- **Excited about next?** The skill registry now behaves better in real repos: quieter scans, cleaner help, safer validation, and sprint-aware briefing.

--- a/docs/retros/sprint-119.json
+++ b/docs/retros/sprint-119.json
@@ -1,0 +1,141 @@
+{
+  "sprint_number": 119,
+  "player": "codex",
+  "theme": "Skill Registry Follow-ups",
+  "par": 4,
+  "slope": 3,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-23",
+  "shots": [
+    {
+      "ticket_key": "S119-1",
+      "title": "Prevent validate --skills from crashing when stats.miss_directions is missing (#440)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "validateScorecard now normalizes scorecard stats before reading miss_directions, so legacy or sparse scorecards report validation findings instead of throwing."
+    },
+    {
+      "ticket_key": "S119-2",
+      "title": "Make slope skills --help exit successfully (#443)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added explicit skills help handling for --help and -h, preserving usage output while returning a successful CLI exit."
+    },
+    {
+      "ticket_key": "S119-3",
+      "title": "Ignore worktrees, virtualenvs, dependencies, and generated folders during skills scan (#441)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "skills scan now prunes common generated, dependency, cache, virtualenv, and worktree directories by default, uses lstat so symlinked directories are not followed, and still scans an explicitly requested root."
+    },
+    {
+      "ticket_key": "S119-4",
+      "title": "Honor requested sprint skill metadata in briefing recommendations (#442)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Briefing recommendations now bias skills and gaps recorded on the requested sprint scorecard, keeping historical context useful without letting recency override an explicit sprint request."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "bugfix + enhancement",
+  "conditions": [
+    "Fresh GitHub issue batch #440-#443 after the v1.56.1 release"
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Validators should normalize sparse historical data before derived checks.",
+      "outcome": "validate --skills no longer crashes when miss_directions is omitted from a scorecard stats block."
+    },
+    {
+      "type": "lessons",
+      "description": "Broad filesystem scans need conservative default pruning with an explicit-root escape hatch.",
+      "outcome": "skills scan avoids noisy dependency/generated/worktree trees by default while still honoring an explicitly requested scan root."
+    },
+    {
+      "type": "lessons",
+      "description": "Briefing recommendations should respect the sprint the user asked about, not just the most recent scorecards.",
+      "outcome": "Requested sprint skill metadata and skill gaps now receive explicit recommendation weight and evidence."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused validation, skills, and briefing tests passed; full pnpm test, build, typecheck, CLI smoke, map check, roadmap validation, diff check, and npm pack dry run also passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "issue_queue",
+      "description": "Implemented the four new GitHub issues in one sprint and prepared PR closure references for #440, #441, #442, and #443.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Tidy and a little satisfying: each report mapped to a narrow product behavior, and the tests made the fixes feel well pinned down.",
+    "advice_for_next_player": "Keep skill-registry work covered at both core and CLI boundaries; these bugs mostly hide where old scorecards or broad repo roots meet user-facing commands.",
+    "what_surprised_you": "The broad validate command still exposes old GIR overflow scorecards even though modern scorecards are clean.",
+    "excited_about_next": "The skill registry now behaves better in real repos: quieter scans, cleaner help, safer validation, and sprint-aware briefing."
+  },
+  "bunker_locations": [
+    "Repo-wide validate --skills still exits nonzero on pre-existing historical S70 and S74-S83 GIR overflow scorecards.",
+    "Skill scanners should default to pruning generated/dependency/worktree directories and avoid following symlinked directories.",
+    "Briefing fixtures need skill ids and gap terms that do not accidentally overlap unrelated registered skill metadata."
+  ],
+  "yardage_book_updates": [
+    "src/core/validation.ts normalizes stats before validating miss direction totals.",
+    "src/cli/commands/skills.ts now treats skills --help and skills -h as successful help requests.",
+    "src/core/skills.ts skips common generated, dependency, virtualenv, cache, and worktree directories during recursive scans.",
+    "src/core/briefing.ts now weights requested sprint scorecard skills and skill gaps in skill briefing output.",
+    "tests/core/validation.test.ts, tests/cli/skills.test.ts, tests/core/skills.test.ts, and tests/core/briefing.test.ts cover the GitHub issue regressions."
+  ],
+  "course_management_notes": [
+    "Created S119 from GitHub issues #440, #441, #442, and #443.",
+    "pnpm vitest run tests/core/validation.test.ts tests/core/skills.test.ts tests/cli/skills.test.ts tests/core/briefing.test.ts tests/cli/validate-skills.test.ts passed: 145 tests.",
+    "pnpm build passed.",
+    "pnpm typecheck passed.",
+    "pnpm test passed: 214 test files and 3478 tests.",
+    "node dist/cli/index.js skills --help passed with exit code 0.",
+    "node dist/cli/index.js briefing --sprint=119 --compact passed.",
+    "node dist/cli/index.js roadmap validate passed as structurally valid with standing roadmap warnings plus branch-local S119 warnings before the scorecard was added.",
+    "node dist/cli/index.js map --check passed: Overall CURRENT.",
+    "git diff --check passed.",
+    "npm pack --dry-run passed for @slope-dev/slope@1.56.1 with 1018 files.",
+    "node dist/cli/index.js validate --skills against the full historical scorecard set still exits 1 because of pre-existing S70 and S74-S83 GIR overflow scorecards; S119 uses targeted scorecard and regression validation."
+  ],
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "slope-api-reference",
+    "slope-performance-analysis"
+  ],
+  "skill_gaps_found": [],
+  "slope_factors": [
+    "skill_registry",
+    "scorecard_validation",
+    "filesystem_scanning",
+    "briefing_recommendations"
+  ]
+}

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -43,6 +43,19 @@ function rootsFor(config: SlopeConfig, args: string[]): string[] {
   return config.skillRoots && config.skillRoots.length > 0 ? config.skillRoots : [...DEFAULT_SKILL_ROOTS];
 }
 
+function printSkillsHelp(): void {
+  console.log(`
+slope skills — Repo-local Agent Skills registry
+
+Usage:
+  slope skills scan [--root=<path>] [--output=<path>]  Scan skill roots into .slope/skills.json
+  slope skills list [--json] [--output=<path>]         List registered skills
+  slope skills validate [--output=<path>]              Validate registry metadata and source paths
+
+SLOPE indexes, recommends, and validates skill metadata. It does not execute skills.
+`);
+}
+
 function skillsScan(args: string[], cwd: string, config: SlopeConfig): void {
   const roots = rootsFor(config, args);
   const output = registryPath(cwd, config, args);
@@ -116,6 +129,11 @@ export async function skillsCommand(args: string[]): Promise<void> {
   const sub = args[0];
   const rest = args.slice(1);
 
+  if (sub === '--help' || sub === '-h') {
+    printSkillsHelp();
+    return;
+  }
+
   switch (sub) {
     case 'scan':
       skillsScan(rest, cwd, config);
@@ -127,16 +145,7 @@ export async function skillsCommand(args: string[]): Promise<void> {
       skillsValidate(rest, cwd, config);
       break;
     default:
-      console.log(`
-slope skills — Repo-local Agent Skills registry
-
-Usage:
-  slope skills scan [--root=<path>] [--output=<path>]  Scan skill roots into .slope/skills.json
-  slope skills list [--json] [--output=<path>]         List registered skills
-  slope skills validate [--output=<path>]              Validate registry metadata and source paths
-
-SLOPE indexes, recommends, and validates skill metadata. It does not execute skills.
-`);
+      printSkillsHelp();
       if (sub) process.exit(1);
       break;
   }

--- a/src/core/briefing.ts
+++ b/src/core/briefing.ts
@@ -274,6 +274,10 @@ export function buildSkillBriefing(opts: {
     ...(claims ?? []).map(c => c.target),
     ...(changedFiles ?? []),
   ].join(' '));
+  const requestedScorecard = currentSprint != null
+    ? scorecards.find(card => scorecardSprintNumber(card) === currentSprint)
+    : undefined;
+  const requestedSkillIds = collectRequestedScorecardSkillIds(requestedScorecard);
   const historicalSkillIds = collectScorecardSkillIds(scorecards);
 
   const contextTokens = new Set([
@@ -284,7 +288,7 @@ export function buildSkillBriefing(opts: {
   ]);
 
   const recommendations = registry.skills
-    .map(skill => scoreSkill(skill, { sprintText, filterText, hazardText, changedFilesText, contextTokens, historicalSkillIds }))
+    .map(skill => scoreSkill(skill, { sprintText, filterText, hazardText, changedFilesText, contextTokens, requestedSkillIds, historicalSkillIds }))
     .filter((rec): rec is SkillBriefingRecommendation => rec != null)
     .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
     .slice(0, opts.maxRecommendations ?? 5);
@@ -294,6 +298,7 @@ export function buildSkillBriefing(opts: {
     commonIssues,
     filter,
     scorecards,
+    requestedScorecard,
     maxGaps: opts.maxGaps ?? 3,
   });
 
@@ -609,6 +614,7 @@ function scoreSkill(
     hazardText: string;
     changedFilesText: string;
     contextTokens: Set<string>;
+    requestedSkillIds: Set<string>;
     historicalSkillIds: Set<string>;
   },
 ): SkillBriefingRecommendation | null {
@@ -616,6 +622,11 @@ function scoreSkill(
   const matchedTerms = new Set<string>();
   const reasons: string[] = [];
   const phrases = skillMatchPhrases(skill);
+
+  if (context.requestedSkillIds.has(skill.id)) {
+    score += 20;
+    addReason(reasons, 'requested sprint scorecard');
+  }
 
   for (const phrase of phrases) {
     const normalized = normalizeSearchText(phrase);
@@ -677,6 +688,7 @@ function findSkillGaps(opts: {
   commonIssues: CommonIssuesFile;
   filter?: BriefingFilter;
   scorecards: GolfScorecard[];
+  requestedScorecard?: GolfScorecard;
   maxGaps: number;
 }): SkillGapRecommendation[] {
   const gaps: SkillGapRecommendation[] = [];
@@ -696,16 +708,21 @@ function findSkillGaps(opts: {
   }
 
   const seenGapTopics = new Set(gaps.map(g => normalizeSearchText(g.topic)));
-  for (const card of opts.scorecards.slice(-10)) {
+  const gapCards = uniqueScorecards([
+    ...(opts.requestedScorecard ? [opts.requestedScorecard] : []),
+    ...opts.scorecards.slice(-10),
+  ]);
+  for (const card of gapCards) {
     for (const gap of card.skill_gaps_found ?? []) {
       const normalized = normalizeSearchText(gap);
       if (!normalized || seenGapTopics.has(normalized)) continue;
       if (isCoveredBySkill(gap, opts.registry.skills)) continue;
       seenGapTopics.add(normalized);
+      const requested = opts.requestedScorecard && scorecardSprintNumber(card) === scorecardSprintNumber(opts.requestedScorecard);
       gaps.push({
         topic: gap,
-        reason: 'recorded in recent scorecard skill_gaps_found',
-        evidence: [`S${card.sprint_number}`],
+        reason: requested ? 'recorded in requested sprint skill_gaps_found' : 'recorded in recent scorecard skill_gaps_found',
+        evidence: [`S${scorecardSprintNumber(card)}`],
       });
       if (gaps.length >= opts.maxGaps) return gaps;
     }
@@ -746,6 +763,19 @@ function skillMatchPhrases(skill: SkillDefinition): string[] {
   ]);
 }
 
+function collectRequestedScorecardSkillIds(scorecard?: GolfScorecard): Set<string> {
+  const ids = new Set<string>();
+  if (!scorecard) return ids;
+  for (const id of [
+    ...(scorecard.skills_used ?? []),
+    ...(scorecard.skills_created ?? []),
+    ...(scorecard.skills_recommended ?? []),
+  ]) {
+    ids.add(id);
+  }
+  return ids;
+}
+
 function collectScorecardSkillIds(scorecards: GolfScorecard[]): Set<string> {
   const ids = new Set<string>();
   for (const card of scorecards) {
@@ -759,6 +789,22 @@ function collectScorecardSkillIds(scorecards: GolfScorecard[]): Set<string> {
     }
   }
   return ids;
+}
+
+function scorecardSprintNumber(card: GolfScorecard): number {
+  return card.sprint_number ?? (card as { sprint?: number }).sprint ?? 0;
+}
+
+function uniqueScorecards(cards: GolfScorecard[]): GolfScorecard[] {
+  const seen = new Set<number>();
+  const unique: GolfScorecard[] = [];
+  for (const card of cards) {
+    const sprint = scorecardSprintNumber(card);
+    if (seen.has(sprint)) continue;
+    seen.add(sprint);
+    unique.push(card);
+  }
+  return unique;
 }
 
 function collectStringValues(value: unknown, out: string[] = []): string[] {

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -1,7 +1,7 @@
 // Skill registry — index repo-local Agent Skills metadata without executing skills.
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { basename, dirname, isAbsolute, join, relative } from 'node:path';
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import type { SlopeConfig } from './config.js';
 
@@ -65,7 +65,32 @@ export interface ParsedSkillMarkdown {
   warnings: string[];
 }
 
-const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'coverage']);
+const SKIP_DIRS = new Set([
+  '.cache',
+  '.eggs',
+  '.git',
+  '.mypy_cache',
+  '.next',
+  '.npm',
+  '.parcel-cache',
+  '.pnpm-store',
+  '.pytest_cache',
+  '.ruff_cache',
+  '.tox',
+  '.turbo',
+  '.venv',
+  '.worktrees',
+  '.yarn',
+  '__pycache__',
+  'build',
+  'coverage',
+  'dist',
+  'env',
+  'node_modules',
+  'out',
+  'target',
+  'venv',
+]);
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
 export function resolveSkillRoots(config: SlopeConfig, cwd: string = process.cwd()): string[] {
@@ -309,15 +334,15 @@ function findSkillMarkdownFiles(root: string): string[] {
     }
 
     for (const entry of entries.sort()) {
-      if (SKIP_DIRS.has(entry)) continue;
       const fullPath = join(dir, entry);
       let stat;
       try {
-        stat = statSync(fullPath);
+        stat = lstatSync(fullPath);
       } catch {
         continue;
       }
       if (stat.isDirectory()) {
+        if (shouldSkipScanDir(root, fullPath, entry)) continue;
         visit(fullPath);
       } else if (entry === 'SKILL.md') {
         found.push(fullPath);
@@ -326,6 +351,12 @@ function findSkillMarkdownFiles(root: string): string[] {
   };
   visit(root);
   return found.sort();
+}
+
+function shouldSkipScanDir(root: string, fullPath: string, entry: string): boolean {
+  if (SKIP_DIRS.has(entry)) return true;
+  const segments = relative(root, fullPath).split(sep);
+  return segments.length >= 2 && segments[0] === '.claude' && segments[1] === 'worktrees';
 }
 
 function mergeSkill(target: SkillDefinition, source: SkillDefinition): void {

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -1,5 +1,6 @@
 import type { GolfScorecard, HazardSeverity, ShotResult } from './types.js';
 import { computeScoreLabel } from './handicap.js';
+import { normalizeStats } from './builder.js';
 
 // --- Validation-specific types ---
 
@@ -92,7 +93,7 @@ export function validateScorecard(
   }
 
   // Rule 2: stat bounds
-  const stats = card.stats;
+  const stats = card.stats ? normalizeStats(card.stats, card.shots?.length ?? 0) : null;
   if (stats) {
     if (stats.fairways_hit > stats.fairways_total) {
       errors.push({

--- a/tests/cli/skills.test.ts
+++ b/tests/cli/skills.test.ts
@@ -84,6 +84,21 @@ describe('slope skills scan', () => {
   });
 });
 
+describe('slope skills help', () => {
+  it('prints top-level help without exiting non-zero (#443)', async () => {
+    const logged: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logged.push(args.join(' '));
+    });
+
+    await skillsCommand(['--help']);
+    spy.mockRestore();
+
+    expect(exitCode).toBeUndefined();
+    expect(logged.join('\n')).toContain('slope skills');
+  });
+});
+
 describe('slope skills list', () => {
   it('prints registered skills', async () => {
     writeSkill();

--- a/tests/core/briefing.test.ts
+++ b/tests/core/briefing.test.ts
@@ -8,7 +8,7 @@ import {
   buildSkillBriefing,
 } from '../../src/core/briefing.js';
 import type { CommonIssuesFile, RecurringPattern } from '../../src/core/briefing.js';
-import type { SkillRegistryFile } from '../../src/core/skills.js';
+import type { SkillDefinition, SkillRegistryFile } from '../../src/core/skills.js';
 import type { GolfScorecard, ShotRecord, HoleStats, SprintClaim, SlopeEvent } from '../../src/core/types.js';
 import { golf, gaming } from '../../src/core/metaphors/index.js';
 import { backend, frontend, generalist } from '../../src/core/roles.js';
@@ -108,6 +108,24 @@ function makeSkillRegistry(): SkillRegistryFile {
         triggers: ['briefing', 'scorecard', 'sprint'],
       },
     ],
+  };
+}
+
+function makeSkill(id: string, description = `${id} skill.`): SkillDefinition {
+  return {
+    id,
+    name: id,
+    description,
+    path: `.agents/skills/${id}/SKILL.md`,
+    directory: `.agents/skills/${id}`,
+    root: '.agents/skills',
+    sources: [{
+      path: `.agents/skills/${id}/SKILL.md`,
+      directory: `.agents/skills/${id}`,
+      root: '.agents/skills',
+      metadata_sources: ['SKILL.md'],
+    }],
+    triggers: [],
   };
 }
 
@@ -1187,6 +1205,52 @@ describe('buildSkillBriefing', () => {
     const reviewRec = result.recommendations.find(r => r.id === 'review-helper');
     expect(reviewRec).toBeDefined();
     expect(reviewRec?.reason).toContain('changed files');
+  });
+
+  it('prioritizes skills explicitly referenced by the requested sprint scorecard (#442)', () => {
+    const registry = makeSkillRegistry();
+    registry.skills.push(
+      makeSkill('frontend-product-audit'),
+      makeSkill('information-architecture-audit'),
+    );
+
+    const result = buildSkillBriefing({
+      registry,
+      scorecards: [
+        makeCard({ sprint_number: 147, skills_recommended: ['slope-sprint-workflow'] }),
+        makeCard({
+          sprint_number: 148,
+          skills_recommended: ['frontend-product-audit'],
+          skills_created: ['information-architecture-audit'],
+        }),
+      ],
+      commonIssues: makeIssues([]),
+      currentSprint: 148,
+    });
+
+    expect(result.recommendations.slice(0, 2).map(r => r.id)).toEqual([
+      'frontend-product-audit',
+      'information-architecture-audit',
+    ]);
+    expect(result.recommendations[0].reason).toContain('requested sprint scorecard');
+  });
+
+  it('surfaces skill gaps from the requested sprint scorecard (#442)', () => {
+    const result = buildSkillBriefing({
+      registry: makeSkillRegistry(),
+      scorecards: [
+        makeCard({ sprint_number: 120, skill_gaps_found: ['older gap'] }),
+        makeCard({ sprint_number: 148, skill_gaps_found: ['browser snapshot qa'] }),
+      ],
+      commonIssues: makeIssues([]),
+      currentSprint: 148,
+    });
+
+    expect(result.gaps[0]).toMatchObject({
+      topic: 'browser snapshot qa',
+      reason: 'recorded in requested sprint skill_gaps_found',
+      evidence: ['S148'],
+    });
   });
 
   it('surfaces repeated relevant topics that have no matching registered skill', () => {

--- a/tests/core/skills.test.ts
+++ b/tests/core/skills.test.ts
@@ -141,6 +141,42 @@ Guide.
     expect(result.warnings.some(w => w.includes('Merged duplicate skill id'))).toBe(true);
   });
 
+  it('skips dependency, generated, and nested worktree folders by default (#441)', () => {
+    const skill = (name: string) => `---
+name: ${name}
+description: ${name} skill.
+---
+
+Use ${name}.
+`;
+    writeSkill('.agents/skills', 'repo-helper', skill('repo-helper'));
+    writeSkill('node_modules/pkg/.agents/skills', 'dependency-helper', skill('dependency-helper'));
+    writeSkill('.venv/lib/python3.12/site-packages/fastapi/.agents/skills', 'fastapi', skill('fastapi'));
+    writeSkill('.claude/worktrees/testing/.claude/skills', 'worktree-helper', skill('worktree-helper'));
+    writeSkill('dist/generated/skills', 'generated-helper', skill('generated-helper'));
+
+    const result = scanSkills({ cwd: tmpDir, roots: ['.'] });
+
+    expect(result.registry.skills.map(s => s.id)).toEqual(['repo-helper']);
+  });
+
+  it('still scans ignored-name locations when they are explicit roots (#441)', () => {
+    writeSkill('.venv/lib/python3.12/site-packages/fastapi/.agents/skills', 'fastapi', `---
+name: fastapi
+description: FastAPI helper.
+---
+
+Use FastAPI.
+`);
+
+    const result = scanSkills({
+      cwd: tmpDir,
+      roots: ['.venv/lib/python3.12/site-packages/fastapi/.agents/skills'],
+    });
+
+    expect(result.registry.skills.map(s => s.id)).toEqual(['fastapi']);
+  });
+
   it('parses agents/openai.yaml metadata without making it executable', () => {
     writeSkill(
       '.agents/skills',

--- a/tests/core/validation.test.ts
+++ b/tests/core/validation.test.ts
@@ -234,6 +234,19 @@ describe('validateScorecard - miss directions', () => {
     }));
     expect(result.errors.filter(e => e.code === 'MISS_DIRECTION_MISMATCH')).toHaveLength(0);
   });
+
+  it('treats missing miss_directions as zeroes instead of throwing (#440)', () => {
+    const shots = [
+      makeShot({ result: 'green' }),
+      makeShot({ result: 'in_the_hole' }),
+    ];
+    const stats = makeStats({ fairways_total: 2, fairways_hit: 2, greens_total: 2, greens_in_regulation: 2 });
+    delete (stats as Partial<HoleStats>).miss_directions;
+
+    const result = validateScorecard(makeCard({ shots, stats }));
+
+    expect(result.errors.filter(e => e.code === 'MISS_DIRECTION_MISMATCH')).toHaveLength(0);
+  });
 });
 
 // --- Rule 6: basic field validation ---


### PR DESCRIPTION
## Summary
- normalize scorecard stats during validation so sparse `miss_directions` data does not crash `validate --skills`
- make `slope skills --help` / `-h` exit successfully
- prune generated, dependency, virtualenv, and worktree directories during skill scans while preserving explicit-root scans
- make briefing skill recommendations honor requested sprint scorecard skill metadata and gaps
- close Sprint 119 in roadmap, scorecard, and review docs

## Validation
- `pnpm vitest run tests/core/validation.test.ts tests/core/skills.test.ts tests/cli/skills.test.ts tests/core/briefing.test.ts tests/cli/validate-skills.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `node dist/cli/index.js validate --skills docs/retros/sprint-119.json`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js skills --help`
- `node dist/cli/index.js briefing --sprint=119 --compact`
- `git diff --check`
- `npm pack --dry-run`

Closes #440
Closes #441
Closes #442
Closes #443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevent crashes when skill statistics are missing
  * Fixed help command exit code behavior
  * Improved validation to handle incomplete statistics data

* **New Features**
  * Enhanced skill directory scanning to exclude build and cache directories
  * Briefing recommendations now honor requested sprint skill metadata

* **Documentation**
  * Added Sprint 119 documentation and retrospective materials

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->