### PR TITLE
[codex] Add pre-sprint reality checks

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -2606,7 +2606,9 @@
       "par": 4,
       "slope": 3,
       "type": "enhancement",
-      "status": "planned",
+      "status": "complete",
+      "score": 4,
+      "score_label": "par",
       "depends_on": [
         123
       ],

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -251,6 +251,14 @@
       ],
       "status": "complete",
       "note": "Published the S122 hook cwd guard correctness work as v1.57.0 using the trusted-publisher release flow."
+    },
+    {
+      "name": "Phase 39 \u2014 Pre-Sprint Reality Checks",
+      "sprints": [
+        124
+      ],
+      "status": "planned",
+      "note": "Close #452 and #453 by surfacing roadmap drift and sibling worktree conflict signals before agents commit to a sprint."
     }
   ],
   "sprints": [
@@ -2588,6 +2596,47 @@
           "complexity": "standard",
           "depends_on": [
             "S123-1"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 124,
+      "theme": "Pre-Sprint Reality Checks",
+      "par": 4,
+      "slope": 3,
+      "type": "enhancement",
+      "status": "planned",
+      "depends_on": [
+        123
+      ],
+      "note": "Surface stale roadmap status and sibling worktree conflicts in pre-sprint flows before an agent starts overlapping or already-shipped work.",
+      "tickets": [
+        {
+          "key": "S124-1",
+          "title": "Route roadmap validation drift warnings into briefing, roadmap show, and sprint start (#453)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 453
+        },
+        {
+          "key": "S124-2",
+          "title": "Surface sibling worktree dirty/ahead/migration state before sprint selection (#452)",
+          "club": "long_iron",
+          "complexity": "moderate",
+          "github_issue": 452,
+          "depends_on": [
+            "S124-1"
+          ]
+        },
+        {
+          "key": "S124-3",
+          "title": "Add regression coverage for pre-sprint reality checks",
+          "club": "wedge",
+          "complexity": "small",
+          "depends_on": [
+            "S124-1",
+            "S124-2"
           ]
         }
       ]

--- a/docs/retros/sprint-124-review.md
+++ b/docs/retros/sprint-124-review.md
@@ -1,0 +1,66 @@
+## Sprint 124 Review: Pre-Sprint Reality Checks
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 3 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (3/3) |
+| GIR % | 100% (3/3) |
+| Putts | 0 |
+| Penalties | 0 |
+| Hazard Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 3)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S124-1 | Short Iron | In the Hole | - | Routed existing roadmap drift validation into briefing, roadmap show, and sprint start. Sprint start now blocks already-scorecarded or shipped sprint selections unless forced. |
+| S124-2 | Long Iron | Green | rough: stale feat/workflow-engine sibling worktree overlaps src/cli | Added sibling worktree reality collection, touched-path overlap checks, migration detection, worktree status/list, and best-effort sprint auto-claiming. |
+| S124-3 | Wedge | Green | rough: regression caught porcelain trimming bug | Added CLI regressions for roadmap show, briefing, sprint start, and worktree status. The parser now preserves Git porcelain leading columns. |
+
+### Hazards Discovered
+
+The new worktree surface immediately found an existing `feat/workflow-engine` sibling worktree with overlapping `src/cli` files. That was useful confirmation of #452 rather than a blocker for this branch, but it should be cleaned up separately if the branch is stale.
+
+The first worktree regression also caught a real parser bug: trimming the whole Git status output removed the leading porcelain status column, which corrupted paths. The fix trims trailing whitespace only and then slices the fixed-width status fields.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Git porcelain status output must preserve leading columns until after status parsing. | The shared git helper now uses trailing trim only, and the status parser keeps fixed-width columns intact. |
+| Lessons | Pre-sprint checks are most useful when wired into passive and active surfaces. | Roadmap drift appears in briefing/show, while sprint start blocks already-complete/scorecarded sprint selections. |
+| Lessons | Sibling worktree conflict reporting should be actionable without being noisy. | Ignored state/build paths are filtered, long lists are summarized, and hard blocking requires explicit `--touches` overlap. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Typecheck, focused Vitest coverage, build, full Vitest suite, roadmap validation, and whitespace checks passed. |
+| workflow | healthy | `slope worktree status` exposes the sibling-worktree hazard class requested in #452. |
+| concurrency | watch | The stale `feat/workflow-engine` sibling worktree still exists with overlapping `src/cli` changes. |
+
+### Course Management Notes
+
+- Created `src/cli/pre-sprint-reality.ts` for shared roadmap and sibling-worktree reality checks.
+- Updated briefing, roadmap show, sprint start, worktree status/list, CLI help, and command registry discovery.
+- Added regression tests for roadmap show drift output, briefing drift output, sprint start blocking an already-scorecarded sprint, and worktree status overlap/migration output.
+- `pnpm typecheck` passed.
+- Focused Vitest run passed: 4 files, 55 tests.
+- `pnpm build` passed.
+- `pnpm test` passed: 215 passed test files, 1 skipped test file, 3485 passed tests, and 23 skipped tests.
+- `node dist/cli/index.js roadmap validate` passed with standing warnings plus the expected branch-local S124 complete-but-not-yet-shipped warning.
+- `node dist/cli/index.js worktree status --touches=src/cli,docs/backlog` surfaced the `feat/workflow-engine` overlap.
+- `node dist/cli/index.js map` refreshed ignored `CODEBASE.md` locally.
+- `git diff --check` passed before the feature commit.
+
+### 19th Hole
+
+- **How did it feel?** Useful in exactly the way this sprint wanted: the tooling now tells the player about stale reality before they step onto the wrong tee.
+- **Advice for next player?** Use `--touches` on sprint start when you know the planned files; that is the difference between a heads-up and a hard overlap block.
+- **What surprised you?** The regression test found a real porcelain parsing bug immediately, which made the new worktree surface sharper before it shipped.
+- **Excited about next?** The next sprint can trust briefing and sprint start to catch more of the drift that previously only appeared after a PR or release.

--- a/docs/retros/sprint-124.json
+++ b/docs/retros/sprint-124.json
@@ -1,0 +1,150 @@
+{
+  "sprint_number": 124,
+  "player": "codex",
+  "theme": "Pre-Sprint Reality Checks",
+  "par": 4,
+  "slope": 3,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-24",
+  "shots": [
+    {
+      "ticket_key": "S124-1",
+      "title": "Route roadmap validation drift warnings into briefing, roadmap show, and sprint start (#453)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added shared roadmap reality helpers and routed existing scorecard/shipped/phantom drift warnings into slope briefing, slope roadmap show, and slope sprint start. Sprint start now blocks already-scorecarded or already-shipped sprints unless --force is used."
+    },
+    {
+      "ticket_key": "S124-2",
+      "title": "Surface sibling worktree dirty/ahead/migration state before sprint selection (#452)",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The new worktree status command surfaced an existing stale sibling worktree on feat/workflow-engine with overlapping src/cli files; it validated the feature and did not require changing that worktree."
+        }
+      ],
+      "notes": "Added sibling worktree reality collection with ahead/behind counts, dirty files, ahead files, migration detection, touched-path overlap detection, slope worktree status/list, and pre-sprint overlap blocking when --touches is supplied. Sprint start also auto-claims the sprint area for the current player when the store is available."
+    },
+    {
+      "ticket_key": "S124-3",
+      "title": "Add regression coverage for pre-sprint reality checks",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The new worktree status regression caught that Git porcelain output was being trimmed before fixed-column parsing, turning src/api.ts into rc/api.ts; the parser now preserves leading status columns."
+        }
+      ],
+      "notes": "Added CLI regressions for roadmap show drift output, briefing drift output, sprint start blocking an already-scorecarded sprint, and worktree status overlap/migration output. Full pnpm test passed after the parser fix."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 3,
+    "fairways_total": 3,
+    "greens_in_regulation": 3,
+    "greens_total": 3,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 2,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "enhancement",
+  "conditions": [
+    "Implemented with a known sibling worktree overlap surfaced by the new command after the branch was already in flight."
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Git porcelain status output must preserve leading columns until after status parsing.",
+      "outcome": "S124 changed the shared git helper to trim only trailing whitespace and parse status paths from the fixed-width porcelain columns."
+    },
+    {
+      "type": "lessons",
+      "description": "Pre-sprint checks are most useful when wired into both passive briefing surfaces and active start gates.",
+      "outcome": "Roadmap drift is visible in briefing and roadmap show, while sprint start blocks already-complete/scorecarded sprint selections."
+    },
+    {
+      "type": "lessons",
+      "description": "Sibling worktree conflict reporting should be actionable without being noisy.",
+      "outcome": "The worktree surface excludes ignored state/build paths, summarizes long file lists, and only blocks when explicit --touches overlap is detected."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "pnpm typecheck, focused Vitest coverage, pnpm build, full pnpm test, roadmap validation, and whitespace checks passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "workflow",
+      "description": "slope worktree status now exposes the same sibling-worktree hazard class requested in #452.",
+      "status": "healthy"
+    },
+    {
+      "category": "concurrency",
+      "description": "A stale feat/workflow-engine sibling worktree still exists with overlapping src/cli changes and should be cleaned up separately if no longer needed.",
+      "status": "watch"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Useful in exactly the way this sprint wanted: the tooling now tells the player about stale reality before they step onto the wrong tee.",
+    "advice_for_next_player": "Use --touches on sprint start when you know the planned files; that is the difference between a heads-up and a hard overlap block.",
+    "what_surprised_you": "The regression test found a real porcelain parsing bug immediately, which made the new worktree surface sharper before it shipped.",
+    "excited_about_next": "The next sprint can trust briefing and sprint start to catch more of the drift that previously only appeared after a PR or release."
+  },
+  "bunker_locations": [
+    "Preserve Git porcelain leading columns until after path extraction.",
+    "A stale sibling worktree on feat/workflow-engine currently overlaps src/cli files.",
+    "Generated CODEBASE.md is ignored, so map refreshes are local verification rather than commit artifacts."
+  ],
+  "yardage_book_updates": [
+    "slope roadmap show now appends ROADMAP REALITY CHECKS for scorecard/shipped/phantom drift.",
+    "slope briefing now appends ROADMAP REALITY CHECKS and WORKTREE CONFLICT SURFACE sections when applicable.",
+    "slope sprint start blocks already-scorecarded or shipped sprint selections unless --force is supplied.",
+    "slope sprint start accepts --touches=path,to,dir to block direct overlap with dirty/ahead sibling worktree files.",
+    "slope sprint start best-effort auto-claims sprint:S<N> as an area claim when the SLOPE store is available.",
+    "slope worktree status and slope worktree list show sibling worktree ahead/behind, dirty files, ahead files, migrations, and touched-path overlap."
+  ],
+  "course_management_notes": [
+    "Created src/cli/pre-sprint-reality.ts for shared roadmap and sibling-worktree reality checks.",
+    "Updated briefing, roadmap show, sprint start, worktree status/list, CLI help, and command registry discovery.",
+    "Added regression tests in tests/cli/roadmap.test.ts, tests/cli/sprint-workflow.test.ts, tests/cli/commands/worktree.test.ts, and tests/cli/commands/briefing-reality.test.ts.",
+    "pnpm typecheck passed.",
+    "Focused Vitest run passed: 4 files, 55 tests.",
+    "pnpm build passed.",
+    "pnpm test passed: 215 passed test files, 1 skipped test file, 3485 passed tests, and 23 skipped tests.",
+    "node dist/cli/index.js roadmap validate passed with standing warnings plus the expected branch-local S124 complete-but-not-yet-shipped warning.",
+    "node dist/cli/index.js worktree status --touches=src/cli,docs/backlog surfaced feat/workflow-engine overlap, confirming the new status path.",
+    "node dist/cli/index.js map refreshed CODEBASE.md locally; CODEBASE.md remains gitignored.",
+    "git diff --check passed before the feature commit."
+  ],
+  "skills_used": [
+    "slope-sprint-workflow",
+    "slope-api-reference"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "slope-performance-analysis"
+  ],
+  "skill_gaps_found": [],
+  "slope_factors": [
+    "roadmap_drift_gate",
+    "sibling_worktree_conflict_surface",
+    "git_porcelain_parsing",
+    "full_cli_regression_suite"
+  ]
+}

--- a/src/cli/commands/briefing.ts
+++ b/src/cli/commands/briefing.ts
@@ -7,6 +7,7 @@ import { loadScorecards } from '../loader.js';
 import { inferSprintContext } from '../sprint-inference.js';
 import { resolveStore } from '../store.js';
 import { resolveMetaphor } from '../metaphor.js';
+import { buildRoadmapReality, collectSiblingWorktreeReality, formatRoadmapRealitySection, formatWorktreeRealitySection } from '../pre-sprint-reality.js';
 
 export async function briefingCommand(args: string[]): Promise<void> {
   const config = loadConfig();
@@ -171,6 +172,22 @@ export async function briefingCommand(args: string[]): Promise<void> {
   const output = formatBriefing({ scorecards: effectiveScorecards, commonIssues: visibleIssues, lastSession, filter, includeTraining, claims, roadmap, currentSprint: sprintNumber, metaphor, role, recentEvents, skillRegistry });
   console.log('');
   console.log(output);
+
+  if (roadmap) {
+    const roadmapRealityLines = formatRoadmapRealitySection(buildRoadmapReality(cwd, roadmap));
+    if (roadmapRealityLines.length > 0) {
+      console.log('\u2500'.repeat(50));
+      for (const line of roadmapRealityLines) console.log(line);
+      console.log('');
+    }
+  }
+
+  const worktreeRealityLines = formatWorktreeRealitySection(collectSiblingWorktreeReality(cwd));
+  if (worktreeRealityLines.length > 0) {
+    console.log('\u2500'.repeat(50));
+    for (const line of worktreeRealityLines) console.log(line);
+    console.log('');
+  }
 
   // Deferred findings section (appended after main briefing)
   const deferred = loadDeferred(cwd);

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -20,6 +20,7 @@ import {
 } from '../../core/index.js';
 import type { RoadmapDefinition, RoadmapSprint, RoadmapTicket, RoadmapClub, GolfScorecard } from '../../core/index.js';
 import { loadConfig } from '../config.js';
+import { buildRoadmapReality, formatRoadmapRealitySection } from '../pre-sprint-reality.js';
 
 // --- Helpers ---
 
@@ -344,6 +345,12 @@ function showSubcommand(flags: Record<string, string>, cwd: string): void {
 
   console.log('');
   console.log(formatRoadmapSummary(roadmap));
+
+  const realityLines = formatRoadmapRealitySection(buildRoadmapReality(cwd, roadmap));
+  if (realityLines.length > 0) {
+    console.log(realityLines.join('\n'));
+    console.log('');
+  }
 }
 
 const CLUB_TO_COMPLEXITY: Record<string, RoadmapTicket['complexity']> = {

--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -13,7 +13,7 @@ import {
   type GateName,
   type SprintPhase,
 } from '../sprint-state.js';
-import { WorkflowEngine, loadWorkflow, resolveVariables, validateWorkflow, loadConfig, loadScorecards, parseRoadmap, castRoadmapStructure, formatSprintNumber, parseSprintNumber } from '../../core/index.js';
+import { WorkflowEngine, loadWorkflow, resolveVariables, validateWorkflow, loadConfig, loadScorecards, parseRoadmap, castRoadmapStructure, formatSprintLabel, formatSprintNumber, parseSprintNumber } from '../../core/index.js';
 import type { RoadmapSprint, WorkflowDefinition, WorkflowExecution } from '../../core/index.js';
 import { createHash } from 'node:crypto';
 
@@ -37,6 +37,14 @@ function getDefinition(exec: WorkflowExecution, cwd: string): { def: WorkflowDef
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { createStore } from '../../store/index.js';
+import {
+  blockingRoadmapIssuesForSprint,
+  collectSiblingWorktreeReality,
+  findWorktreeOverlaps,
+  formatWorktreeRealitySection,
+  loadRoadmapReality,
+  parseTouchedPaths,
+} from '../pre-sprint-reality.js';
 
 /**
  * Check completion_conditions for a step before allowing completion/skip.
@@ -208,7 +216,7 @@ async function beginCommand(args: string[], cwd: string): Promise<void> {
   console.log('');
 }
 
-function startCommand(args: string[], cwd: string): void {
+async function startCommand(args: string[], cwd: string): Promise<void> {
   const numberArg = args.find(a => a.startsWith('--number='));
   if (!numberArg) {
     console.error('Error: --number=N is required. Usage: slope sprint start --number=22');
@@ -228,6 +236,9 @@ function startCommand(args: string[], cwd: string): void {
     process.exit(1);
   }
   const phase = phaseInput as SprintPhase;
+  const force = args.includes('--force');
+  const touchesArg = args.find(a => a.startsWith('--touches='));
+  const touchedPaths = parseTouchedPaths(touchesArg?.slice('--touches='.length));
 
   const existing = loadSprintState(cwd);
   if (existing && existing.sprint === sprint) {
@@ -240,9 +251,65 @@ function startCommand(args: string[], cwd: string): void {
     return;
   }
 
+  const roadmapReality = loadRoadmapReality(cwd);
+  const blockingRoadmapIssues = blockingRoadmapIssuesForSprint(roadmapReality, sprint);
+  if (blockingRoadmapIssues.length > 0 && !force) {
+    console.error(`\nPre-sprint reality check failed for ${formatSprintLabel(sprint)}:`);
+    for (const issue of blockingRoadmapIssues) {
+      console.error(`  [${issue.type}] ${issue.message}`);
+    }
+    console.error('\nThis sprint appears to have already shipped or already has a scorecard. Reconcile the roadmap, or rerun with --force if this is intentional.');
+    process.exit(1);
+  }
+
+  const worktrees = collectSiblingWorktreeReality(cwd);
+  const worktreeLines = formatWorktreeRealitySection(worktrees, touchedPaths);
+  if (worktreeLines.length > 0) {
+    console.log('');
+    console.log(worktreeLines.join('\n'));
+    console.log('');
+  }
+
+  const overlaps = findWorktreeOverlaps(worktrees, touchedPaths);
+  if (overlaps.length > 0 && !force) {
+    console.error('Pre-sprint reality check failed: sibling worktree overlap detected.');
+    console.error('Resolve the overlap, choose a non-overlapping sprint, or rerun with --force if this is intentional.');
+    process.exit(1);
+  }
+
   const state = createSprintState(sprint, phase);
   saveSprintState(cwd, state);
+  const autoClaim = await autoClaimSprint(cwd, sprint);
   console.log(`Sprint ${formatSprintNumber(sprint)} started (phase: ${phase}). Use 'slope sprint gate <name>' to mark gates.`);
+  if (autoClaim) console.log(autoClaim);
+}
+
+async function autoClaimSprint(cwd: string, sprint: number): Promise<string | null> {
+  const { resolveStore } = await import('../store.js');
+  const player = process.env.USER || 'unknown';
+  const target = `sprint:${formatSprintLabel(sprint)}`;
+
+  try {
+    const store = await resolveStore(cwd);
+    try {
+      const existing = await store.list(sprint);
+      if (existing.some(c => c.player === player && c.target === target)) {
+        return `Claim: ${target} already held by ${player}.`;
+      }
+      const claim = await store.claim({
+        sprint_number: sprint,
+        player,
+        target,
+        scope: 'area',
+        notes: 'auto-claimed by slope sprint start',
+      });
+      return `Claim: ${claim.target} (${claim.scope}) auto-claimed for ${player}.`;
+    } finally {
+      store.close();
+    }
+  } catch {
+    return null;
+  }
 }
 
 function phaseCommand(args: string[], cwd: string): void {
@@ -893,7 +960,7 @@ export async function sprintCommand(args: string[]): Promise<void> {
 
   switch (sub) {
     case 'start':
-      startCommand(args.slice(1), cwd);
+      await startCommand(args.slice(1), cwd);
       break;
     case 'begin':
       await beginCommand(args.slice(1), cwd);
@@ -941,7 +1008,8 @@ export async function sprintCommand(args: string[]): Promise<void> {
 slope sprint — Sprint lifecycle management
 
 Legacy commands:
-  slope sprint start --number=N      Start sprint state tracking
+  slope sprint start --number=N [--phase=<phase>] [--touches=<paths>] [--force]
+                                      Start sprint state tracking with pre-sprint reality checks
   slope sprint begin --sprint=N --ticket=T  Bundled start + claim + briefing + prep (#311)
   slope sprint plan --sprint=N [--output=path]  Generate markdown sprint plan (#312)
   slope sprint phase <phase>       Update current sprint phase

--- a/src/cli/commands/worktree.ts
+++ b/src/cli/commands/worktree.ts
@@ -1,6 +1,7 @@
 // slope worktree — Manage persistent git worktrees
 // Usage:
 //   slope worktree start --branch=<name> [--base=<ref>] [--path=<path>] [--role=secondary] [--ide=<id>] [--target=<claim>]
+//   slope worktree status [--base=<ref>] [--touches=<paths>]
 //   slope worktree cleanup [--path=<path>] [--all] [--dry-run]
 
 import { execFileSync, execSync } from 'node:child_process';
@@ -13,6 +14,7 @@ import type { ClaimScope, SprintClaim } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { inferSprintContext } from '../sprint-inference.js';
 import { resolveStore } from '../store.js';
+import { collectSiblingWorktreeReality, formatWorktreeRealitySection, parseTouchedPaths } from '../pre-sprint-reality.js';
 
 interface WorktreeInfo {
   path: string;
@@ -402,6 +404,21 @@ async function cleanupCommand(args: string[]): Promise<void> {
   }
 }
 
+function statusCommand(args: string[]): void {
+  const { flags } = parseFlagArgs(args);
+  const cwd = process.cwd();
+  const touchedPaths = parseTouchedPaths(flags.touches);
+  const worktrees = collectSiblingWorktreeReality(cwd, flags.base);
+  const lines = formatWorktreeRealitySection(worktrees, touchedPaths);
+
+  if (lines.length === 0) {
+    console.log('No sibling worktrees found.');
+    return;
+  }
+
+  console.log(lines.join('\n'));
+}
+
 export async function worktreeCommand(args: string[]): Promise<void> {
   const sub = args[0];
 
@@ -413,12 +430,18 @@ export async function worktreeCommand(args: string[]): Promise<void> {
     return cleanupCommand(args.slice(1));
   }
 
+  if (sub === 'status' || sub === 'list') {
+    statusCommand(args.slice(1));
+    return;
+  }
+
   if (args.includes('--help') || args.includes('-h') || !sub) {
     console.log(`
 slope worktree — Manage git worktrees
 
 Usage:
   slope worktree start --branch=<name> [--base=<ref>] [--path=<path>] [--role=secondary] [--ide=<id>] [--target=<claim>]
+  slope worktree status [--base=<ref>] [--touches=<paths>]
   slope worktree cleanup [--path=<path>] [--all] [--dry-run]
 
 Options:
@@ -437,6 +460,10 @@ Options:
   --path=<path>  Target a specific worktree
   --all          Clean up all secondary worktrees
   --dry-run      Preview what would happen without making changes
+
+  status:
+    --base=<ref>       Base ref for ahead/behind and changed-file detection (default: origin/main, main, master, HEAD)
+    --touches=<paths>  Comma-separated paths to check for direct overlap
 
 For each worktree, cleanup will:
   1. Check if the branch's PR is merged (requires gh CLI)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -529,7 +529,7 @@ Usage:
   slope stats export [--pretty]                      Export stats JSON for slope-web
   slope docs generate|changelog|check                Documentation manifest and changelog
   slope sprint start|gate|status|reset               Manage sprint lifecycle state
-  slope worktree start|cleanup [options]             Manage persistent worktrees
+  slope worktree start|status|cleanup [options]      Manage persistent worktrees
   slope loop status|config|run|continuous|...        Autonomous sprint execution loop
   slope doctor [--fix] [--dry-run]                   Check repo health and fix issues
   slope version                                      Show current version

--- a/src/cli/pre-sprint-reality.ts
+++ b/src/cli/pre-sprint-reality.ts
@@ -1,0 +1,315 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import {
+  castRoadmapStructure,
+  findShippedSprintsOnMain,
+  formatSprintLabel,
+  loadScorecards,
+  parseRoadmap,
+  validateRoadmap,
+} from '../core/index.js';
+import type {
+  RoadmapDefinition,
+  RoadmapValidationError,
+  RoadmapValidationResult,
+  RoadmapValidationWarning,
+} from '../core/index.js';
+import { loadConfig } from './config.js';
+
+export interface RoadmapReality {
+  roadmap?: RoadmapDefinition;
+  validation?: RoadmapValidationResult;
+}
+
+export interface WorktreeReality {
+  path: string;
+  branch: string;
+  head: string;
+  ahead: number;
+  behind: number;
+  dirtyFiles: string[];
+  changedFiles: string[];
+  migrationFiles: string[];
+}
+
+export interface WorktreeOverlap {
+  path: string;
+  branch: string;
+  files: string[];
+}
+
+type RoadmapIssue = RoadmapValidationError | RoadmapValidationWarning;
+
+interface WorktreeInfo {
+  path: string;
+  branch: string;
+  head: string;
+}
+
+export function buildRoadmapReality(cwd: string, roadmap: RoadmapDefinition): RoadmapReality {
+  const config = loadConfig(cwd);
+  const scorecards = loadScorecards(config, cwd).map(s => ({ sprint_number: s.sprint_number }));
+  const shippedSprintIds = findShippedSprintsOnMain(cwd);
+  return {
+    roadmap,
+    validation: validateRoadmap(roadmap, scorecards, shippedSprintIds),
+  };
+}
+
+export function loadRoadmapReality(cwd: string): RoadmapReality {
+  const config = loadConfig(cwd);
+  const path = join(cwd, config.roadmapPath);
+  if (!existsSync(path)) return {};
+
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf8'));
+    const parsed = parseRoadmap(raw);
+    const roadmap = parsed.roadmap ?? castRoadmapStructure(raw) ?? undefined;
+    return roadmap ? buildRoadmapReality(cwd, roadmap) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function roadmapRealityIssues(reality: RoadmapReality, sprint?: number): RoadmapIssue[] {
+  const validation = reality.validation;
+  if (!validation) return [];
+
+  return [...validation.errors, ...validation.warnings]
+    .filter(isRealityIssue)
+    .filter(issue => sprint == null || issue.sprint === sprint);
+}
+
+export function blockingRoadmapIssuesForSprint(reality: RoadmapReality, sprint: number): RoadmapIssue[] {
+  return roadmapRealityIssues(reality, sprint)
+    .filter(issue => /has shipped commits on main|has a scorecard/.test(issue.message));
+}
+
+export function formatRoadmapRealitySection(reality: RoadmapReality, sprint?: number, limit = 8): string[] {
+  const issues = roadmapRealityIssues(reality, sprint);
+  if (issues.length === 0) return [];
+
+  const shown = issues.slice(0, limit);
+  const lines = ['ROADMAP REALITY CHECKS'];
+  for (const issue of shown) {
+    const level = issue.type === 'error' ? 'error' : 'warn';
+    const loc = issue.sprint ? `[${formatSprintLabel(issue.sprint)}] ` : '';
+    lines.push(`  [${level}] ${loc}${issue.message}`);
+  }
+  if (issues.length > shown.length) {
+    lines.push(`  ... ${issues.length - shown.length} more roadmap reality issue(s)`);
+  }
+  return lines;
+}
+
+export function collectSiblingWorktreeReality(cwd: string, baseRef?: string): WorktreeReality[] {
+  const worktrees = listWorktrees(cwd);
+  if (worktrees.length <= 1) return [];
+
+  const currentPath = currentWorktreePath(cwd);
+  const base = baseRef ?? resolveBaseRef(cwd);
+  return worktrees
+    .filter(wt => resolve(wt.path) !== currentPath)
+    .map(wt => buildWorktreeReality(wt, base));
+}
+
+export function parseTouchedPaths(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map(p => normalizeRepoPath(p))
+    .filter(Boolean);
+}
+
+export function findWorktreeOverlaps(worktrees: WorktreeReality[], touchedPaths: string[]): WorktreeOverlap[] {
+  if (touchedPaths.length === 0) return [];
+
+  const overlaps: WorktreeOverlap[] = [];
+  for (const wt of worktrees) {
+    const candidateFiles = unique([...wt.dirtyFiles, ...wt.changedFiles, ...wt.migrationFiles]);
+    const files = candidateFiles.filter(file =>
+      touchedPaths.some(touched => pathsOverlap(file, touched)),
+    );
+    if (files.length > 0) {
+      overlaps.push({ path: wt.path, branch: wt.branch, files });
+    }
+  }
+  return overlaps;
+}
+
+export function formatWorktreeRealitySection(worktrees: WorktreeReality[], touchedPaths: string[] = []): string[] {
+  if (worktrees.length === 0) return [];
+
+  const lines = ['WORKTREE CONFLICT SURFACE'];
+  for (const wt of worktrees) {
+    const branch = wt.branch || '(detached)';
+    lines.push(`  ${branch} at ${wt.path} (ahead ${wt.ahead}, behind ${wt.behind})`);
+    if (wt.dirtyFiles.length > 0) {
+      lines.push(`    dirty: ${formatFileList(wt.dirtyFiles)}`);
+    }
+    if (wt.changedFiles.length > 0) {
+      lines.push(`    ahead files: ${formatFileList(wt.changedFiles)}`);
+    }
+    if (wt.migrationFiles.length > 0) {
+      lines.push(`    migrations: ${formatFileList(wt.migrationFiles)}`);
+    }
+    if (wt.dirtyFiles.length === 0 && wt.changedFiles.length === 0) {
+      lines.push('    no dirty or ahead files detected');
+    }
+  }
+
+  const overlaps = findWorktreeOverlaps(worktrees, touchedPaths);
+  if (overlaps.length > 0) {
+    lines.push('');
+    lines.push('  Potential overlap with requested touched paths:');
+    for (const overlap of overlaps) {
+      lines.push(`    [!!] ${overlap.branch || '(detached)'}: ${formatFileList(overlap.files, 8)}`);
+    }
+  } else if (touchedPaths.length === 0) {
+    lines.push('');
+    lines.push('  Tip: pass --touches=path/to/file,path/to/dir to block on direct overlap during sprint start.');
+  }
+
+  return lines;
+}
+
+function isRealityIssue(issue: RoadmapIssue): boolean {
+  return /scorecard|shipped commits|phantom sprint/i.test(issue.message);
+}
+
+function listWorktrees(cwd: string): WorktreeInfo[] {
+  const output = git(cwd, ['worktree', 'list', '--porcelain']);
+  if (!output) return [];
+
+  const worktrees: WorktreeInfo[] = [];
+  let current: Partial<WorktreeInfo> = {};
+
+  for (const line of output.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      if (current.path) worktrees.push(normalizeWorktree(current));
+      current = { path: line.slice('worktree '.length) };
+    } else if (line.startsWith('HEAD ')) {
+      current.head = line.slice('HEAD '.length);
+    } else if (line.startsWith('branch ')) {
+      current.branch = line.slice('branch '.length).replace('refs/heads/', '');
+    } else if (line === '') {
+      if (current.path) worktrees.push(normalizeWorktree(current));
+      current = {};
+    }
+  }
+  if (current.path) worktrees.push(normalizeWorktree(current));
+  return worktrees;
+}
+
+function normalizeWorktree(wt: Partial<WorktreeInfo>): WorktreeInfo {
+  return {
+    path: wt.path ?? '',
+    branch: wt.branch ?? '',
+    head: wt.head ?? '',
+  };
+}
+
+function buildWorktreeReality(wt: WorktreeInfo, baseRef: string): WorktreeReality {
+  const statusFiles = parseStatus(git(wt.path, ['status', '--porcelain=v1', '--untracked-files=all']));
+  const changedFiles = splitLines(git(wt.path, ['diff', '--name-only', `${baseRef}...HEAD`]))
+    .map(normalizeRepoPath)
+    .filter(isRelevantPath);
+  const counts = parseAheadBehind(git(wt.path, ['rev-list', '--left-right', '--count', `${baseRef}...HEAD`]));
+  const migrationFiles = unique([...statusFiles, ...changedFiles].filter(isMigrationPath));
+
+  return {
+    path: wt.path,
+    branch: wt.branch,
+    head: wt.head,
+    ahead: counts.ahead,
+    behind: counts.behind,
+    dirtyFiles: statusFiles,
+    changedFiles,
+    migrationFiles,
+  };
+}
+
+function currentWorktreePath(cwd: string): string {
+  const top = git(cwd, ['rev-parse', '--show-toplevel']);
+  return resolve(top || cwd);
+}
+
+function resolveBaseRef(cwd: string): string {
+  for (const ref of ['origin/main', 'main', 'master', 'HEAD']) {
+    if (git(cwd, ['rev-parse', '--verify', ref])) return ref;
+  }
+  return 'HEAD';
+}
+
+function git(cwd: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10000,
+    }).trimEnd();
+  } catch {
+    return '';
+  }
+}
+
+function parseStatus(output: string): string[] {
+  return output.split('\n')
+    .map(line => line.trimEnd())
+    .filter(Boolean)
+    .map(line => normalizeStatusPath(line.slice(3)))
+    .map(normalizeRepoPath)
+    .filter(isRelevantPath);
+}
+
+function parseAheadBehind(output: string): { ahead: number; behind: number } {
+  const [left, right] = output.trim().split(/\s+/).map(v => parseInt(v, 10));
+  return {
+    behind: Number.isFinite(left) ? left : 0,
+    ahead: Number.isFinite(right) ? right : 0,
+  };
+}
+
+function normalizeStatusPath(path: string): string {
+  const renameArrow = ' -> ';
+  return path.includes(renameArrow) ? path.slice(path.indexOf(renameArrow) + renameArrow.length) : path;
+}
+
+function normalizeRepoPath(path: string): string {
+  return path.trim().replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+}
+
+function pathsOverlap(a: string, b: string): boolean {
+  if (a === b) return true;
+  return a.startsWith(`${b}/`) || b.startsWith(`${a}/`);
+}
+
+function isRelevantPath(path: string): boolean {
+  if (!path) return false;
+  return !/^(?:\.git|\.slope|\.codex|\.claude|node_modules|dist|coverage|\.DS_Store)(?:\/|$)/.test(path);
+}
+
+function isMigrationPath(path: string): boolean {
+  return /(^|\/)(?:migrations?|drizzle)(\/|$)/i.test(path) || /\b\d{3,}[_-].*\.sql$/i.test(path);
+}
+
+function splitLines(output: string): string[] {
+  return output.split('\n').map(line => line.trim()).filter(Boolean);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function formatFileList(files: string[], limit = 6): string {
+  const shown = files.slice(0, limit);
+  const suffix = files.length > shown.length ? ` (+${files.length - shown.length} more)` : '';
+  return shown.join(', ') + suffix;
+}
+
+export function relativeWorktreePath(cwd: string, path: string): string {
+  const rel = relative(cwd, path);
+  return rel && !rel.startsWith('..') ? rel : path;
+}

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -118,6 +118,8 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
       { name: 'start', desc: 'Start a new sprint', flags: [
         { flag: '--number=<N>', desc: 'Sprint number (required)' },
         { flag: '--phase=<phase>', desc: 'Initial phase (default: planning)' },
+        { flag: '--touches=<paths>', desc: 'Comma-separated paths to check against sibling worktrees' },
+        { flag: '--force', desc: 'Override pre-sprint reality-check blockers' },
       ]},
       { name: 'gate', desc: 'Mark a gate as complete', flags: [
         { flag: '<name>', desc: 'Gate name to complete' },
@@ -543,6 +545,10 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
   {
     cmd: 'worktree', desc: 'Manage git worktrees', category: 'tooling',
     subcommands: [
+      { name: 'status', desc: 'Show sibling worktree dirty/ahead/migration state', flags: [
+        { flag: '--base=<ref>', desc: 'Base ref for ahead/behind and changed-file detection' },
+        { flag: '--touches=<paths>', desc: 'Comma-separated paths to check for overlap' },
+      ]},
       { name: 'cleanup', desc: 'Clean up stale worktrees (remove, delete branch, delete remote)', flags: [
         { flag: '--path=<path>', desc: 'Target a specific worktree' },
         { flag: '--all', desc: 'Clean up all secondary worktrees' },

--- a/tests/cli/commands/briefing-reality.test.ts
+++ b/tests/cli/commands/briefing-reality.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { RoadmapDefinition } from '../../../src/core/index.js';
+import { briefingCommand } from '../../../src/cli/commands/briefing.js';
+
+let tmpDir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-briefing-reality-'));
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+    currentSprint: 7,
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+    commonIssuesPath: '.slope/common-issues.json',
+    roadmapPath: 'docs/backlog/roadmap.json',
+    minSprint: 1,
+  }, null, 2));
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function writeRoadmap(): void {
+  const roadmap: RoadmapDefinition = {
+    name: 'Briefing Reality Roadmap',
+    phases: [{ name: 'Phase 1', sprints: [7] }],
+    sprints: [{
+      id: 7,
+      theme: 'Already Landed',
+      par: 4,
+      slope: 2,
+      type: 'feature',
+      status: 'planned',
+      tickets: [
+        { key: 'S7-1', title: 'Ticket 1', club: 'short_iron', complexity: 'standard' },
+        { key: 'S7-2', title: 'Ticket 2', club: 'wedge', complexity: 'small' },
+        { key: 'S7-3', title: 'Ticket 3', club: 'putter', complexity: 'trivial' },
+      ],
+    }],
+  };
+  mkdirSync(join(tmpDir, 'docs', 'backlog'), { recursive: true });
+  writeFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), JSON.stringify(roadmap, null, 2));
+}
+
+function writeScorecard(): void {
+  mkdirSync(join(tmpDir, 'docs', 'retros'), { recursive: true });
+  writeFileSync(join(tmpDir, 'docs', 'retros', 'sprint-7.json'), JSON.stringify({
+    sprint_number: 7,
+    theme: 'Already Landed',
+    par: 4,
+    slope: 2,
+    score: 4,
+    score_label: 'par',
+    type: 'feature',
+    shots: [],
+    conditions: [],
+    special_plays: [],
+    stats: { fairways_hit: 0, fairways_total: 0, greens_in_regulation: 0, greens_total: 0, putts: 0, penalties: 0, hazards_hit: 0, hazard_penalties: 0, miss_directions: {} },
+    date: '2025-01-01',
+    yardage_book_updates: [],
+    bunker_locations: [],
+    course_management_notes: [],
+  }));
+}
+
+describe('slope briefing reality checks', () => {
+  it('includes roadmap drift warnings from existing scorecards', async () => {
+    writeRoadmap();
+    writeScorecard();
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    });
+
+    await briefingCommand(['--sprint=7']);
+
+    const output = logs.join('\n');
+    expect(output).toContain('ROADMAP REALITY CHECKS');
+    expect(output).toContain('S7 has a scorecard');
+    expect(output).toContain('expected "complete"');
+  });
+});

--- a/tests/cli/commands/worktree.test.ts
+++ b/tests/cli/commands/worktree.test.ts
@@ -93,6 +93,46 @@ describe('slope worktree cleanup', () => {
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('cleanup'));
   });
 
+  it('surfaces sibling worktree status and touched-path overlap', async () => {
+    const porcelainOutput = [
+      'worktree /repo',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo/.slope/worktrees/feature',
+      'HEAD def456',
+      'branch refs/heads/feat/parallel',
+      '',
+    ].join('\n');
+
+    mockExecFileSync.mockImplementation((cmd, args, options) => {
+      const argv = Array.isArray(args) ? args : [];
+      const cwd = typeof options === 'object' && options && 'cwd' in options ? String(options.cwd) : '';
+      const key = `${cmd} ${argv.join(' ')}`;
+
+      if (key === 'git worktree list --porcelain') return porcelainOutput as any;
+      if (key === 'git rev-parse --show-toplevel') return '/repo' as any;
+      if (cwd === '/repo/.slope/worktrees/feature' && key === 'git status --porcelain=v1 --untracked-files=all') {
+        return ' M src/api.ts\n?? drizzle/0017_new.sql\n' as any;
+      }
+      if (cwd === '/repo/.slope/worktrees/feature' && key === 'git diff --name-only origin/main...HEAD') {
+        return 'src/api.ts\n' as any;
+      }
+      if (cwd === '/repo/.slope/worktrees/feature' && key === 'git rev-list --left-right --count origin/main...HEAD') {
+        return '1\t2\n' as any;
+      }
+      return '' as any;
+    });
+
+    await worktreeCommand(['status', '--base=origin/main', '--touches=src']);
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('WORKTREE CONFLICT SURFACE'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('feat/parallel'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('dirty: src/api.ts'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('migrations: drizzle/0017_new.sql'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Potential overlap'));
+  });
+
   it('previews persistent worktree start with session and claim metadata', async () => {
     mockExecSync
       .mockReturnValueOnce('.git' as any) // git-common-dir

--- a/tests/cli/roadmap.test.ts
+++ b/tests/cli/roadmap.test.ts
@@ -344,6 +344,19 @@ describe('slope roadmap show', () => {
     const output = consoleOutput.join('\n');
     expect(output).toContain('| 3 | 9 | 11 |');
   });
+
+  it('surfaces roadmap reality drift from scorecards', () => {
+    writeRoadmap(tmpDir, makeRoadmapJson());
+    writeConfig(tmpDir, { scorecardDir: 'docs/retros', scorecardPattern: 'sprint-*.json', minSprint: 1 });
+    writeScorecard(tmpDir, 7);
+
+    roadmapCommand(['show']);
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('ROADMAP REALITY CHECKS');
+    expect(output).toContain('S7 has a scorecard');
+    expect(output).toContain('expected "complete"');
+  });
 });
 
 function writeScorecard(dir: string, sprint: number, overrides: Record<string, unknown> = {}): void {

--- a/tests/cli/sprint-workflow.test.ts
+++ b/tests/cli/sprint-workflow.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { sprintCommand } from '../../src/cli/commands/sprint.js';
 import { createStore } from '../../src/store/index.js';
+import type { RoadmapDefinition } from '../../src/core/index.js';
 import { WorkflowEngine, loadWorkflow, resolveVariables } from '../../src/core/index.js';
 
 class ProcessExitError extends Error {
@@ -70,6 +71,28 @@ function writeScorecard(sprint: number): void {
     yardage_book_updates: [],
     course_management_notes: [],
   }));
+}
+
+function writeRoadmap(sprint: number, status = 'planned'): void {
+  const roadmap: RoadmapDefinition = {
+    name: 'Sprint Workflow Test Roadmap',
+    phases: [{ name: 'Phase 1', sprints: [sprint] }],
+    sprints: [{
+      id: sprint,
+      theme: `Sprint ${sprint}`,
+      par: 4,
+      slope: 2,
+      type: 'feature',
+      status,
+      tickets: [
+        { key: `S${sprint}-1`, title: 'Ticket 1', club: 'short_iron', complexity: 'standard' },
+        { key: `S${sprint}-2`, title: 'Ticket 2', club: 'wedge', complexity: 'small' },
+        { key: `S${sprint}-3`, title: 'Ticket 3', club: 'putter', complexity: 'trivial' },
+      ],
+    }],
+  };
+  mkdirSync(join(tmpDir, 'docs', 'backlog'), { recursive: true });
+  writeFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), JSON.stringify(roadmap, null, 2));
 }
 
 describe('slope sprint run', () => {
@@ -336,6 +359,25 @@ describe('slope sprint skip', () => {
 });
 
 describe('slope sprint phase', () => {
+  it('blocks sprint start when roadmap reality says the sprint already has a scorecard', async () => {
+    writeRoadmap(98);
+    writeScorecard(98);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new ProcessExitError(code as number); });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let errors = '';
+    try {
+      await expect(sprintCommand(['start', '--number=98', '--phase=planning'])).rejects.toThrow(ProcessExitError);
+      errors = errSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    } finally {
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+
+    expect(errors).toContain('Pre-sprint reality check failed for S98');
+    expect(errors).toContain('S98 has a scorecard');
+  });
+
   it('starts decimal inserted sprint state without truncating', async () => {
     const output = await captureLog(() =>
       sprintCommand(['start', '--number=114.5', '--phase=planning'])


### PR DESCRIPTION
## Summary

Adds pre-sprint reality checks for roadmap drift and sibling worktree conflicts.

- Routes existing roadmap drift validation into `slope briefing`, `slope roadmap show`, and `slope sprint start`.
- Blocks sprint start when a sprint already has a scorecard or shipped commits unless `--force` is supplied.
- Adds sibling worktree status/overlap detection, `slope worktree status`/`list`, migration surfacing, and `--touches` overlap blocking.
- Adds best-effort sprint area auto-claiming on sprint start.
- Closes S124 with roadmap/scorecard/review artifacts.

Closes #452.
Closes #453.

## Validation

- `pnpm typecheck`
- `pnpm vitest run tests/cli/roadmap.test.ts tests/cli/sprint-workflow.test.ts tests/cli/commands/worktree.test.ts tests/cli/commands/briefing-reality.test.ts`
- `pnpm build`
- `pnpm test` (215 passed files, 3485 passed tests; 1 skipped file, 23 skipped tests)
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`
- `git diff --check`

## Notes

`node dist/cli/index.js worktree status --touches=src/cli,docs/backlog` now surfaces an existing stale `feat/workflow-engine` sibling worktree with overlapping `src/cli` files. I left that worktree untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pre-sprint reality checks that detect roadmap drift and sibling worktree conflicts before sprint start (bypass with `--force` flag).
  * Added `slope worktree status` command to view Git worktree states and identify path conflicts using `--touches` flag.
  * Enhanced briefing and roadmap commands to surface roadmap reality and worktree conflict information.

* **Documentation**
  * Added Sprint 124 roadmap phase and retrospective documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->