### PR TITLE
[codex] Triage open issues into upcoming sprints

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -257,8 +257,18 @@
       "sprints": [
         124
       ],
-      "status": "planned",
+      "status": "complete",
       "note": "Close #452 and #453 by surfacing roadmap drift and sibling worktree conflict signals before agents commit to a sprint."
+    },
+    {
+      "name": "Phase 40 \u2014 Codex Runtime Recovery",
+      "sprints": [
+        125,
+        126,
+        127
+      ],
+      "status": "planned",
+      "note": "Triage the open #456/#459/#460 issue batch into two focused repair sprints and one patch-release sprint: first fix Codex effective-workdir hook routing, then improve native SQLite recovery messaging, then publish the combined fixes."
     }
   ],
   "sprints": [
@@ -2639,6 +2649,136 @@
           "depends_on": [
             "S124-1",
             "S124-2"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 125,
+      "theme": "Codex Hook Effective Workdir Recovery",
+      "par": 4,
+      "slope": 4,
+      "type": "bugfix",
+      "status": "planned",
+      "depends_on": [
+        124
+      ],
+      "note": "Close #456 and #459 by making Codex hook dispatch evaluate the effective Bash command workdir, recover workdir from transcripts when Codex omits it, and diagnose duplicate project/user hook installs.",
+      "tickets": [
+        {
+          "key": "S125-1",
+          "title": "Normalize Codex Bash guard input to the effective exec workdir (#456/#459)",
+          "club": "long_iron",
+          "complexity": "moderate",
+          "github_issue": [
+            456,
+            459
+          ]
+        },
+        {
+          "key": "S125-2",
+          "title": "Recover and remember exec workdir from Codex transcript/tool_use_id context (#459)",
+          "club": "driver",
+          "complexity": "risky",
+          "github_issue": 459,
+          "depends_on": [
+            "S125-1"
+          ]
+        },
+        {
+          "key": "S125-3",
+          "title": "Detect duplicate project-level and user-level Codex hook installs in doctor (#459)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 459,
+          "depends_on": [
+            "S125-1"
+          ]
+        },
+        {
+          "key": "S125-4",
+          "title": "Add cross-repo/worktree regressions for branch-before-commit and worktree-check (#456/#459)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": [
+            456,
+            459
+          ],
+          "depends_on": [
+            "S125-1",
+            "S125-2",
+            "S125-3"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 126,
+      "theme": "Native Store Error Recovery Guidance",
+      "par": 4,
+      "slope": 2,
+      "type": "bugfix",
+      "status": "planned",
+      "depends_on": [
+        125
+      ],
+      "note": "Close #460 by reusing existing native SQLite recovery guidance from common top-level CLI error handlers instead of dumping raw better-sqlite3 binding stacks.",
+      "tickets": [
+        {
+          "key": "S126-1",
+          "title": "Extract shared CLI error reporter around native SQLite recovery helpers (#460)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 460
+        },
+        {
+          "key": "S126-2",
+          "title": "Route duplicated top-level command catches through the shared reporter (#460)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 460,
+          "depends_on": [
+            "S126-1"
+          ]
+        },
+        {
+          "key": "S126-3",
+          "title": "Add native-binding failure regressions for common store-backed commands (#460)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 460,
+          "depends_on": [
+            "S126-1",
+            "S126-2"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 127,
+      "theme": "Codex Runtime Patch Release",
+      "par": 3,
+      "slope": 1,
+      "type": "release",
+      "status": "planned",
+      "depends_on": [
+        126
+      ],
+      "note": "Publish the S125/S126 Codex hook and native recovery fixes as the next patch release after validation and npm trusted-publisher verification.",
+      "tickets": [
+        {
+          "key": "S127-1",
+          "title": "Bump @slope-dev/slope and bundled Codex plugin for the Codex runtime patch release",
+          "club": "wedge",
+          "complexity": "small"
+        },
+        {
+          "key": "S127-2",
+          "title": "Run release validation, publish the patch release, and verify npm",
+          "club": "short_iron",
+          "complexity": "standard",
+          "depends_on": [
+            "S127-1"
           ]
         }
       ]


### PR DESCRIPTION
## Summary

Triages the current open GitHub issue batch into upcoming roadmap sprints.

- Marks Phase 39 complete now that S124 is closed.
- Adds Phase 40: Codex Runtime Recovery.
- Adds S125 for #456/#459 Codex effective-workdir hook recovery and duplicate hook install diagnostics.
- Adds S126 for #460 native better-sqlite3 recovery-message plumbing.
- Adds S127 as the follow-on patch-release sprint for the combined fixes.
- Labels #456/#459/#460 as `bug` + `agent-dx` where needed and comments the sprint assignment on each issue.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('docs/backlog/roadmap.json','utf8'))"`
- `node dist/cli/index.js roadmap validate`
- `git diff --check`

## Notes

There is also an already-open green PR #458 (`fix: nested scorecards and commit-tree guard detection`) that does not close an open issue, so I left it separate from this issue triage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product roadmap marking Phase 39 ("Pre-Sprint Reality Checks") as complete and introducing Phase 40 ("Codex Runtime Recovery") with planned improvements across three upcoming sprints, including runtime recovery enhancements, native error recovery guidance, and a combined patch release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/srbryers/slope/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->