### PR TITLE
[codex] Prepare v1.57.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
## Summary
- bump `@slope-dev/slope` from 1.57.0 to 1.57.1
- keep the bundled Codex plugin manifest version aligned with the package version

## Verification
- `pnpm run build`
- `pnpm exec tsc --noEmit`
- `pnpm test` (216 passed, 1 skipped; 3503 passed, 23 skipped)
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js version` (`@slope-dev/slope v1.57.1`)
- `git diff --check`
- `npm pack --dry-run` (`@slope-dev/slope@1.57.1`, 1026 files, 930.1 kB package size, 4.3 MB unpacked)