### PR TITLE
fix: show native SQLite recovery guidance

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -2720,7 +2720,9 @@
       "par": 4,
       "slope": 2,
       "type": "bugfix",
-      "status": "planned",
+      "status": "complete",
+      "score": 3,
+      "score_label": "birdie",
       "depends_on": [
         125
       ],

--- a/docs/retros/sprint-126.json
+++ b/docs/retros/sprint-126.json
@@ -1,0 +1,134 @@
+{
+  "sprint_number": 126,
+  "player": "codex",
+  "theme": "Native Store Error Recovery Guidance",
+  "par": 4,
+  "slope": 2,
+  "score": 3,
+  "score_label": "birdie",
+  "date": "2026-05-29",
+  "shots": [
+    {
+      "ticket_key": "S126-1",
+      "title": "Extract shared CLI error reporter around native SQLite recovery helpers (#460)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added a shared CLI error reporter that formats normal errors consistently and appends the existing native SQLite store recovery suggestions when a better-sqlite3 binding/setup failure is detected."
+    },
+    {
+      "ticket_key": "S126-2",
+      "title": "Route duplicated top-level command catches through the shared reporter (#460)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Replaced the duplicated top-level async command catch blocks in the CLI entrypoint with reportCliError so store-backed commands no longer dump only the raw native binding stack."
+    },
+    {
+      "ticket_key": "S126-3",
+      "title": "Add native-binding failure regressions for common store-backed commands (#460)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added focused formatter/reporter coverage plus a source-shape regression proving common store-backed top-level commands route through the shared reporter and do not reintroduce inline Error-only catches."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 3,
+    "fairways_total": 3,
+    "greens_in_regulation": 3,
+    "greens_total": 3,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "bugfix",
+  "conditions": [
+    {
+      "type": "workflow",
+      "impact": "minor",
+      "description": "Implemented after PR #462 merged and main was synced."
+    },
+    {
+      "type": "release",
+      "impact": "minor",
+      "description": "Scoped to issue #460 so the follow-up release sprint can publish S125 and S126 together."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Native store recovery guidance belongs at the CLI error boundary, not only inside one store subcommand.",
+      "outcome": "Top-level commands now share reportCliError, which can enrich native SQLite setup failures without each command learning store-specific recovery logic."
+    },
+    {
+      "type": "lessons",
+      "description": "CLI entrypoints with process.exit side effects are easier to protect with formatting-unit tests plus narrow source-shape regressions.",
+      "outcome": "The tests cover formatCliError/reportCliError behavior directly and guard the common store-backed command registrations against drifting back to inline Error-only catches."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused native reporter/store tests, typecheck, build, and full pnpm test passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "workflow",
+      "description": "S126 closes issue #460 and clears the planned S127 patch release for the Codex runtime fixes.",
+      "status": "healthy"
+    },
+    {
+      "category": "concurrency",
+      "description": "The known untracked .codex/ state was left untouched.",
+      "status": "watch"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Clean and nicely bounded: the existing recovery copy was already good, it just needed to reach the callers where users actually hit the failure.",
+    "advice_for_next_player": "Keep specialized recovery hints behind shared error boundaries so new commands inherit them by default.",
+    "what_surprised_you": "The CLI entrypoint simplified substantially once the repeated catch blocks moved to one reporter.",
+    "excited_about_next": "S127 can be a straight patch release sprint for the S125/S126 Codex runtime fixes."
+  },
+  "bunker_locations": [
+    "Do not duplicate top-level command catch blocks that only print err.message; they can bypass richer recovery guidance.",
+    "Keep native SQLite setup detection behind storeRecoverySuggestions so the message-matching policy remains centralized.",
+    "Source-shape regressions around CLI registration should stay narrow and focused on high-value drift."
+  ],
+  "yardage_book_updates": [
+    "src/cli/error-reporter.ts now owns formatCliError and reportCliError for top-level CLI failures.",
+    "Common async command registrations in src/cli/index.ts now use .catch(reportCliError).",
+    "Native SQLite binding/setup failures now include the existing store recovery suggestions from top-level commands.",
+    "tests/cli/error-reporter.test.ts covers formatter output, process-exit reporting, and command registration drift."
+  ],
+  "course_management_notes": [
+    "Committed shared reporter and CLI catch routing as 223b980: fix(S126-1): report native SQLite recovery hints.",
+    "Committed routing regression coverage as a0fd02a: test(S126-3): cover native recovery reporter routing.",
+    "Focused Vitest run passed: tests/cli/error-reporter.test.ts and tests/cli/store.test.ts, 18 tests.",
+    "pnpm exec tsc --noEmit passed.",
+    "pnpm run build passed.",
+    "pnpm test passed: 216 passed test files, 1 skipped test file, 3503 passed tests, and 23 skipped tests."
+  ],
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "slope-performance-analysis"
+  ],
+  "skill_gaps_found": [],
+  "slope_factors": [
+    "native_sqlite_recovery",
+    "shared_cli_error_boundary",
+    "top_level_command_routing",
+    "source_shape_regression"
+  ]
+}

--- a/src/cli/error-reporter.ts
+++ b/src/cli/error-reporter.ts
@@ -1,0 +1,21 @@
+import { storeRecoverySuggestions } from './commands/store.js';
+
+export function formatCliError(err: unknown, cwd = process.cwd()): string[] {
+  const message = err instanceof Error ? err.message : String(err);
+  const lines = [`Error: ${message}`];
+  const recovery = storeRecoverySuggestions(message, cwd);
+  if (recovery.length > 0) {
+    lines.push('Recovery:');
+    for (const suggestion of recovery) {
+      lines.push(`  - ${suggestion}`);
+    }
+  }
+  return lines;
+}
+
+export function reportCliError(err: unknown): never {
+  for (const line of formatCliError(err)) {
+    console.error(line);
+  }
+  process.exit(1);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -75,6 +75,7 @@ import { orgCommand } from './commands/org.js';
 import { memoryCommand } from './commands/memory.js';
 import { phaseCommand } from './commands/phase.js';
 import { skillsCommand } from './commands/skills.js';
+import { reportCliError } from './error-reporter.js';
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -114,16 +115,10 @@ if (subcommand === '--version') {
 
 switch (subcommand) {
   case 'init':
-    initCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    initCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'interview':
-    interviewCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    interviewCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'card':
     cardCommand(process.argv.slice(3));
@@ -134,10 +129,7 @@ switch (subcommand) {
   case 'review': {
     const reviewArgs = process.argv.slice(3);
     if (shouldRouteToReviewState(reviewArgs)) {
-      reviewStateCommand(reviewArgs).catch(err => {
-        console.error('Error:', err.message);
-        process.exit(1);
-      });
+      reviewStateCommand(reviewArgs).catch(reportCliError);
     } else {
       const plainFlag = reviewArgs.includes('--plain');
       const metaphorArg = reviewArgs.find((a: string) => a.startsWith('--metaphor='));
@@ -148,10 +140,7 @@ switch (subcommand) {
     break;
   }
   case 'briefing':
-    briefingCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    briefingCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'plan':
     planCommand(process.argv.slice(3));
@@ -160,308 +149,161 @@ switch (subcommand) {
     classifyCommand(process.argv.slice(3));
     break;
   case 'claim':
-    claimCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    claimCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'release':
-    releaseCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    releaseCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'status':
-    statusCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    statusCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'tournament':
     tournamentCommand(process.argv.slice(3));
     break;
   case 'auto-card':
-    autoCardCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    autoCardCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'hook':
-    hookCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    hookCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'session':
-    sessionCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    sessionCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'next':
     nextCommand();
     break;
   case 'agent':
-    agentCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    agentCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'ticket':
-    ticketCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    ticketCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'gate':
-    gateCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    gateCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'commit-ready':
-    commitReadyCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    commitReadyCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'pr':
-    prCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    prCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'roadmap':
-    roadmapCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    roadmapCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'retro':
-    retroCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    retroCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'extract':
-    extractCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    extractCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'distill':
-    distillCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    distillCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'report':
-    reportCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    reportCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'standup':
-    standupCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    standupCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'escalate':
-    escalateCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    escalateCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'guard': {
     const guardArgs = process.argv.slice(3);
     const guardSub = guardArgs[0];
     if (guardSub === 'list' || guardSub === 'status' || guardSub === 'enable' || guardSub === 'disable' || guardSub === 'docs' || guardSub === 'audit' || guardSub === 'recommend' || guardSub === 'metrics' || guardSub === 'check') {
-      guardManageCommand(guardArgs).catch(err => {
-        console.error('Error:', err.message);
-        process.exit(1);
-      });
+      guardManageCommand(guardArgs).catch(reportCliError);
     } else {
-      guardCommand(guardArgs).catch(err => {
-        console.error('Error:', err.message);
-        process.exit(1);
-      });
+      guardCommand(guardArgs).catch(reportCliError);
     }
     break;
   }
   case 'plugin':
-    pluginCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    pluginCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'dashboard':
-    dashboardCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    dashboardCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'map':
-    mapCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    mapCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'flows':
-    flowsCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    flowsCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'workflow':
-    workflowCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    workflowCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'inspirations':
-    inspirationsCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    inspirationsCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'analyze':
-    analyzeCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    analyzeCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'vision':
-    visionCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    visionCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'transcript':
-    transcriptCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    transcriptCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'store':
-    storeCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    storeCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'metaphor':
-    metaphorCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    metaphorCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'initiative':
-    initiativeCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    initiativeCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'index':
-    indexCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    indexCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'context':
-    contextCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    contextCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'prep':
-    prepCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    prepCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'enrich':
-    enrichCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    enrichCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'stats':
-    statsCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    statsCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'docs':
-    docsCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    docsCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'loop':
-    loopCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    loopCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'sprint':
-    sprintCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    sprintCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'phase':
-    phaseCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    phaseCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'skills':
-    skillsCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    skillsCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'doctor':
-    doctorCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    doctorCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'version':
-    versionCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    versionCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'help':
-    helpCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    helpCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'quickstart':
-    quickstartCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    quickstartCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'worktree':
-    worktreeCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    worktreeCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'org':
-    orgCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    orgCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'memory':
-    memoryCommand(process.argv.slice(3)).catch(err => {
-      console.error('Error:', err.message);
-      process.exit(1);
-    });
+    memoryCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   default:
     console.log(`

--- a/tests/cli/error-reporter.test.ts
+++ b/tests/cli/error-reporter.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { formatCliError } from '../../src/cli/error-reporter.js';
+import { formatCliError, reportCliError } from '../../src/cli/error-reporter.js';
 
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), 'slope-error-reporter-'));
@@ -39,5 +39,40 @@ describe('formatCliError', () => {
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
+  });
+
+  it('prints formatted recovery guidance before exiting', () => {
+    const cwd = makeTmpDir();
+    const originalCwd = process.cwd();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+
+    try {
+      process.chdir(cwd);
+      writeFileSync(join(cwd, 'package-lock.json'), '{}\n');
+
+      expect(() => reportCliError(new Error('ERR_DLOPEN_FAILED: better_sqlite3.node'))).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const output = errorSpy.mock.calls.map(call => call.join(' ')).join('\n');
+      expect(output).toContain('Error: ERR_DLOPEN_FAILED');
+      expect(output).toContain('Recovery:');
+      expect(output).toContain('npm ci');
+    } finally {
+      process.chdir(originalCwd);
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('routes common store-backed top-level CLI commands through the shared reporter', () => {
+    const indexSource = readFileSync(join(process.cwd(), 'src', 'cli', 'index.ts'), 'utf8');
+
+    for (const command of ['briefingCommand', 'claimCommand', 'statusCommand', 'autoCardCommand', 'sessionCommand', 'agentCommand']) {
+      expect(indexSource).toContain(`${command}(process.argv.slice(3)).catch(reportCliError);`);
+    }
+    expect(indexSource).not.toContain("console.error('Error:', err.message)");
   });
 });

--- a/tests/cli/error-reporter.test.ts
+++ b/tests/cli/error-reporter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { formatCliError } from '../../src/cli/error-reporter.js';
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'slope-error-reporter-'));
+}
+
+describe('formatCliError', () => {
+  it('adds native SQLite recovery suggestions to top-level CLI errors', () => {
+    const cwd = makeTmpDir();
+    try {
+      writeFileSync(join(cwd, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+      writeFileSync(join(cwd, 'package.json'), JSON.stringify({ engines: { node: '>=22 <23' } }));
+
+      const lines = formatCliError(
+        new Error("Could not locate the bindings file. Tried: /tmp/better_sqlite3.node"),
+        cwd,
+      );
+
+      expect(lines[0]).toContain('Could not locate the bindings file');
+      expect(lines).toContain('Recovery:');
+      expect(lines).toContain('  - Install this worktree\'s dependencies first: pnpm install.');
+      expect(lines.join('\n')).toContain('package.json engines.node (>=22 <23)');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps non-native errors concise', () => {
+    const cwd = makeTmpDir();
+    try {
+      mkdirSync(join(cwd, 'node_modules'), { recursive: true });
+      const lines = formatCliError(new Error('ordinary failure'), cwd);
+
+      expect(lines).toEqual(['Error: ordinary failure']);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared CLI error reporter that reuses store native SQLite recovery suggestions
- route top-level async CLI command catches through the shared reporter
- add regressions for native recovery formatting and common store-backed command routing

Closes #460.

## Verification
- `pnpm vitest run tests/cli/error-reporter.test.ts tests/cli/store.test.ts` (18 tests)
- `pnpm exec tsc --noEmit`
- `pnpm run build`
- `pnpm test` (216 passed, 1 skipped; 3503 passed, 23 skipped)
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js roadmap validate`
- `git diff --check`