### PR TITLE
Fix closeout review help and auto-card scope mapping

### DIFF
--- a/src/cli/commands/auto-card.ts
+++ b/src/cli/commands/auto-card.ts
@@ -101,8 +101,30 @@ export function matchSprintTicket(
     return null;
   }
 
-  // 4. No reference to this sprint at all — drop
+  // 4. Sprint-scoped workflow follow-ups such as `S130-review` or
+  // `S130-follow-up` belong to the sprint, even though they are not roadmap
+  // ticket ids. Assign them positionally so they are not filtered as unrelated
+  // closeout commits (#471).
+  if (isSprintWorkflowScope(subject, sprintNumber)) {
+    while (positionalCursor.next < allowedKeys.length) {
+      return allowedKeys[positionalCursor.next++];
+    }
+    return null;
+  }
+
+  // 5. No reference to this sprint at all — drop
   return null;
+}
+
+function isSprintScopedSubject(subject: string, sprintNumber: number): boolean {
+  const sprintToken = escapeRegex(formatSprintNumber(sprintNumber));
+  return new RegExp(`[(\\s+]S${sprintToken}(?![-.\\d])`, 'i').test(subject)
+    || isSprintWorkflowScope(subject, sprintNumber);
+}
+
+function isSprintWorkflowScope(subject: string, sprintNumber: number): boolean {
+  const sprintToken = escapeRegex(formatSprintNumber(sprintNumber));
+  return new RegExp(`\\bS${sprintToken}[-_](?:review|follow[-_]?up|closeout)\\b`, 'i').test(subject);
 }
 
 function inferClub(filesChanged: number): ShotRecord['club'] {
@@ -188,6 +210,14 @@ export async function autoCardCommand(args: string[]): Promise<void> {
       }
       if (dropped.length > 5) console.error(`    ... and ${dropped.length - 5} more`);
       console.error(`  Use --include-untracked to keep them as synthetic shots.\n`);
+    }
+
+    const matchedKeySet = new Set(keptKeys);
+    const unmatchedKeys = allowedKeys.filter(key => !matchedKeySet.has(key));
+    if (unmatchedKeys.length > 0 && allCommits.some(c => isSprintScopedSubject(c.subject, sprintNumber))) {
+      console.error(`  Warning: matched ${matchedKeySet.size}/${allowedKeys.length} S${formatSprintNumber(sprintNumber)} roadmap ticket(s).`);
+      console.error(`  Sprint-scoped commits such as \`feat(S${formatSprintNumber(sprintNumber)})\` or \`fix(S${formatSprintNumber(sprintNumber)}-review)\` are assigned positionally and may undercount multi-ticket closeout work.`);
+      console.error(`  Review the generated scorecard manually; unmatched roadmap ticket(s): ${unmatchedKeys.join(', ')}.\n`);
     }
 
     if (kept.length === 0) {

--- a/src/cli/commands/review-state.ts
+++ b/src/cli/commands/review-state.ts
@@ -688,7 +688,13 @@ Run a structured review pass on the current sprint plan or PR. Pass
 \`--help\` after \`run\` for full options.`);
       break;
     default:
-      console.log(`Usage: slope review <subcommand> [options]
+      console.log(`Usage:
+  slope review [scorecard.json] [--plain] [--metaphor=<name>]
+  slope review <subcommand> [options]
+
+Retrospective:
+  Format sprint retrospective markdown from a scorecard. Defaults to the
+  latest scorecard when no scorecard path is provided.
 
 Subcommands:
   start       Start a review (auto-detects tier or use --rounds/--tier)

--- a/tests/cli/commands/auto-card.test.ts
+++ b/tests/cli/commands/auto-card.test.ts
@@ -40,6 +40,13 @@ describe('matchSprintTicket (#352 helper)', () => {
     expect(matchSprintTicket('feat(S1): umbrella two', 1, allowedKeys, cursor)).toBe('S1-2');
   });
 
+  it('treats sprint review/follow-up scopes as sprint-owned closeout commits', () => {
+    const cursor = { next: 0 };
+    expect(matchSprintTicket('fix(S1-review): tighten shell parsing', 1, allowedKeys, cursor)).toBe('S1-1');
+    expect(matchSprintTicket('fix(S1-follow-up): address review', 1, allowedKeys, cursor)).toBe('S1-2');
+    expect(matchSprintTicket('fix(S2-review): other sprint review', 1, allowedKeys, cursor)).toBeNull();
+  });
+
   it('returns null once positional cursor exhausts the allowed keys', () => {
     const cursor = { next: 3 }; // already past the last allowed key
     expect(matchSprintTicket('feat(S1): one too many', 1, allowedKeys, cursor)).toBeNull();
@@ -142,6 +149,30 @@ describe('slope auto-card --dry-run roadmap filtering (#352)', () => {
       expect(combined).toMatch(/Filtered 1 commit/);
       expect(combined).toContain('chore: unrelated cleanup');
       expect(combined).toContain('--include-untracked');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('warns when sprint-scoped commits do not cover every roadmap ticket', () => {
+    const cwd = setupRepoWithRoadmap();
+    try {
+      commitWith(cwd, 'feat(S1): broad implementation');
+      commitWith(cwd, 'fix(S1-review): review follow-up');
+
+      const combined = execSync(
+        `node ${SLOPE_BIN} auto-card --sprint=1 --dry-run 2>&1`,
+        { cwd, encoding: 'utf8', shell: '/bin/sh' },
+      );
+      const jsonStart = combined.indexOf('{');
+      expect(jsonStart).toBeGreaterThanOrEqual(0);
+      const card = JSON.parse(combined.slice(jsonStart).trim());
+      const keys = (card.shots as Array<{ ticket_key: string }>).map(s => s.ticket_key);
+
+      expect(keys).toEqual(['S1-1', 'S1-2']);
+      expect(combined).toContain('matched 2/3 S1 roadmap ticket');
+      expect(combined).toContain('may undercount multi-ticket closeout work');
+      expect(combined).toContain('S1-3');
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/cli/review-state.test.ts
+++ b/tests/cli/review-state.test.ts
@@ -148,7 +148,9 @@ describe('reviewStateCommand', () => {
       try {
         await runCommand(['--help']);
         const helpText = log.mock.calls.map(c => c[0] as string).join('\n');
-        expect(helpText).toMatch(/Usage: slope review <subcommand>/);
+        expect(helpText).toMatch(/slope review \[scorecard\.json\]/);
+        expect(helpText).toMatch(/slope review <subcommand>/);
+        expect(helpText).toContain('Format sprint retrospective markdown');
         expect(helpText).toContain('start');
         expect(helpText).toContain('round');
         expect(helpText).toContain('findings');


### PR DESCRIPTION
## Summary

- Expose the scorecard retrospective generation path in `slope review --help` so users can discover the plain scorecard review flow without knowing subcommands.
- Treat sprint review/follow-up/closeout scopes as sprint-owned closeout commits in auto-card ticket matching.
- Warn when broad sprint-scoped commits are assigned positionally but leave roadmap tickets unmatched, so users can manually review potential undercounting.

## Validation

- `pnpm run build`
- `pnpm vitest run tests/cli/review-state.test.ts tests/cli/commands/auto-card.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm run typecheck`
- `pnpm test`
- `slope roadmap validate`

Closes #470.
Closes #471.
