### PR TITLE
[codex] Prepare v1.57.0 release

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -243,6 +243,14 @@
       ],
       "status": "complete",
       "note": "Fixed GitHub issue #447 so tool hooks prefer the payload cwd in Codex worktrees before falling back to the launcher cwd."
+    },
+    {
+      "name": "Phase 38 \u2014 Hook CWD Minor Release",
+      "sprints": [
+        123
+      ],
+      "status": "planned",
+      "note": "Publish the S122 hook cwd guard correctness work as v1.57.0 using the trusted-publisher release flow."
     }
   ],
   "sprints": [
@@ -2549,6 +2557,35 @@
           "complexity": "small",
           "depends_on": [
             "S122-1"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 123,
+      "theme": "Hook CWD Minor Release",
+      "par": 3,
+      "slope": 1,
+      "type": "release",
+      "status": "planned",
+      "depends_on": [
+        122
+      ],
+      "note": "Release the S122 Codex worktree hook cwd guard fix as v1.57.0 and verify trusted publishing to npm.",
+      "tickets": [
+        {
+          "key": "S123-1",
+          "title": "Bump @slope-dev/slope and bundled Codex plugin to v1.57.0",
+          "club": "wedge",
+          "complexity": "small"
+        },
+        {
+          "key": "S123-2",
+          "title": "Run release validation, publish v1.57.0, and verify npm",
+          "club": "short_iron",
+          "complexity": "standard",
+          "depends_on": [
+            "S123-1"
           ]
         }
       ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.56.2",
+  "version": "1.57.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.56.2",
+  "version": "1.57.0",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
## Summary

Prepare the `v1.57.0` minor release for `@slope-dev/slope`.

- Add S123 / Phase 38 release planning to the machine-readable roadmap.
- Bump `@slope-dev/slope` from `1.56.2` to `1.57.0`.
- Bump the bundled Codex plugin manifest from `1.56.2` to `1.57.0`.

This release ships the S122 hook cwd guard correctness work so Codex worktree hook invocations honor the hook payload cwd before falling back to the launcher cwd.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test` (`214` test files passed, `3481` tests passed, Postgres suite skipped)
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js version`
- `git diff --check`
- `npm pack --dry-run`