### PR TITLE
fix: recover Codex hook workdir routing

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -2659,7 +2659,9 @@
       "par": 4,
       "slope": 4,
       "type": "bugfix",
-      "status": "planned",
+      "status": "complete",
+      "score": 4,
+      "score_label": "par",
       "depends_on": [
         124
       ],

--- a/docs/retros/sprint-125.json
+++ b/docs/retros/sprint-125.json
@@ -32,6 +32,11 @@
           "type": "rough",
           "severity": "minor",
           "description": "The remembered cwd regression exposed macOS /var versus /private/var path canonicalization drift; the remembered-cwd gate now compares real paths before deciding the hook cwd and launcher cwd refer to different directories."
+        },
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Post-hole architecture review caught that transcript lines may include both a top-level session cwd and nested tool input.workdir; transcript parsing now prioritizes nested tool input fields before top-level cwd."
         }
       ],
       "notes": "Added transcript tool_use_id lookup for nested tool-call workdir/cwd fields, a best-effort per-session Codex workdir cache, and single staged non-main worktree inference for git commit commands when Codex omits exec workdir."
@@ -60,7 +65,7 @@
     "greens_total": 4,
     "putts": 0,
     "penalties": 0,
-    "hazards_hit": 2,
+    "hazards_hit": 3,
     "hazard_penalties": 0,
     "miss_directions": {
       "long": 0,
@@ -133,6 +138,7 @@
     "Committed guard recovery as 080c693: fix(S125-1): normalize Codex hook workdir.",
     "Committed doctor duplicate-hook diagnostics as 5258929: fix(S125-3): detect duplicate Codex hook installs.",
     "Focused Vitest run passed: tests/cli/commands/doctor.test.ts and tests/cli/commands/guard.test.ts, 38 tests.",
+    "Post-hole architecture review caught nested transcript input.workdir priority over top-level session cwd; added regression coverage and reran focused guard/doctor tests.",
     "pnpm exec tsc --noEmit passed.",
     "pnpm run build passed.",
     "pnpm test passed: 215 passed test files, 1 skipped test file, 3499 passed tests, and 23 skipped tests."

--- a/docs/retros/sprint-125.json
+++ b/docs/retros/sprint-125.json
@@ -1,0 +1,155 @@
+{
+  "sprint_number": 125,
+  "player": "codex",
+  "theme": "Codex Hook Effective Workdir Recovery",
+  "par": 4,
+  "slope": 4,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-05-29",
+  "shots": [
+    {
+      "ticket_key": "S125-1",
+      "title": "Normalize Codex Bash guard input to the effective exec workdir (#456/#459)",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Initial file-path cwd recovery was too eager for non-existent edit targets and routed existing guard tests into a synthetic src/ directory; the recovery now requires the edited file parent to exist before it can override the hook cwd."
+        }
+      ],
+      "notes": "Centralized hook cwd normalization before config load, baseline recording, and guard dispatch. Codex hooks now prefer explicit tool_input.workdir/cwd, derive repository roots from existing edit file paths, canonicalize to SLOPE config or git roots, and preserve the hook cwd when no stronger signal exists."
+    },
+    {
+      "ticket_key": "S125-2",
+      "title": "Recover and remember exec workdir from Codex transcript/tool_use_id context (#459)",
+      "club": "driver",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The remembered cwd regression exposed macOS /var versus /private/var path canonicalization drift; the remembered-cwd gate now compares real paths before deciding the hook cwd and launcher cwd refer to different directories."
+        }
+      ],
+      "notes": "Added transcript tool_use_id lookup for nested tool-call workdir/cwd fields, a best-effort per-session Codex workdir cache, and single staged non-main worktree inference for git commit commands when Codex omits exec workdir."
+    },
+    {
+      "ticket_key": "S125-3",
+      "title": "Detect duplicate project-level and user-level Codex hook installs in doctor (#459)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Made Codex user hook discovery honor SLOPE_CODEX_HOME/CODEX_HOME and expanded the duplicate project/user warning to show the exact hook config paths so users can keep one active runtime path."
+    },
+    {
+      "ticket_key": "S125-4",
+      "title": "Add cross-repo/worktree regressions for branch-before-commit and worktree-check (#456/#459)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added command-level regressions covering explicit Codex workdir, transcript recovery plus remembered cwd reuse, single staged worktree inference, and worktree-check routing from an edited file path in another worktree."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 2,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "bugfix",
+  "conditions": [
+    "Implemented after PR #458 merged and main was synced.",
+    "A stale feat/workflow-engine sibling worktree remains present but was not touched."
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Codex hook payload cwd is a session cwd, not necessarily the command cwd.",
+      "outcome": "Guard dispatch now resolves the effective cwd from tool inputs, transcript metadata, remembered session cwd, or staged worktree inference before any guard probes git."
+    },
+    {
+      "type": "lessons",
+      "description": "Path comparisons need realpath handling on macOS temp paths.",
+      "outcome": "Remembered Codex workdir recovery compares real paths so /var and /private/var do not block legitimate recovery."
+    },
+    {
+      "type": "lessons",
+      "description": "File-path based recovery should only override cwd when the path is concrete enough to locate a repo.",
+      "outcome": "Edit path recovery now requires an existing parent directory before canonicalizing to a SLOPE or git root."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused guard/doctor tests, typecheck, build, and full pnpm test passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "workflow",
+      "description": "S125 closes the effective-workdir half of the Codex runtime recovery phase; S126 remains the next planned bugfix sprint.",
+      "status": "healthy"
+    },
+    {
+      "category": "concurrency",
+      "description": "The known feat/workflow-engine sibling worktree is still dirty/ahead and should remain isolated from this PR.",
+      "status": "watch"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A little fiddly, but in the productive way: every failing regression pointed straight at the real edge Codex users were feeling.",
+    "advice_for_next_player": "Keep cwd recovery centralized in guard input normalization; individual guards should not each learn a different version of Codex payload shape.",
+    "what_surprised_you": "The macOS /var realpath mismatch was invisible until the remembered-workdir regression reused the same session across two hook invocations.",
+    "excited_about_next": "S126 can focus cleanly on native store recovery guidance now that Codex hook routing has a safer cwd foundation."
+  },
+  "bunker_locations": [
+    "Codex hook stdin cwd can be a session root while the actual exec_command workdir is a different repository or worktree.",
+    "Do not route edit hooks by a file_path whose parent directory does not exist yet.",
+    "Compare canonical/real paths when using temp directories on macOS."
+  ],
+  "yardage_book_updates": [
+    "slope guard now normalizes hook cwd from tool_input.workdir/cwd before loading config or running guards.",
+    "slope guard can recover Codex exec workdir from transcript_path plus tool_use_id when workdir is omitted from hook stdin.",
+    "slope guard remembers recovered Codex workdir per session in a temp cache and can reuse it on later hook invocations from the same launcher cwd.",
+    "branch-before-commit can infer a single staged non-main worktree for git commit commands when Codex omits exec workdir.",
+    "worktree-check can route by existing edited file paths when hook cwd points at a different repo.",
+    "slope doctor now reports exact duplicate project/user Codex hook config paths and honors SLOPE_CODEX_HOME/CODEX_HOME."
+  ],
+  "course_management_notes": [
+    "Merged PR #458 before starting S125 and branched from updated main.",
+    "Committed guard recovery as 080c693: fix(S125-1): normalize Codex hook workdir.",
+    "Committed doctor duplicate-hook diagnostics as 5258929: fix(S125-3): detect duplicate Codex hook installs.",
+    "Focused Vitest run passed: tests/cli/commands/doctor.test.ts and tests/cli/commands/guard.test.ts, 38 tests.",
+    "pnpm exec tsc --noEmit passed.",
+    "pnpm run build passed.",
+    "pnpm test passed: 215 passed test files, 1 skipped test file, 3499 passed tests, and 23 skipped tests."
+  ],
+  "skills_used": [
+    "slope-sprint-workflow",
+    "slope-api-reference"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "slope-performance-analysis"
+  ],
+  "skill_gaps_found": [],
+  "slope_factors": [
+    "codex_payload_normalization",
+    "transcript_recovery",
+    "session_workdir_cache",
+    "cross_repo_worktree_regressions"
+  ]
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -491,7 +491,7 @@ function checkCodexHookScripts(hooksDir: string): DoctorCheck[] {
 function checkCodexHooks(cwd: string): DoctorCheck[] {
   const checks: DoctorCheck[] = [];
   const projectHooksPath = join(cwd, '.codex', 'hooks.json');
-  const userHooksPath = join(homedir(), '.codex', 'hooks.json');
+  const userHooksPath = join(resolveCodexHome(), 'hooks.json');
   const hasProjectSlopeHooks = existsSync(projectHooksPath) && fileHasSlopeHooks(projectHooksPath);
   const hasUserSlopeHooks = existsSync(userHooksPath) && fileHasSlopeHooks(userHooksPath);
 
@@ -505,12 +505,17 @@ function checkCodexHooks(cwd: string): DoctorCheck[] {
     checks.push({
       name: 'codex-hooks',
       status: 'warn',
-      message: 'SLOPE hooks found in both project .codex/hooks.json and ~/.codex/hooks.json — choose one runtime path to avoid duplicate firing',
+      message: `SLOPE hooks found in both ${projectHooksPath} and ${userHooksPath} — keep one active Codex runtime path to avoid duplicate firing`,
       fixable: false,
     });
   }
 
   return checks;
+}
+
+function resolveCodexHome(): string {
+  const override = process.env.SLOPE_CODEX_HOME ?? process.env.CODEX_HOME;
+  return override && override.trim().length > 0 ? resolve(override.trim()) : join(homedir(), '.codex');
 }
 
 function checkCodexRuntimeResolution(cwd: string): DoctorCheck[] {

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -1,5 +1,8 @@
-import { existsSync, readFileSync, appendFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, appendFileSync, mkdirSync, writeFileSync, statSync, realpathSync } from 'node:fs';
+import { execFileSync, execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { GUARD_DEFINITIONS, formatPreToolUseOutput, formatPostToolUseOutput, formatStopOutput, getAllGuardDefinitions, getCustomGuard, loadPluginGuards, detectAdapter } from '../../core/index.js';
 import type { HookInput, GuardResult, GuardName, AnyGuardDefinition } from '../../core/index.js';
 import { loadConfig } from '../config.js';
@@ -33,7 +36,6 @@ import { roadmapEditShippedGuard } from '../guards/roadmap-edit-shipped.js';
 import { postHoleEnforcementGuard } from '../guards/post-hole-enforcement.js';
 import { formatGuardDocs } from '../guards/docs.js';
 import { recordBaseline } from '../guards/git-utils.js';
-import { execSync } from 'node:child_process';
 import { isAdhocSession } from '../session-state.js';
 
 // Side-effect imports: ensure all adapters are registered for detectAdapter()
@@ -300,13 +302,341 @@ async function readStdin(): Promise<HookInput> {
   });
 }
 
-function normalizeHookInput(input: HookInput | null, fallbackCwd: string): HookInput {
-  return {
+type HookCwdSource = 'hook' | 'tool-workdir' | 'tool-path' | 'transcript' | 'remembered' | 'staged-worktree';
+
+interface HookCwdResolution {
+  cwd: string;
+  source: HookCwdSource;
+}
+
+export function normalizeHookInput(input: HookInput | null, fallbackCwd: string): HookInput {
+  const baseCwd = normalizeBaseCwd(input, fallbackCwd);
+  const resolved = resolveEffectiveHookCwd(input, baseCwd, fallbackCwd);
+  const normalized = {
     ...(input ?? {}),
     session_id: input?.session_id ?? '',
-    cwd: typeof input?.cwd === 'string' && input.cwd.length > 0 ? input.cwd : fallbackCwd,
+    cwd: resolved.cwd,
     hook_event_name: input?.hook_event_name ?? '',
   };
+
+  if (input && resolved.source !== 'hook') {
+    rememberCodexWorkdir(normalized, resolved);
+  }
+
+  return normalized;
+}
+
+function normalizeBaseCwd(input: HookInput | null, fallbackCwd: string): string {
+  const raw = typeof input?.cwd === 'string' && input.cwd.trim().length > 0
+    ? input.cwd.trim()
+    : fallbackCwd;
+  return normalizePath(raw, fallbackCwd);
+}
+
+function resolveEffectiveHookCwd(input: HookInput | null, baseCwd: string, fallbackCwd: string): HookCwdResolution {
+  if (!input) return { cwd: baseCwd, source: 'hook' };
+
+  const explicitWorkdir = extractToolInputWorkdir(input);
+  if (explicitWorkdir) {
+    return { cwd: normalizePath(explicitWorkdir, baseCwd), source: 'tool-workdir' };
+  }
+
+  const toolPathCwd = extractToolInputPathCwd(input, baseCwd);
+  if (toolPathCwd) {
+    return { cwd: toolPathCwd, source: 'tool-path' };
+  }
+
+  const transcriptCwd = extractTranscriptWorkdir(input, baseCwd);
+  if (transcriptCwd) {
+    return { cwd: transcriptCwd, source: 'transcript' };
+  }
+
+  const rememberedCwd = readRememberedCodexWorkdir(input, fallbackCwd);
+  if (rememberedCwd) {
+    return { cwd: rememberedCwd, source: 'remembered' };
+  }
+
+  const inferredWorktree = inferSingleStagedWorktree(input, baseCwd);
+  if (inferredWorktree) {
+    return { cwd: inferredWorktree, source: 'staged-worktree' };
+  }
+
+  return { cwd: baseCwd, source: 'hook' };
+}
+
+function normalizePath(rawPath: string, baseCwd: string): string {
+  const absolute = isAbsolute(rawPath) ? rawPath : resolve(baseCwd, rawPath);
+  return canonicalHookCwd(absolute);
+}
+
+function canonicalHookCwd(path: string): string {
+  const start = existingDirectory(path);
+  const slopeRoot = start ? findAncestorWithSlopeConfig(start) : null;
+  if (slopeRoot) return slopeRoot;
+
+  if (start) {
+    try {
+      return execFileSync('git', ['-C', start, 'rev-parse', '--show-toplevel'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 3000,
+      }).trim();
+    } catch { /* not a git repo */ }
+  }
+
+  return path;
+}
+
+function existingDirectory(path: string): string | null {
+  let current = path;
+  try {
+    if (!existsSync(current)) return null;
+    if (!statSync(current).isDirectory()) current = dirname(current);
+    return current;
+  } catch {
+    return null;
+  }
+}
+
+function findAncestorWithSlopeConfig(start: string): string | null {
+  let current = start;
+  while (true) {
+    if (existsSync(join(current, '.slope', 'config.json'))) return current;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function extractToolInputWorkdir(input: HookInput): string | null {
+  const toolInput = input.tool_input;
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  for (const key of ['workdir', 'cwd']) {
+    const value = toolInput[key];
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim();
+  }
+  return null;
+}
+
+function extractToolInputPathCwd(input: HookInput, baseCwd: string): string | null {
+  const toolInput = input.tool_input;
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  for (const key of ['file_path', 'path']) {
+    const value = toolInput[key];
+    if (typeof value !== 'string' || value.trim().length === 0) continue;
+    const absolute = isAbsolute(value) ? value : resolve(baseCwd, value);
+    if (!existingDirectory(dirname(absolute))) continue;
+    return canonicalHookCwd(dirname(absolute));
+  }
+  return null;
+}
+
+function extractTranscriptWorkdir(input: HookInput, baseCwd: string): string | null {
+  const transcriptPath = typeof input.transcript_path === 'string' ? input.transcript_path.trim() : '';
+  const toolUseId = typeof input.tool_use_id === 'string' ? input.tool_use_id.trim() : '';
+  if (!transcriptPath || !toolUseId || !existsSync(transcriptPath)) return null;
+
+  try {
+    const lines = readFileSync(transcriptPath, 'utf8').split('\n').filter(Boolean);
+    for (const line of lines.reverse()) {
+      if (!line.includes(toolUseId)) continue;
+      const fromJson = parseTranscriptLineForWorkdir(line, toolUseId);
+      const rawWorkdir = fromJson ?? parseWorkdirFromLine(line);
+      if (rawWorkdir) return normalizePath(rawWorkdir, baseCwd);
+    }
+  } catch { /* transcript lookup is best-effort */ }
+
+  return null;
+}
+
+function parseTranscriptLineForWorkdir(line: string, toolUseId: string): string | null {
+  try {
+    return findWorkdirForToolUse(JSON.parse(line), toolUseId);
+  } catch {
+    return null;
+  }
+}
+
+function findWorkdirForToolUse(value: unknown, toolUseId: string): string | null {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findWorkdirForToolUse(item, toolUseId);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!value || typeof value !== 'object') return null;
+
+  const record = value as Record<string, unknown>;
+  if (record.id === toolUseId || record.tool_use_id === toolUseId || record.call_id === toolUseId) {
+    return findFirstWorkdir(record);
+  }
+
+  for (const child of Object.values(record)) {
+    const found = findWorkdirForToolUse(child, toolUseId);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findFirstWorkdir(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findFirstWorkdir(item);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!value || typeof value !== 'object') return null;
+
+  const record = value as Record<string, unknown>;
+  for (const key of ['workdir', 'cwd']) {
+    const candidate = record[key];
+    if (typeof candidate === 'string' && candidate.trim().length > 0) return candidate.trim();
+  }
+  for (const child of Object.values(record)) {
+    const found = findFirstWorkdir(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+function parseWorkdirFromLine(line: string): string | null {
+  const match = line.match(/"(?:workdir|cwd)"\s*:\s*"((?:\\"|[^"])*)"/);
+  if (!match) return null;
+  try {
+    return JSON.parse(`"${match[1]}"`) as string;
+  } catch {
+    return match[1];
+  }
+}
+
+function readRememberedCodexWorkdir(input: HookInput, fallbackCwd: string): string | null {
+  const sessionId = typeof input.session_id === 'string' ? input.session_id.trim() : '';
+  if (!sessionId) return null;
+  const hookCwd = typeof input.cwd === 'string' && input.cwd.trim().length > 0
+    ? normalizePath(input.cwd.trim(), fallbackCwd)
+    : normalizePath(fallbackCwd, fallbackCwd);
+  const launcherCwd = normalizePath(fallbackCwd, fallbackCwd);
+  if (!samePath(hookCwd, launcherCwd)) return null;
+
+  try {
+    const path = codexWorkdirStatePath(sessionId);
+    if (!existsSync(path)) return null;
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as { cwd?: unknown };
+    if (typeof parsed.cwd !== 'string' || parsed.cwd.trim().length === 0) return null;
+    const remembered = canonicalHookCwd(parsed.cwd.trim());
+    return existsSync(remembered) ? remembered : null;
+  } catch {
+    return null;
+  }
+}
+
+function samePath(left: string, right: string): boolean {
+  return comparisonPath(left) === comparisonPath(right);
+}
+
+function comparisonPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function rememberCodexWorkdir(input: HookInput, resolution: HookCwdResolution): void {
+  const sessionId = typeof input.session_id === 'string' ? input.session_id.trim() : '';
+  if (!sessionId || resolution.source === 'remembered') return;
+
+  try {
+    const path = codexWorkdirStatePath(sessionId);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({
+      session_id: sessionId,
+      cwd: resolution.cwd,
+      source: resolution.source,
+      updated_at: new Date().toISOString(),
+    }, null, 2) + '\n');
+  } catch { /* best-effort recovery cache */ }
+}
+
+function codexWorkdirStatePath(sessionId: string): string {
+  const dir = process.env.SLOPE_CODEX_WORKDIR_STORE ?? join(tmpdir(), 'slope-codex-workdirs');
+  const key = createHash('sha256').update(sessionId).digest('hex').slice(0, 32);
+  return join(dir, `${key}.json`);
+}
+
+function inferSingleStagedWorktree(input: HookInput, baseCwd: string): string | null {
+  const command = getHookCommand(input);
+  if (!/git\s+commit(\s|$)/.test(command)) return null;
+
+  const entries = listWorktreeEntries(baseCwd);
+  const candidates = entries
+    .filter(entry => entry.path && entry.branch && !['main', 'master'].includes(entry.branch))
+    .filter(entry => hasStagedChanges(entry.path));
+
+  if (candidates.length !== 1) return null;
+  return canonicalHookCwd(candidates[0].path);
+}
+
+function getHookCommand(input: HookInput): string {
+  const toolInput = input.tool_input;
+  if (!toolInput || typeof toolInput !== 'object') return '';
+  for (const key of ['command', 'cmd', 'input']) {
+    const value = toolInput[key];
+    if (typeof value === 'string') return value;
+  }
+  return '';
+}
+
+interface WorktreeEntry {
+  path: string;
+  branch: string;
+}
+
+function listWorktreeEntries(cwd: string): WorktreeEntry[] {
+  try {
+    const raw = execFileSync('git', ['-C', cwd, 'worktree', 'list', '--porcelain'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+    const entries: WorktreeEntry[] = [];
+    let currentPath = '';
+    let currentBranch = '';
+
+    const flush = () => {
+      if (currentPath) entries.push({ path: currentPath, branch: currentBranch });
+      currentPath = '';
+      currentBranch = '';
+    };
+
+    for (const line of raw.split('\n')) {
+      if (line.startsWith('worktree ')) {
+        flush();
+        currentPath = line.slice('worktree '.length).trim();
+      } else if (line.startsWith('branch ')) {
+        currentBranch = line.slice('branch '.length).replace(/^refs\/heads\//, '').trim();
+      }
+    }
+    flush();
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+function hasStagedChanges(cwd: string): boolean {
+  try {
+    const staged = execFileSync('git', ['-C', cwd, 'diff', '--cached', '--name-only'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 3000,
+    }).trim();
+    return staged.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 function printUsage(): void {

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -490,11 +490,17 @@ function findFirstWorkdir(value: unknown): string | null {
   if (!value || typeof value !== 'object') return null;
 
   const record = value as Record<string, unknown>;
-  for (const key of ['workdir', 'cwd']) {
-    const candidate = record[key];
-    if (typeof candidate === 'string' && candidate.trim().length > 0) return candidate.trim();
+  for (const key of ['input', 'tool_input', 'arguments', 'parameters']) {
+    const nested = findFirstWorkdir(record[key]);
+    if (nested) return nested;
   }
-  for (const child of Object.values(record)) {
+  const workdir = record.workdir;
+  if (typeof workdir === 'string' && workdir.trim().length > 0) return workdir.trim();
+  const cwd = record.cwd;
+  if (typeof cwd === 'string' && cwd.trim().length > 0) return cwd.trim();
+
+  for (const [key, child] of Object.entries(record)) {
+    if (['input', 'tool_input', 'arguments', 'parameters', 'workdir', 'cwd'].includes(key)) continue;
     const found = findFirstWorkdir(child);
     if (found) return found;
   }

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -254,6 +254,45 @@ describe('doctor checks', () => {
       expect(codexCheck!.fixable).toBe(true);
     });
 
+    it('warns when SLOPE Codex hooks are installed at both project and user level', () => {
+      setupSlopeDir(cwd);
+      const previousCodexHome = process.env.SLOPE_CODEX_HOME;
+      const codexHome = join(cwd, '.test-codex-home');
+
+      try {
+        process.env.SLOPE_CODEX_HOME = codexHome;
+        mkdirSync(join(cwd, '.codex'), { recursive: true });
+        mkdirSync(codexHome, { recursive: true });
+        const hooksConfig = {
+          hooks: {
+            PreToolUse: [{
+              matcher: 'Bash',
+              hooks: [{ type: 'command', command: '"./.codex/hooks/slope-guard.sh" branch-before-commit' }],
+            }],
+          },
+        };
+        writeFileSync(join(cwd, '.codex', 'hooks.json'), JSON.stringify(hooksConfig));
+        writeFileSync(join(codexHome, 'hooks.json'), JSON.stringify(hooksConfig));
+
+        const checks = runDoctorChecks(cwd);
+        const duplicateCheck = checks.find(c =>
+          c.name === 'codex-hooks' &&
+          c.status === 'warn' &&
+          c.message.includes('keep one active Codex runtime path'),
+        );
+
+        expect(duplicateCheck).toBeDefined();
+        expect(duplicateCheck!.message).toContain(join(cwd, '.codex', 'hooks.json'));
+        expect(duplicateCheck!.message).toContain(join(codexHome, 'hooks.json'));
+      } finally {
+        if (previousCodexHome === undefined) {
+          delete process.env.SLOPE_CODEX_HOME;
+        } else {
+          process.env.SLOPE_CODEX_HOME = previousCodexHome;
+        }
+      }
+    });
+
     it('fixes Codex hooks.json root event shape', async () => {
       setupSlopeDir(cwd);
       mkdirSync(join(cwd, '.codex'), { recursive: true });

--- a/tests/cli/commands/guard.test.ts
+++ b/tests/cli/commands/guard.test.ts
@@ -288,6 +288,7 @@ describe('guardCommand dispatcher path', () => {
       writeFileSync(transcriptPath, JSON.stringify({
         type: 'tool_call',
         id: 'toolu_123',
+        cwd,
         input: {
           command: 'git commit -m "feat: from transcript"',
           workdir: worktreeCwd,

--- a/tests/cli/commands/guard.test.ts
+++ b/tests/cli/commands/guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { PassThrough } from 'node:stream';
@@ -20,6 +20,10 @@ function makeTmpDir(): string {
   const dir = join(tmpdir(), `slope-guard-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(dir, { recursive: true });
   return dir;
+}
+
+function makeTmpPath(prefix: string): string {
+  return join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 }
 
 function writeMinimalSlopeConfig(cwd: string): void {
@@ -138,17 +142,25 @@ describe('slope guard recommend (S65-3)', () => {
 describe('guardCommand dispatcher path', () => {
   let cwd: string;
   let origCwd: string;
+  let originalCodexWorkdirStore: string | undefined;
 
   beforeEach(() => {
     cwd = makeTmpDir();
     origCwd = process.cwd();
+    originalCodexWorkdirStore = process.env.SLOPE_CODEX_WORKDIR_STORE;
     process.chdir(cwd);
     writeMinimalSlopeConfig(cwd);
+    process.env.SLOPE_CODEX_WORKDIR_STORE = join(cwd, '.slope', 'codex-workdirs');
     setSessionMode(cwd, 'test-session', 'adhoc');
   });
 
   afterEach(() => {
     process.chdir(origCwd);
+    if (originalCodexWorkdirStore === undefined) {
+      delete process.env.SLOPE_CODEX_WORKDIR_STORE;
+    } else {
+      process.env.SLOPE_CODEX_WORKDIR_STORE = originalCodexWorkdirStore;
+    }
     rmSync(cwd, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
@@ -233,6 +245,147 @@ describe('guardCommand dispatcher path', () => {
       expect(worktreeMetrics).toContain('"decision":"silent"');
       expect(existsSync(join(cwd, '.slope', 'guard-metrics.jsonl'))).toBe(false);
     } finally {
+      rmSync(worktreeCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers Codex exec workdir over hook cwd when running branch-before-commit', async () => {
+    initGitRepo(cwd, 'main');
+    const worktreeCwd = makeTmpDir();
+
+    try {
+      writeMinimalSlopeConfig(worktreeCwd);
+      initGitRepo(worktreeCwd, 'feat/codex-workdir');
+
+      const output = await runGuardCommandWithInput(
+        ['branch-before-commit'],
+        makeHookInput(cwd, {
+          session_id: 'explicit-workdir-session',
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'git commit -m "feat: keep worktree branch"',
+            workdir: worktreeCwd,
+          },
+        }),
+      );
+
+      expect(output).toBe('');
+      expect(readFileSync(join(worktreeCwd, '.slope', 'guard-metrics.jsonl'), 'utf8')).toContain('"guard":"branch-before-commit"');
+      expect(existsSync(join(cwd, '.slope', 'guard-metrics.jsonl'))).toBe(false);
+    } finally {
+      rmSync(worktreeCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers and remembers Codex exec workdir from transcript tool_use_id', async () => {
+    initGitRepo(cwd, 'main');
+    const worktreeCwd = makeTmpDir();
+
+    try {
+      writeMinimalSlopeConfig(worktreeCwd);
+      initGitRepo(worktreeCwd, 'feat/codex-transcript-workdir');
+      const transcriptPath = join(cwd, '.slope', 'codex-transcript.jsonl');
+      writeFileSync(transcriptPath, JSON.stringify({
+        type: 'tool_call',
+        id: 'toolu_123',
+        input: {
+          command: 'git commit -m "feat: from transcript"',
+          workdir: worktreeCwd,
+        },
+      }) + '\n');
+
+      const firstOutput = await runGuardCommandWithInput(
+        ['branch-before-commit'],
+        makeHookInput(cwd, {
+          session_id: 'remember-workdir-session',
+          tool_name: 'Bash',
+          tool_input: { command: 'git commit -m "feat: from transcript"' },
+          transcript_path: transcriptPath,
+          tool_use_id: 'toolu_123',
+        }),
+      );
+      expect(readdirSync(join(cwd, '.slope', 'codex-workdirs'))).toHaveLength(1);
+      const secondOutput = await runGuardCommandWithInput(
+        ['branch-before-commit'],
+        makeHookInput(cwd, {
+          session_id: 'remember-workdir-session',
+          tool_name: 'Bash',
+          tool_input: { command: 'git commit -m "feat: remembered"' },
+        }),
+      );
+
+      expect(firstOutput).toBe('');
+      expect(secondOutput).toBe('');
+      const metrics = readFileSync(join(worktreeCwd, '.slope', 'guard-metrics.jsonl'), 'utf8')
+        .trim()
+        .split('\n');
+      expect(metrics).toHaveLength(2);
+      expect(existsSync(join(cwd, '.slope', 'guard-metrics.jsonl'))).toBe(false);
+    } finally {
+      rmSync(worktreeCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('infers the single staged non-main worktree when Codex omits exec workdir', async () => {
+    initGitRepo(cwd, 'main');
+    const worktreeCwd = makeTmpPath('slope-guard-inferred-worktree');
+
+    try {
+      execFileSync('git', ['worktree', 'add', '-q', '-b', 'feat/inferred-workdir', worktreeCwd], { cwd, stdio: 'ignore' });
+      writeMinimalSlopeConfig(worktreeCwd);
+      writeFileSync(join(worktreeCwd, 'feature.txt'), 'ready\n');
+      execFileSync('git', ['add', 'feature.txt'], { cwd: worktreeCwd, stdio: 'ignore' });
+
+      const output = await runGuardCommandWithInput(
+        ['branch-before-commit'],
+        makeHookInput(cwd, {
+          session_id: 'infer-workdir-session',
+          tool_name: 'Bash',
+          tool_input: { command: 'git commit -m "feat: inferred worktree"' },
+        }),
+      );
+
+      expect(output).toBe('');
+      expect(readFileSync(join(worktreeCwd, '.slope', 'guard-metrics.jsonl'), 'utf8')).toContain('"guard":"branch-before-commit"');
+      expect(existsSync(join(cwd, '.slope', 'guard-metrics.jsonl'))).toBe(false);
+    } finally {
+      try {
+        execFileSync('git', ['worktree', 'remove', '--force', worktreeCwd], { cwd, stdio: 'ignore' });
+      } catch { /* ignore */ }
+      rmSync(worktreeCwd, { recursive: true, force: true });
+    }
+  });
+
+  it('routes worktree-check through the edited file repository when hook cwd is another repo', async () => {
+    initGitRepo(cwd, 'main');
+    const worktreeCwd = makeTmpPath('slope-guard-edit-worktree');
+
+    try {
+      execFileSync('git', ['worktree', 'add', '-q', '-b', 'feat/edit-workdir', worktreeCwd], { cwd, stdio: 'ignore' });
+      writeMinimalSlopeConfig(worktreeCwd);
+      mkdirSync(join(worktreeCwd, 'src'), { recursive: true });
+      writeFileSync(join(worktreeCwd, 'src', 'foo.ts'), 'export const foo = 1;\n');
+
+      const output = await runGuardCommandWithInput(
+        ['worktree-check'],
+        makeHookInput(cwd, {
+          session_id: 'worktree-check-edit-session',
+          tool_name: 'Edit',
+          tool_input: {
+            file_path: join(worktreeCwd, 'src', 'foo.ts'),
+            old_string: '1',
+            new_string: '2',
+          },
+        }),
+      );
+
+      expect(output).toBe('');
+      expect(readFileSync(join(worktreeCwd, '.slope', 'guard-metrics.jsonl'), 'utf8')).toContain('"guard":"worktree-check"');
+      expect(existsSync(join(cwd, '.slope', 'guard-metrics.jsonl'))).toBe(false);
+    } finally {
+      try {
+        execFileSync('git', ['worktree', 'remove', '--force', worktreeCwd], { cwd, stdio: 'ignore' });
+      } catch { /* ignore */ }
       rmSync(worktreeCwd, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary
- Normalize Codex guard input to the effective tool cwd before config load, git probes, baselines, and guard dispatch.
- Recover exec workdir from transcript `tool_use_id`, remember recovered workdir per session, and infer a single staged non-main worktree for missing `git commit` workdirs.
- Add cross-repo/worktree regressions for `branch-before-commit` and `worktree-check` plus doctor diagnostics for duplicate project/user Codex hook installs.
- Record S125 as complete in the roadmap and add the sprint scorecard.

Closes #456.
Closes #459.

## Verification
- `pnpm vitest run tests/cli/commands/guard.test.ts tests/cli/commands/doctor.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm run build`
- `pnpm test` (215 passed files, 1 skipped; 3499 passed tests, 23 skipped)
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js roadmap validate`
- `git diff --check`