### PR TITLE
fix: nested scorecards and commit-tree guard detection

### DIFF
--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -82,6 +82,10 @@ function inSprintPhase(cwd: string): boolean {
   return phase === 'planning' || phase === 'implementing' || phase === 'scoring';
 }
 
+function isGitCommitCommand(command: string): boolean {
+  return /(?:^|[;&|]\s*)git\s+commit(?:\s|$)/.test(command);
+}
+
 function hasRecentPlan(ctx: { sessionManager: { getEntries: () => Array<{ role?: string; content?: string }> } }): boolean {
   const entries = ctx.sessionManager.getEntries();
   // Scan last 5 assistant messages for a structured plan.
@@ -493,7 +497,7 @@ export default function slopeExtension(pi: ExtensionAPI, _cwdOverride?: string):
     }
 
     // Commit discipline: warn on direct main/master commits
-    if (toolName === 'bash' && typeof inp.command === 'string' && /git\s+commit/.test(inp.command)) {
+    if (toolName === 'bash' && typeof inp.command === 'string' && isGitCommitCommand(inp.command)) {
       try {
         const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: ctx.cwd, encoding: 'utf8' }).trim();
         if (branch === 'main' || branch === 'master') {

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -1,6 +1,6 @@
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
-import { DEFAULT_SKILLS_PATH, compareSprintIds, loadSkillRegistry, parseSprintNumber, skillIds, validateScorecard } from '../../core/index.js';
+import { DEFAULT_SKILLS_PATH, discoverScorecardFiles, loadSkillRegistry, skillIds, validateScorecard } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { updateGate } from '../sprint-state.js';
 
@@ -28,31 +28,7 @@ export function validateCommand(input?: string | string[]): void {
   if (path) {
     files.push(isAbsolute(path) ? path : join(cwd, path));
   } else {
-    // Validate all scorecards matching config
-    const dir = join(cwd, config.scorecardDir);
-    const patternParts = config.scorecardPattern.split('*');
-    const prefix = patternParts[0] ?? '';
-    const suffix = patternParts[1] ?? '';
-    const regex = new RegExp(`^${prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+(?:\\.\\d+)?)${suffix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`);
-
-    try {
-      const dirFiles = readdirSync(dir)
-        .filter((f: string) => {
-          const m = f.match(regex);
-          const sprint = m ? parseSprintNumber(m[1]) : null;
-          return sprint != null && sprint >= config.minSprint;
-        })
-        .sort((a, b) => {
-          const na = parseSprintNumber(a.match(regex)?.[1] ?? '0') ?? 0;
-          const nb = parseSprintNumber(b.match(regex)?.[1] ?? '0') ?? 0;
-          return compareSprintIds(na, nb);
-        });
-      for (const f of dirFiles) {
-        files.push(join(dir, f));
-      }
-    } catch {
-      // Directory doesn't exist
-    }
+    files.push(...discoverScorecardFiles(config, cwd));
   }
 
   if (files.length === 0) {

--- a/src/cli/guards/push-nudge.ts
+++ b/src/cli/guards/push-nudge.ts
@@ -3,6 +3,10 @@ import type { HookInput, GuardResult } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { headIsOnMain } from './git-utils.js';
 
+function isGitCommitCommand(command: string): boolean {
+  return /(?:^|[;&|]\s*)git\s+commit(?:\s|$)/.test(command);
+}
+
 /**
  * Push nudge guard: fires PostToolUse on Bash.
  * Nudges to push after git commit commands when unpushed count or time is high.
@@ -11,7 +15,7 @@ export async function pushNudgeGuard(input: HookInput, cwd: string): Promise<Gua
   const command = (input.tool_input?.command as string) ?? '';
 
   // Only fire after git commit commands
-  if (!command.includes('git commit')) return {};
+  if (!isGitCommitCommand(command)) return {};
 
   const config = loadConfig(cwd);
   const guidance = config.guidance ?? {};

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -207,7 +207,7 @@ export { parseTestPlan, getTestPlanSummary, getAreasNeedingTest } from './test-p
 export type { TestPlanArea, TestPlanSection, TestPlanSummary, ParsedTestPlan } from './test-plan.js';
 
 // Loader
-export { loadScorecards, detectLatestSprint, resolveCurrentSprint, normalizeScorecard } from './loader.js';
+export { loadScorecards, detectLatestSprint, resolveCurrentSprint, normalizeScorecard, discoverScorecardFiles } from './loader.js';
 
 // Metaphor
 export {

--- a/src/core/loader.ts
+++ b/src/core/loader.ts
@@ -3,13 +3,47 @@ import { join } from 'node:path';
 import type { GolfScorecard } from './types.js';
 import type { SlopeConfig } from './config.js';
 import { normalizeStats } from './builder.js';
+import { computePar, computeScoreLabel } from './handicap.js';
 import { compareSprintIds, nextCanonicalSprintId } from './roadmap.js';
+
+type ScorecardCandidate = {
+  path: string;
+  sprintNumber: number;
+  priority: number;
+  label: string;
+};
 
 /**
  * Load SLOPE scorecards from the configured directory.
  * Filters by minSprint and normalizes sprint_number.
  */
 export function loadScorecards(config: SlopeConfig, cwd: string = process.cwd()): GolfScorecard[] {
+  const candidates = discoverScorecardCandidatesForConfig(config, cwd);
+  const scorecards: GolfScorecard[] = [];
+  const loadedSprints = new Set<number>();
+
+  for (const candidate of candidates) {
+    if (loadedSprints.has(candidate.sprintNumber)) continue;
+
+    try {
+      const raw = JSON.parse(readFileSync(candidate.path, 'utf8'));
+      const card = normalizeScorecard(raw);
+      if (card.sprint_number < config.minSprint || loadedSprints.has(card.sprint_number)) continue;
+      scorecards.push(card);
+      loadedSprints.add(card.sprint_number);
+    } catch {
+      console.error(`  Warning: Could not parse ${candidate.label}, skipping`);
+    }
+  }
+
+  return scorecards;
+}
+
+export function discoverScorecardFiles(config: SlopeConfig, cwd: string = process.cwd()): string[] {
+  return discoverScorecardCandidatesForConfig(config, cwd).map((candidate) => candidate.path);
+}
+
+function discoverScorecardCandidatesForConfig(config: SlopeConfig, cwd: string): ScorecardCandidate[] {
   const dir = join(cwd, config.scorecardDir);
   if (!existsSync(dir)) {
     return [];
@@ -21,32 +55,23 @@ export function loadScorecards(config: SlopeConfig, cwd: string = process.cwd())
   const suffix = patternParts[1] ?? '';
   const regex = new RegExp(`^${escapeRegex(prefix)}(\\d+(?:\\.\\d+)?)${escapeRegex(suffix)}$`);
 
-  const files = readdirSync(dir)
-    .filter((f: string) => regex.test(f))
+  const candidates = discoverScorecardCandidates(dir, regex)
+    .filter((candidate) => candidate.sprintNumber >= config.minSprint)
     .sort((a, b) => {
-      const na = parseFloat(a.match(regex)?.[1] ?? '0');
-      const nb = parseFloat(b.match(regex)?.[1] ?? '0');
-      return compareSprintIds(na, nb);
+      const bySprint = compareSprintIds(a.sprintNumber, b.sprintNumber);
+      return bySprint === 0 ? a.priority - b.priority : bySprint;
     });
 
-  const scorecards: GolfScorecard[] = [];
+  const loadedSprints = new Set<number>();
+  const dedupedCandidates: ScorecardCandidate[] = [];
 
-  for (const file of files) {
-    const match = file.match(regex);
-    if (!match) continue;
-    const num = parseFloat(match[1]);
-    if (num < config.minSprint) continue;
-
-    try {
-      const raw = JSON.parse(readFileSync(join(dir, file), 'utf8'));
-      const card = normalizeScorecard(raw);
-      scorecards.push(card);
-    } catch {
-      console.error(`  Warning: Could not parse ${file}, skipping`);
-    }
+  for (const candidate of candidates) {
+    if (loadedSprints.has(candidate.sprintNumber)) continue;
+    dedupedCandidates.push(candidate);
+    loadedSprints.add(candidate.sprintNumber);
   }
 
-  return scorecards;
+  return dedupedCandidates;
 }
 
 /**
@@ -77,12 +102,25 @@ export function resolveCurrentSprint(config: SlopeConfig, cwd: string = process.
  */
 export function normalizeScorecard(raw: Record<string, unknown>): GolfScorecard {
   const card = { ...raw } as Record<string, unknown>;
+  const shotCount = (card.shots as unknown[])?.length ?? 0;
+  const ticketCount = (card.tickets as unknown[])?.length ?? shotCount;
 
   // Normalize sprint_number
   card.sprint_number = card.sprint_number ?? card.sprint;
 
+  if (typeof card.par !== 'number' || Number.isNaN(card.par)) {
+    card.par = computePar(ticketCount);
+  }
+
+  if (typeof card.score !== 'number' || Number.isNaN(card.score)) {
+    card.score = card.par;
+  }
+
+  if (typeof card.score_label !== 'string') {
+    card.score_label = computeScoreLabel(card.score as number, card.par as number);
+  }
+
   // Normalize hole_stats → stats using the existing normalizeStats coercion
-  const shotCount = (card.shots as unknown[])?.length ?? 0;
   if (card.hole_stats && !card.stats) {
     card.stats = normalizeStats(card.hole_stats, shotCount);
     delete card.hole_stats;
@@ -96,4 +134,37 @@ export function normalizeScorecard(raw: Record<string, unknown>): GolfScorecard 
 
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function discoverScorecardCandidates(dir: string, regex: RegExp): ScorecardCandidate[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const candidates: ScorecardCandidate[] = [];
+
+  for (const entry of entries) {
+    if (entry.isFile()) {
+      const match = entry.name.match(regex);
+      if (!match) continue;
+      candidates.push({
+        path: join(dir, entry.name),
+        sprintNumber: parseFloat(match[1] ?? '0'),
+        priority: 0,
+        label: entry.name,
+      });
+      continue;
+    }
+
+    if (!entry.isDirectory()) continue;
+    const nestedMatch = entry.name.match(/^s(?:print-)?(\d+(?:\.\d+)?)$/i);
+    if (!nestedMatch) continue;
+    const nestedPath = join(dir, entry.name, 'scorecard.json');
+    if (!existsSync(nestedPath)) continue;
+    candidates.push({
+      path: nestedPath,
+      sprintNumber: parseFloat(nestedMatch[1] ?? '0'),
+      priority: 1,
+      label: `${entry.name}/scorecard.json`,
+    });
+  }
+
+  return candidates;
 }

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -50,7 +50,7 @@ function isValidISODate(s: string): boolean {
  * Accepts either `sprint_number` (TypeScript type) or `sprint` (retro JSON field name).
  */
 export function validateScorecard(
-  card: GolfScorecard & { sprint?: number },
+  card: GolfScorecard & { sprint?: number; completed_on?: string; started_on?: string },
   options: ScorecardValidationOptions = {},
 ): ScorecardValidationResult {
   const errors: ScorecardValidationError[] = [];
@@ -63,16 +63,20 @@ export function validateScorecard(
 
   // Normalize sprint field — retro JSONs use "sprint", TS type uses "sprint_number"
   const sprintNumber = card.sprint_number ?? card.sprint;
+  const validPar = [3, 4, 5].includes(card.par);
+  const hasExplicitScore = typeof card.score === 'number' && !Number.isNaN(card.score);
+  const effectiveScore = hasExplicitScore ? card.score : validPar ? card.par : undefined;
+  const effectiveDate = card.date ?? card.completed_on ?? card.started_on;
 
   // Rule 6: basic field validation
-  if (![3, 4, 5].includes(card.par)) {
+  if (!validPar) {
     errors.push({ code: 'INVALID_PAR', message: `par must be 3, 4, or 5 (got ${card.par})`, field: 'par' });
   }
-  if (typeof card.score !== 'number' || card.score <= 0) {
+  if (typeof effectiveScore !== 'number' || effectiveScore <= 0) {
     errors.push({ code: 'INVALID_SCORE', message: `score must be > 0 (got ${card.score})`, field: 'score' });
   }
-  if (!card.date || !isValidISODate(card.date)) {
-    errors.push({ code: 'INVALID_DATE', message: `date must be a valid ISO string (got "${card.date}")`, field: 'date' });
+  if (typeof effectiveDate !== 'string' || !isValidISODate(effectiveDate)) {
+    errors.push({ code: 'INVALID_DATE', message: `date must be a valid ISO string (got "${effectiveDate}")`, field: 'date' });
   }
   if (sprintNumber == null || typeof sprintNumber !== 'number' || sprintNumber <= 0) {
     errors.push({ code: 'MISSING_SPRINT', message: 'sprint_number (or sprint) is required and must be > 0', field: 'sprint_number' });
@@ -81,12 +85,12 @@ export function validateScorecard(
   validateSkillFields(card as unknown as Record<string, unknown>, errors, knownSkillIds);
 
   // Rule 1: score_label matches computeScoreLabel(score, par)
-  if (typeof card.score === 'number' && card.score > 0 && [3, 4, 5].includes(card.par)) {
-    const expected = computeScoreLabel(card.score, card.par);
-    if (card.score_label !== expected) {
+  if (typeof effectiveScore === 'number' && effectiveScore > 0 && validPar) {
+    const expected = computeScoreLabel(effectiveScore, card.par);
+    if (card.score_label != null && card.score_label !== expected) {
       errors.push({
         code: 'SCORE_LABEL_MISMATCH',
-        message: `score_label "${card.score_label}" doesn't match computed "${expected}" (score=${card.score}, par=${card.par})`,
+        message: `score_label "${card.score_label}" doesn't match computed "${expected}" (score=${effectiveScore}, par=${card.par})`,
         field: 'score_label',
       });
     }

--- a/tests/cli/guards.test.ts
+++ b/tests/cli/guards.test.ts
@@ -864,6 +864,14 @@ describe('pushNudgeGuard', () => {
     expect(result).toEqual({});
   });
 
+  it('passes through git commit-tree plumbing commands', async () => {
+    const result = await pushNudgeGuard(
+      makeInput({ tool_input: { command: 'git commit-tree abc123 -p HEAD' } }),
+      tmpDir,
+    );
+    expect(result).toEqual({});
+  });
+
   it('passes through empty command', async () => {
     const result = await pushNudgeGuard(
       makeInput({ tool_input: {} }),

--- a/tests/cli/validate-skills.test.ts
+++ b/tests/cli/validate-skills.test.ts
@@ -77,6 +77,30 @@ function writeScorecard(skillsUsed: string[], sprintNumber = 1): string {
   return `docs/retros/sprint-${sprintNumber}.json`;
 }
 
+function writeNestedScorecard(sprintNumber: number): void {
+  const nestedDir = join(tmpDir, 'docs', 'retros', `s${sprintNumber}`);
+  mkdirSync(nestedDir, { recursive: true });
+  const card = buildScorecard({
+    sprint_number: sprintNumber,
+    theme: 'Nested validation',
+    par: 3,
+    slope: 1,
+    date: '2026-05-23',
+    player: 'test',
+    shots: [{
+      ticket_key: `S${sprintNumber}-1`,
+      title: 'Test',
+      club: 'wedge',
+      result: 'in_the_hole',
+      hazards: [],
+    }],
+    training: [{ type: 'lessons', description: 'test', outcome: 'ok' }],
+    nutrition: [{ category: 'hydration', description: 'test', status: 'healthy' }],
+    bunker_locations: ['none'],
+  });
+  writeFileSync(join(nestedDir, 'scorecard.json'), JSON.stringify(card, null, 2));
+}
+
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'slope-validate-skills-'));
   writeConfig();
@@ -113,6 +137,13 @@ describe('slope validate --skills', () => {
 
   it('includes decimal inserted sprint scorecards during default validation', () => {
     writeScorecard([], 114.5);
+
+    expect(() => validateCommand()).toThrow('process.exit(0)');
+    expect(exitCode).toBe(0);
+  });
+
+  it('includes nested sN/scorecard.json scorecards during default validation', () => {
+    writeNestedScorecard(155);
 
     expect(() => validateCommand()).toThrow('process.exit(0)');
     expect(exitCode).toBe(0);

--- a/tests/core/loader.test.ts
+++ b/tests/core/loader.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { loadScorecards, detectLatestSprint } from '../../src/core/loader.js';
+import { loadScorecards, detectLatestSprint, discoverScorecardFiles } from '../../src/core/loader.js';
 import type { SlopeConfig } from '../../src/core/config.js';
 
 const TMP = join(__dirname, '__loader_tmp__');
@@ -36,6 +36,12 @@ function writeCard(dir: string, filename: string, sprintNumber: number): void {
     course_management_notes: [],
   };
   writeFileSync(join(dir, filename), JSON.stringify(card));
+}
+
+function writeNestedCard(retrosDir: string, dirname: string, sprintNumber: number): void {
+  const nestedDir = join(retrosDir, dirname);
+  mkdirSync(nestedDir, { recursive: true });
+  writeCard(nestedDir, 'scorecard.json', sprintNumber);
 }
 
 describe('loadScorecards — numeric sort', () => {
@@ -85,12 +91,57 @@ describe('loadScorecards — numeric sort', () => {
     expect(numbers).toEqual([5, 10]);
   });
 
+  it('normalizes missing score fields to a neutral par score', () => {
+    const card = {
+      sprint_number: 153,
+      sprint_label: 'S153',
+      par: 4,
+      slope: 3,
+      tickets: [],
+      shots: [],
+    };
+    writeFileSync(join(retrosDir, 'sprint-153.json'), JSON.stringify(card));
+
+    const cards = loadScorecards(baseConfig, TMP);
+    expect(cards[0].score).toBe(4);
+    expect(cards[0].score_label).toBe('par');
+  });
+
   it('loads and sorts decimal scorecard filenames for inserted sub-sprints', () => {
     writeCard(retrosDir, 'sprint-44.json', 44);
     writeCard(retrosDir, 'sprint-43.5.json', 43.5);
 
     const cards = loadScorecards(baseConfig, TMP);
     expect(cards.map(c => c.sprint_number)).toEqual([43.5, 44]);
+  });
+
+  it('also loads nested sN/scorecard.json scorecards for repos that keep sprint artifacts together', () => {
+    writeCard(retrosDir, 'sprint-103.json', 103);
+    writeNestedCard(retrosDir, 's104', 104);
+    writeNestedCard(retrosDir, 's155', 155);
+
+    const cards = loadScorecards(baseConfig, TMP);
+    expect(cards.map(c => c.sprint_number)).toEqual([103, 104, 155]);
+  });
+
+  it('prefers configured top-level scorecards over nested duplicates for the same sprint', () => {
+    writeCard(retrosDir, 'sprint-104.json', 104);
+    writeNestedCard(retrosDir, 's104', 104);
+
+    const cards = loadScorecards(baseConfig, TMP);
+    expect(cards.map(c => c.sprint_number)).toEqual([104]);
+    expect(cards).toHaveLength(1);
+  });
+
+  it('discovers nested scorecard paths for validation commands', () => {
+    writeCard(retrosDir, 'sprint-103.json', 103);
+    writeNestedCard(retrosDir, 's104', 104);
+
+    const files = discoverScorecardFiles(baseConfig, TMP);
+    expect(files.map(f => f.replace(TMP, ''))).toEqual([
+      '/retros/sprint-103.json',
+      '/retros/s104/scorecard.json',
+    ]);
   });
 });
 
@@ -120,6 +171,14 @@ describe('detectLatestSprint', () => {
 
     const latest = detectLatestSprint(baseConfig, TMP);
     expect(latest).toBe(44);
+  });
+
+  it('detects latest sprint from nested sN/scorecard.json scorecards', () => {
+    writeCard(retrosDir, 'sprint-103.json', 103);
+    writeNestedCard(retrosDir, 's155', 155);
+
+    const latest = detectLatestSprint(baseConfig, TMP);
+    expect(latest).toBe(155);
   });
 
   it('returns 0 for no scorecards', () => {

--- a/tests/core/validation.test.ts
+++ b/tests/core/validation.test.ts
@@ -276,9 +276,20 @@ describe('validateScorecard - basic fields', () => {
     expect(result.errors.some(e => e.code === 'INVALID_SCORE')).toBe(true);
   });
 
+  it('accepts missing score as a neutral par score for compatibility scorecards', () => {
+    const result = validateScorecard(makeCard({ score: undefined as any, score_label: undefined as any }));
+    expect(result.errors.filter(e => e.code === 'INVALID_SCORE')).toHaveLength(0);
+    expect(result.errors.filter(e => e.code === 'SCORE_LABEL_MISMATCH')).toHaveLength(0);
+  });
+
   it('fails for invalid date', () => {
     const result = validateScorecard(makeCard({ date: 'not-a-date' }));
     expect(result.errors.some(e => e.code === 'INVALID_DATE')).toBe(true);
+  });
+
+  it('accepts completed_on as a compatibility date fallback', () => {
+    const result = validateScorecard(makeCard({ date: undefined as any, completed_on: '2026-05-23' } as any));
+    expect(result.errors.filter(e => e.code === 'INVALID_DATE')).toHaveLength(0);
   });
 
   it('passes for valid basic fields', () => {


### PR DESCRIPTION
## Summary
- load nested docs/retros/sN/scorecard.json scorecards alongside legacy top-level sprint-*.json files
- normalize compatibility scorecards with missing score/date fields so briefing, next, and validate agree
- update validate default discovery to use the same scorecard discovery path as briefing
- avoid treating git commit-tree plumbing as a normal git commit in CLI and Pi guards

## Verification
- pnpm vitest run tests/core/loader.test.ts tests/core/validation.test.ts tests/cli/validate-skills.test.ts tests/cli/guards/branch-before-commit.test.ts
- pnpm vitest run tests/cli/guards.test.ts -t pushNudgeGuard
- pnpm run build
- in fathoms-art worktree: slope briefing --compact reports S156/latest S155 and slope validate docs/retros/s155/scorecard.json is valid with warnings only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for discovering scorecards in nested sprint directories alongside flat file storage
  * Enhanced scorecard validation with intelligent defaults for missing score-related fields

* **Bug Fixes**
  * Improved git commit command detection to reduce false positives with stricter pattern matching
  
* **Improvements**
  * Streamlined scorecard discovery mechanism for better file handling and deduplication

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->