### PR TITLE
[codex] Prepare v1.56.2 release

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -227,6 +227,14 @@
       ],
       "status": "complete",
       "note": "Cleared the repo-wide validate --skills failure caused by legacy scorecards that predate explicit greens_total stats."
+    },
+    {
+      "name": "Phase 36 \u2014 Skill Registry Patch Release",
+      "sprints": [
+        121
+      ],
+      "status": "planned",
+      "note": "Publish the S119/S120 skill registry and validation fixes as v1.56.2 using the trusted-publisher release flow."
     }
   ],
   "sprints": [
@@ -2472,6 +2480,35 @@
           "title": "Infer missing greens_total for legacy scorecards so repo-wide validate --skills passes",
           "club": "wedge",
           "complexity": "small"
+        }
+      ]
+    },
+    {
+      "id": 121,
+      "theme": "Skill Registry Patch Release",
+      "par": 3,
+      "slope": 1,
+      "type": "release",
+      "status": "planned",
+      "depends_on": [
+        120
+      ],
+      "note": "Release the S119 skill registry follow-ups and S120 historical validation cleanup as v1.56.2.",
+      "tickets": [
+        {
+          "key": "S121-1",
+          "title": "Bump @slope-dev/slope and bundled Codex plugin to v1.56.2",
+          "club": "wedge",
+          "complexity": "small"
+        },
+        {
+          "key": "S121-2",
+          "title": "Run release validation, publish v1.56.2, and verify npm",
+          "club": "short_iron",
+          "complexity": "standard",
+          "depends_on": [
+            "S121-1"
+          ]
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.56.1",
+  "version": "1.56.2",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.56.1",
+  "version": "1.56.2",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
## Summary
- plan Sprint 121 as the v1.56.2 release cycle
- bump `@slope-dev/slope` package metadata to `1.56.2`
- bump the bundled Codex plugin manifest to `1.56.2`

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run tests/cli/init-codex.test.ts`
- `pnpm test`
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js version`
- `git diff --check`
- `npm pack --dry-run`

Note: an initial local parallel `pnpm build` + `pnpm test` run exposed a validation sequencing race against generated `dist/`; rerunning build and tests sequentially passed cleanly.