### PR TITLE
[codex] Fix guard hook cwd handling

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -235,6 +235,14 @@
       ],
       "status": "complete",
       "note": "Published the S119/S120 skill registry and validation fixes as v1.56.2 using the trusted-publisher release flow."
+    },
+    {
+      "name": "Phase 37 \u2014 Hook CWD Guard Correctness",
+      "sprints": [
+        122
+      ],
+      "status": "planned",
+      "note": "Fix GitHub issue #447 so tool hooks prefer the payload cwd in Codex worktrees before falling back to the launcher cwd."
     }
   ],
   "sprints": [
@@ -2510,6 +2518,35 @@
           "complexity": "standard",
           "depends_on": [
             "S121-1"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 122,
+      "theme": "Hook CWD Guard Correctness",
+      "par": 3,
+      "slope": 1,
+      "type": "bugfix",
+      "status": "planned",
+      "depends_on": [
+        121
+      ],
+      "note": "Close GitHub issue #447 by making guard execution honor hook payload cwd in Codex worktrees.",
+      "tickets": [
+        {
+          "key": "S122-1",
+          "title": "Route guard execution through hook payload cwd with process cwd fallback",
+          "club": "short_iron",
+          "complexity": "standard"
+        },
+        {
+          "key": "S122-2",
+          "title": "Add regression coverage for branch-before-commit in Codex worktrees",
+          "club": "wedge",
+          "complexity": "small",
+          "depends_on": [
+            "S122-1"
           ]
         }
       ]

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -241,8 +241,8 @@
       "sprints": [
         122
       ],
-      "status": "planned",
-      "note": "Fix GitHub issue #447 so tool hooks prefer the payload cwd in Codex worktrees before falling back to the launcher cwd."
+      "status": "complete",
+      "note": "Fixed GitHub issue #447 so tool hooks prefer the payload cwd in Codex worktrees before falling back to the launcher cwd."
     }
   ],
   "sprints": [
@@ -2528,7 +2528,9 @@
       "par": 3,
       "slope": 1,
       "type": "bugfix",
-      "status": "planned",
+      "status": "complete",
+      "score": 3,
+      "score_label": "par",
       "depends_on": [
         121
       ],

--- a/docs/retros/sprint-122-review.md
+++ b/docs/retros/sprint-122-review.md
@@ -1,0 +1,69 @@
+## Sprint 122 Review: Hook CWD Guard Correctness
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 1 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (2/2) |
+| GIR % | 100% (2/2) |
+| Putts | 0 |
+| Penalties | 0 |
+| Hazard Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 2)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S122-1 | Short Iron | In the Hole | - | Moved guardCommand config/plugin loading, baseline recording, suppression, metrics, and handler execution to use the normalized hook input cwd, falling back to process.cwd() only when stdin has no usable cwd. |
+| S122-2 | Wedge | In the Hole | - | Added branch-before-commit and dispatcher tests proving the guard checks branch/config/metrics in the hook payload cwd instead of the launcher cwd. |
+
+### Hazards Discovered
+
+No new hazards were hit during S122.
+
+**Known hazards for future sprints:**
+- Guard command dispatch must read HookInput before loading repo-local guard config in worktree-aware harnesses.
+- Guard handlers that receive cwd should use loadConfig(cwd) when reading guidance settings.
+- Regression tests for hook cwd bugs should verify both emitted guard output and metrics location.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Hook dispatchers should resolve the runtime workspace from hook payloads before loading repo-local configuration. | S122 normalizes HookInput up front, then uses that cwd for config, plugins, metrics, suppression, and guard handlers. |
+| Lessons | Guard handlers that receive cwd should pass it through to config loading instead of relying on process.cwd(). | Branch, nudge, compaction, transcript, and subagent guards now load configuration from the effective guard cwd. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Focused guard tests, typecheck, build, full pnpm test, scorecard validation, roadmap validation, map check, and whitespace checks passed. |
+| workflow | healthy | The fix is tied to GitHub issue #447 and includes a Codex worktree regression test. |
+
+### Course Management Notes
+
+- Planned Phase 37 and Sprint 122 for GitHub issue #447.
+- Changed src/cli/commands/guard.ts so guard execution reads stdin before loading config and uses HookInput.cwd when present.
+- Changed guard handlers with internal loadConfig() calls to pass the effective cwd.
+- Added unit coverage for branch-before-commit checking branch state and config from the effective cwd.
+- Added dispatcher coverage proving branch-before-commit allows a feature-branch hook cwd even when the launcher cwd is on main.
+- pnpm vitest run tests/cli/guards/branch-before-commit.test.ts tests/cli/commands/guard.test.ts passed: 30 tests.
+- pnpm typecheck passed.
+- pnpm build passed.
+- pnpm test passed: 214 passed test files, 1 skipped test file, 3481 passed tests, and 23 skipped tests.
+- node dist/cli/index.js validate --skills passed before closeout.
+- node dist/cli/index.js roadmap validate passed before closeout with standing warnings only plus the expected branch-local S122 warning.
+- node dist/cli/index.js map --check passed: Overall CURRENT.
+- git diff --check passed.
+- slope review recommend suggested architect review and optional code review; self-review found no blocking issues.
+
+### 19th Hole
+
+- **How did it feel?** Small but satisfying: the bug lived in one early cwd choice, and the fix made the whole guard path more honest.
+- **Advice for next player?** When a hook payload includes cwd, normalize it before any repo-local config or plugin work begins.
+- **What surprised you?** Several guard handlers already accepted cwd but still loaded config from process.cwd(), so the central fix needed a small follow-through pass.
+- **Excited about next?** Codex worktree commits should no longer get blocked by the branch state of the launcher checkout.

--- a/docs/retros/sprint-122.json
+++ b/docs/retros/sprint-122.json
@@ -1,0 +1,117 @@
+{
+  "sprint_number": 122,
+  "player": "codex",
+  "theme": "Hook CWD Guard Correctness",
+  "par": 3,
+  "slope": 1,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-05-23",
+  "shots": [
+    {
+      "ticket_key": "S122-1",
+      "title": "Route guard execution through hook payload cwd with process cwd fallback",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Moved guardCommand config/plugin loading, baseline recording, suppression, metrics, and handler execution to use the normalized hook input cwd, falling back to process.cwd() only when stdin has no usable cwd."
+    },
+    {
+      "ticket_key": "S122-2",
+      "title": "Add regression coverage for branch-before-commit in Codex worktrees",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added branch-before-commit and dispatcher tests proving the guard checks branch/config/metrics in the hook payload cwd instead of the launcher cwd."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 2,
+    "fairways_total": 2,
+    "greens_in_regulation": 2,
+    "greens_total": 2,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "bugfix",
+  "conditions": [],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Hook dispatchers should resolve the runtime workspace from hook payloads before loading repo-local configuration.",
+      "outcome": "S122 normalizes HookInput up front, then uses that cwd for config, plugins, metrics, suppression, and guard handlers."
+    },
+    {
+      "type": "lessons",
+      "description": "Guard handlers that receive cwd should pass it through to config loading instead of relying on process.cwd().",
+      "outcome": "Branch, nudge, compaction, transcript, and subagent guards now load configuration from the effective guard cwd."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused guard tests, typecheck, build, full pnpm test, scorecard validation, roadmap validation, map check, and whitespace checks passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "workflow",
+      "description": "The fix is tied to GitHub issue #447 and includes a Codex worktree regression test.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Small but satisfying: the bug lived in one early cwd choice, and the fix made the whole guard path more honest.",
+    "advice_for_next_player": "When a hook payload includes cwd, normalize it before any repo-local config or plugin work begins.",
+    "what_surprised_you": "Several guard handlers already accepted cwd but still loaded config from process.cwd(), so the central fix needed a small follow-through pass.",
+    "excited_about_next": "Codex worktree commits should no longer get blocked by the branch state of the launcher checkout."
+  },
+  "bunker_locations": [
+    "Guard command dispatch must read HookInput before loading repo-local guard config in worktree-aware harnesses.",
+    "Guard handlers that receive cwd should use loadConfig(cwd) when reading guidance settings.",
+    "Regression tests for hook cwd bugs should verify both emitted guard output and metrics location."
+  ],
+  "yardage_book_updates": [
+    "guardCommand now normalizes HookInput and treats input.cwd as the effective guard cwd when present.",
+    "branch-before-commit now checks protected-branch config from the effective guard cwd.",
+    "Commit/push nudges, compaction, subagent gate, and transcript guards now load config from their handler cwd.",
+    "tests/cli/commands/guard.test.ts includes a Codex-style launcher-main plus hook-feature-branch regression path."
+  ],
+  "course_management_notes": [
+    "Planned Phase 37 and Sprint 122 for GitHub issue #447.",
+    "Changed src/cli/commands/guard.ts so guard execution reads stdin before loading config and uses HookInput.cwd when present.",
+    "Changed guard handlers with internal loadConfig() calls to pass the effective cwd.",
+    "Added unit coverage for branch-before-commit checking branch state and config from the effective cwd.",
+    "Added dispatcher coverage proving branch-before-commit allows a feature-branch hook cwd even when the launcher cwd is on main.",
+    "pnpm vitest run tests/cli/guards/branch-before-commit.test.ts tests/cli/commands/guard.test.ts passed: 30 tests.",
+    "pnpm typecheck passed.",
+    "pnpm build passed.",
+    "pnpm test passed: 214 passed test files, 1 skipped test file, 3481 passed tests, and 23 skipped tests.",
+    "node dist/cli/index.js validate --skills passed before closeout.",
+    "node dist/cli/index.js roadmap validate passed before closeout with standing warnings only plus the expected branch-local S122 warning.",
+    "node dist/cli/index.js map --check passed: Overall CURRENT.",
+    "git diff --check passed.",
+    "slope review recommend suggested architect review and optional code review; self-review found no blocking issues."
+  ],
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "slope-performance-analysis"
+  ],
+  "skill_gaps_found": [],
+  "slope_factors": [
+    "guard_dispatch",
+    "codex_worktrees",
+    "hook_payload_cwd"
+  ]
+}

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -125,28 +125,21 @@ export async function guardCommand(args: string[]): Promise<void> {
     return;
   }
 
-  const cwd = process.cwd();
-  const config = loadConfig();
-  const disabled = config.guidance?.disabled ?? [];
-
-  // Load custom guard plugins
-  loadPluginGuards(cwd, config.plugins);
+  const fallbackCwd = process.cwd();
 
   // Read hook input from stdin
   let input: HookInput;
   try {
-    input = await readStdin();
-    // Backfill required fields that Claude Code may omit from hook JSON
-    if (!input.session_id) input.session_id = '';
-    if (!input.cwd) input.cwd = cwd;
-    if (!input.hook_event_name) input.hook_event_name = '';
+    input = normalizeHookInput(await readStdin(), fallbackCwd);
   } catch {
-    input = {
-      session_id: '',
-      cwd,
-      hook_event_name: '',
-    };
+    input = normalizeHookInput(null, fallbackCwd);
   }
+  const cwd = input.cwd;
+  const config = loadConfig(cwd);
+  const disabled = config.guidance?.disabled ?? [];
+
+  // Load custom guard plugins from the hook target workspace.
+  loadPluginGuards(cwd, config.plugins);
 
   // Record git status baseline on first guard call for this session.
   // Used by stop-check to distinguish pre-existing dirty files from session changes.
@@ -305,6 +298,15 @@ async function readStdin(): Promise<HookInput> {
       if (data === '') reject(new Error('No stdin'));
     }, 100);
   });
+}
+
+function normalizeHookInput(input: HookInput | null, fallbackCwd: string): HookInput {
+  return {
+    ...(input ?? {}),
+    session_id: input?.session_id ?? '',
+    cwd: typeof input?.cwd === 'string' && input.cwd.length > 0 ? input.cwd : fallbackCwd,
+    hook_event_name: input?.hook_event_name ?? '',
+  };
 }
 
 function printUsage(): void {

--- a/src/cli/guards/branch-before-commit.ts
+++ b/src/cli/guards/branch-before-commit.ts
@@ -38,7 +38,7 @@ export async function branchBeforeCommitGuard(input: HookInput, cwd: string): Pr
   }
 
   // Check against protected branches (configurable, default: main/master)
-  const config = loadConfig();
+  const config = loadConfig(cwd);
   const protectedBranches = config.guidance?.protectedBranches ?? DEFAULT_PROTECTED;
 
   // HEAD means initial repo with no commits — allow

--- a/src/cli/guards/commit-nudge.ts
+++ b/src/cli/guards/commit-nudge.ts
@@ -9,7 +9,7 @@ import { dedupGuardContext } from '../session-state.js';
  * Nudges to commit/push after prolonged editing.
  */
 export async function commitNudgeGuard(input: HookInput, cwd: string): Promise<GuardResult> {
-  const config = loadConfig();
+  const config = loadConfig(cwd);
   const commitInterval = config.guidance?.commitInterval ?? 15;
   const pushInterval = config.guidance?.pushInterval ?? 30;
 

--- a/src/cli/guards/compaction.ts
+++ b/src/cli/guards/compaction.ts
@@ -35,7 +35,7 @@ export async function compactionGuard(input: HookInput, cwd: string): Promise<Gu
   const sessionId = input.session_id;
   if (!sessionId) return {};
 
-  const config = loadConfig();
+  const config = loadConfig(cwd);
   const handoffsDir = join(cwd, config.guidance?.handoffsDir ?? '.slope/handoffs');
 
   const handoff: HandoffData = {

--- a/src/cli/guards/push-nudge.ts
+++ b/src/cli/guards/push-nudge.ts
@@ -13,7 +13,7 @@ export async function pushNudgeGuard(input: HookInput, cwd: string): Promise<Gua
   // Only fire after git commit commands
   if (!command.includes('git commit')) return {};
 
-  const config = loadConfig();
+  const config = loadConfig(cwd);
   const guidance = config.guidance ?? {};
   const pushCommitThreshold = guidance.pushCommitThreshold ?? 5;
   const pushInterval = guidance.pushInterval ?? 30;

--- a/src/cli/guards/subagent-gate.ts
+++ b/src/cli/guards/subagent-gate.ts
@@ -42,7 +42,7 @@ function buildOrientation(cwd: string): string {
  * Subagent gate guard: fires PreToolUse on Agent.
  * Enforces model selection on Explore/Plan subagents.
  */
-export async function subagentGateGuard(input: HookInput, _cwd: string): Promise<GuardResult> {
+export async function subagentGateGuard(input: HookInput, cwd: string): Promise<GuardResult> {
   const toolInput = input.tool_input ?? {};
   const subagentType = toolInput.subagent_type as string | undefined;
   const model = toolInput.model as string | undefined;
@@ -54,7 +54,7 @@ export async function subagentGateGuard(input: HookInput, _cwd: string): Promise
   // Only gate Explore and Plan subagents
   if (subagentType !== 'Explore' && subagentType !== 'Plan') return {};
 
-  const config = loadConfig();
+  const config = loadConfig(cwd);
   const guidance = config.guidance ?? {};
   const allowedModels = guidance.subagentAllowModels ?? ['haiku'];
 
@@ -72,5 +72,5 @@ export async function subagentGateGuard(input: HookInput, _cwd: string): Promise
     };
   }
 
-  return { context: buildOrientation(_cwd) };
+  return { context: buildOrientation(cwd) };
 }

--- a/src/cli/guards/transcript.ts
+++ b/src/cli/guards/transcript.ts
@@ -54,7 +54,7 @@ export async function transcriptGuard(input: HookInput, cwd: string): Promise<Gu
   // Skip if no session_id
   if (!input.session_id) return {};
 
-  const config = loadConfig();
+  const config = loadConfig(cwd);
   const transcriptsDir = join(cwd, config.transcriptsPath ?? '.slope/transcripts');
 
   const toolName = input.tool_name ?? 'unknown';

--- a/tests/cli/commands/guard.test.ts
+++ b/tests/cli/commands/guard.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { PassThrough } from 'node:stream';
+import { execFileSync } from 'node:child_process';
 import type { HookInput } from '../../../src/core/index.js';
 
 // Ensure adapters are registered
@@ -27,6 +28,14 @@ function writeMinimalSlopeConfig(cwd: string): void {
     scorecardDir: 'docs/retros',
     metaphor: 'golf',
   }));
+}
+
+function initGitRepo(cwd: string, branch: string): void {
+  execFileSync('git', ['init', '-q'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['checkout', '-q', '-b', branch], { cwd, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-q', '--allow-empty', '-m', 'initial'], { cwd, stdio: 'ignore' });
 }
 
 function makeHookInput(cwd: string, overrides: Partial<HookInput> = {}): HookInput {
@@ -200,6 +209,32 @@ describe('guardCommand dispatcher path', () => {
     expect(metrics).toContain('"decision":"suppressed"');
     expect(metrics).toContain('"guard":"claim-required"');
     expect(metrics).toContain('"decision":"ask"');
+  });
+
+  it('uses hook input cwd instead of launcher cwd when running branch-before-commit', async () => {
+    initGitRepo(cwd, 'main');
+    const worktreeCwd = makeTmpDir();
+
+    try {
+      writeMinimalSlopeConfig(worktreeCwd);
+      initGitRepo(worktreeCwd, 'feat/hook-cwd');
+
+      const output = await runGuardCommandWithInput(
+        ['branch-before-commit'],
+        makeHookInput(worktreeCwd, {
+          tool_name: 'Bash',
+          tool_input: { command: 'git commit -m "feat: keep worktree branch"' },
+        }),
+      );
+
+      expect(output).toBe('');
+      const worktreeMetrics = readFileSync(join(worktreeCwd, '.slope', 'guard-metrics.jsonl'), 'utf8');
+      expect(worktreeMetrics).toContain('"guard":"branch-before-commit"');
+      expect(worktreeMetrics).toContain('"decision":"silent"');
+      expect(existsSync(join(cwd, '.slope', 'guard-metrics.jsonl'))).toBe(false);
+    } finally {
+      rmSync(worktreeCwd, { recursive: true, force: true });
+    }
   });
 
   it('prints metric reason counts in the metrics command', async () => {

--- a/tests/cli/guards/branch-before-commit.test.ts
+++ b/tests/cli/guards/branch-before-commit.test.ts
@@ -37,6 +37,23 @@ describe('branchBeforeCommitGuard', () => {
     const result = await branchBeforeCommitGuard(makeInput('git commit -m "feat: stuff"'), '/tmp/test');
     expect(result.decision).toBe('deny');
     expect(result.blockReason).toContain('feature branch');
+    expect(mockLoadConfig).toHaveBeenCalledWith('/tmp/test');
+  });
+
+  it('checks branch state and config from the effective guard cwd', async () => {
+    mockExecSync.mockReturnValue('release');
+    mockLoadConfig.mockReturnValue({
+      guidance: { protectedBranches: ['release'] },
+    } as ReturnType<typeof loadConfig>);
+
+    const result = await branchBeforeCommitGuard(makeInput('git commit -m "release: patch"'), '/tmp/worktree');
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      'git rev-parse --abbrev-ref HEAD 2>/dev/null',
+      { cwd: '/tmp/worktree', encoding: 'utf8' },
+    );
+    expect(mockLoadConfig).toHaveBeenCalledWith('/tmp/worktree');
+    expect(result.decision).toBe('deny');
   });
 
   it('denies git commit on master', async () => {


### PR DESCRIPTION
## Summary
- make `slope guard` read and normalize hook stdin before loading repo-local config/plugins
- route guard execution, suppression, baseline, and metrics through the hook payload `cwd` when present
- update guard handlers with internal config reads to call `loadConfig(cwd)`
- add branch-before-commit and dispatcher regression tests for Codex worktree commits
- close Sprint 122 / Phase 37 scorecard and review

Closes #447

## Validation
- `pnpm vitest run tests/cli/guards/branch-before-commit.test.ts tests/cli/commands/guard.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js review`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guards now properly respect the working directory specified in hook payloads, with fallback to the current process directory. Resolves incorrect behavior when running in repository worktrees or other multi-directory scenarios.

* **Tests**
  * Added regression test coverage for guard execution with alternate working directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->