### PR TITLE
[codex] Fix historical scorecard validation

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -225,8 +225,8 @@
       "sprints": [
         120
       ],
-      "status": "planned",
-      "note": "Clear the repo-wide validate --skills failure caused by legacy scorecards that predate explicit greens_total stats."
+      "status": "complete",
+      "note": "Cleared the repo-wide validate --skills failure caused by legacy scorecards that predate explicit greens_total stats."
     }
   ],
   "sprints": [
@@ -2459,7 +2459,9 @@
       "par": 3,
       "slope": 1,
       "type": "bugfix",
-      "status": "planned",
+      "status": "complete",
+      "score": 3,
+      "score_label": "par",
       "depends_on": [
         119
       ],

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -219,6 +219,14 @@
       ],
       "status": "complete",
       "note": "Closed the new GitHub issue batch for skills validation, scanning, help behavior, and sprint-specific briefing recommendations."
+    },
+    {
+      "name": "Phase 35 \u2014 Historical Scorecard Validation Cleanup",
+      "sprints": [
+        120
+      ],
+      "status": "planned",
+      "note": "Clear the repo-wide validate --skills failure caused by legacy scorecards that predate explicit greens_total stats."
     }
   ],
   "sprints": [
@@ -2442,6 +2450,26 @@
           "depends_on": [
             "S119-3"
           ]
+        }
+      ]
+    },
+    {
+      "id": 120,
+      "theme": "Historical Scorecard Validation Cleanup",
+      "par": 3,
+      "slope": 1,
+      "type": "bugfix",
+      "status": "planned",
+      "depends_on": [
+        119
+      ],
+      "note": "Make legacy scorecards without stats.greens_total validate correctly by inferring the total from shots.length.",
+      "tickets": [
+        {
+          "key": "S120-1",
+          "title": "Infer missing greens_total for legacy scorecards so repo-wide validate --skills passes",
+          "club": "wedge",
+          "complexity": "small"
         }
       ]
     }

--- a/docs/retros/sprint-120-review.md
+++ b/docs/retros/sprint-120-review.md
@@ -1,0 +1,63 @@
+## Sprint 120 Review: Historical Scorecard Validation Cleanup
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 1 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+| Hazard Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S120-1 | Wedge | In the Hole | - | normalizeStats now falls back to shots.length when legacy full-shape stats omit greens_total, preserving explicit zero totals while allowing old S70 and S74-S83 cards to validate. |
+
+### Hazards Discovered
+
+No new hazards were hit during S120.
+
+**Known hazards for future sprints:**
+- Legacy scorecards can have modern-looking stats with individual total fields omitted.
+- Normalization fallback rules should keep explicit zero distinct from missing or null fields.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Normalization should distinguish omitted legacy totals from explicit zero totals. | Missing greens_total now uses the scorecard shot count, while explicit greens_total: 0 still validates as zero. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Focused validation tests, build, typecheck, full pnpm test, repo-wide validate --skills, roadmap validation, map check, and diff check passed. |
+| validation | healthy | The historical scorecard set now validates with --skills instead of failing on S70 and S74-S83 GIR overflow errors. |
+
+### Course Management Notes
+
+- Confirmed S70 and S74-S83 all omitted stats.greens_total while reporting greens_in_regulation.
+- pnpm vitest run tests/core/validation.test.ts passed: 34 tests.
+- pnpm build passed.
+- pnpm typecheck passed.
+- pnpm test passed: 214 test files and 3479 tests.
+- node dist/cli/index.js validate --skills passed repo-wide.
+- node dist/cli/index.js validate --skills docs/retros/sprint-120.json passed with no errors or warnings.
+- node dist/cli/index.js roadmap validate passed as structurally valid with standing warnings plus the expected branch-local S120 not-on-main warning.
+- node dist/cli/index.js map --check passed: Overall CURRENT.
+- git diff --check passed.
+- node dist/cli/index.js review recommend reported only optional code review for the one-ticket, slope-1 sprint.
+
+### 19th Hole
+
+- **How did it feel?** Small and clean: the failure was a compatibility edge in normalization, not bad historical intent.
+- **Advice for next player?** When validating older scorecards, prefer shape-aware normalization over mass-editing historical records.
+- **What surprised you?** The old cards had greens_in_regulation and shot counts, so the missing total was enough information to recover safely.
+- **Excited about next?** Repo-wide validation is useful again as a real gate instead of a known-failing command.

--- a/docs/retros/sprint-120.json
+++ b/docs/retros/sprint-120.json
@@ -1,0 +1,99 @@
+{
+  "sprint_number": 120,
+  "player": "codex",
+  "theme": "Historical Scorecard Validation Cleanup",
+  "par": 3,
+  "slope": 1,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-05-23",
+  "shots": [
+    {
+      "ticket_key": "S120-1",
+      "title": "Infer missing greens_total for legacy scorecards so repo-wide validate --skills passes",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "normalizeStats now falls back to shots.length when legacy full-shape stats omit greens_total, preserving explicit zero totals while allowing old S70 and S74-S83 cards to validate."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "bugfix",
+  "conditions": [
+    "Follow-up from S119 closeout after repo-wide validate --skills exposed legacy scorecard GIR_OVERFLOW errors"
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Normalization should distinguish omitted legacy totals from explicit zero totals.",
+      "outcome": "Missing greens_total now uses the scorecard shot count, while explicit greens_total: 0 still validates as zero."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused validation tests, build, typecheck, full pnpm test, repo-wide validate --skills, roadmap validation, map check, and diff check passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "validation",
+      "description": "The historical scorecard set now validates with --skills instead of failing on S70 and S74-S83 GIR overflow errors.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Small and clean: the failure was a compatibility edge in normalization, not bad historical intent.",
+    "advice_for_next_player": "When validating older scorecards, prefer shape-aware normalization over mass-editing historical records.",
+    "what_surprised_you": "The old cards had greens_in_regulation and shot counts, so the missing total was enough information to recover safely.",
+    "excited_about_next": "Repo-wide validation is useful again as a real gate instead of a known-failing command."
+  },
+  "bunker_locations": [
+    "Legacy scorecards can have modern-looking stats with individual total fields omitted.",
+    "Normalization fallback rules should keep explicit zero distinct from missing or null fields."
+  ],
+  "yardage_book_updates": [
+    "src/core/builder.ts normalizeStats now defaults missing fairways_total and greens_total to shotCount for full-shape stats.",
+    "tests/core/validation.test.ts covers legacy stats that omit greens_total while preserving GIR validation."
+  ],
+  "course_management_notes": [
+    "Confirmed S70 and S74-S83 all omitted stats.greens_total while reporting greens_in_regulation.",
+    "pnpm vitest run tests/core/validation.test.ts passed: 34 tests.",
+    "pnpm build passed.",
+    "pnpm typecheck passed.",
+    "pnpm test passed: 214 test files and 3479 tests.",
+    "node dist/cli/index.js validate --skills passed repo-wide.",
+    "node dist/cli/index.js roadmap validate passed as structurally valid with standing warnings plus expected branch-local S120 warnings before the scorecard was added.",
+    "node dist/cli/index.js map --check passed: Overall CURRENT.",
+    "git diff --check passed.",
+    "node dist/cli/index.js review recommend reported only optional code review for the one-ticket, slope-1 sprint."
+  ],
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "slope-api-reference",
+    "slope-performance-analysis"
+  ],
+  "skill_gaps_found": [],
+  "slope_factors": [
+    "legacy_scorecards",
+    "validation_normalization"
+  ]
+}

--- a/src/core/builder.ts
+++ b/src/core/builder.ts
@@ -104,11 +104,14 @@ export function normalizeStats(raw: unknown, shotCount = 0): HoleStats {
   const s = raw as Record<string, unknown>;
 
   if ('fairways_hit' in s && 'fairways_total' in s) {
+    const numberOrDefault = (value: unknown, fallback: number) => (
+      value == null ? fallback : Number(value) || 0
+    );
     return {
       fairways_hit: Number(s.fairways_hit) || 0,
-      fairways_total: Number(s.fairways_total) || 0,
+      fairways_total: numberOrDefault(s.fairways_total, shotCount),
       greens_in_regulation: Number(s.greens_in_regulation) || 0,
-      greens_total: Number(s.greens_total) || 0,
+      greens_total: numberOrDefault(s.greens_total, shotCount),
       putts: Number(s.putts) || 0,
       penalties: Number(s.penalties) || 0,
       hazards_hit: Number(s.hazards_hit) || 0,

--- a/tests/core/validation.test.ts
+++ b/tests/core/validation.test.ts
@@ -100,6 +100,20 @@ describe('validateScorecard - stat bounds', () => {
     expect(result.errors.some(e => e.code === 'GIR_OVERFLOW')).toBe(true);
   });
 
+  it('infers missing greens_total from shots for legacy stats', () => {
+    const shots = [
+      makeShot({ result: 'green' }),
+      makeShot({ result: 'in_the_hole' }),
+    ];
+    const stats = makeStats({ fairways_hit: 2, fairways_total: 2, greens_in_regulation: 2 });
+    delete (stats as Partial<HoleStats>).greens_total;
+
+    const result = validateScorecard(makeCard({ shots, stats }));
+
+    expect(result.errors.filter(e => e.code === 'GIR_OVERFLOW')).toHaveLength(0);
+    expect(result.valid).toBe(true);
+  });
+
   it('passes when stats are within bounds', () => {
     const result = validateScorecard(makeCard());
     expect(result.errors.filter(e => e.code === 'FAIRWAYS_OVERFLOW')).toHaveLength(0);


### PR DESCRIPTION
## Summary
- infer missing `greens_total` from `shots.length` for legacy full-shape scorecard stats while preserving explicit zero totals
- add regression coverage for legacy stats that omit `greens_total`
- record S120 roadmap, scorecard, and review closeout

## Validation
- `pnpm vitest run tests/core/validation.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js validate --skills docs/retros/sprint-120.json`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`
- `git diff --check`
- `npm pack --dry-run`