### PR TITLE
[codex] Prepare v1.57.2 release

### DIFF
--- a/docs/retros/sprint-130.json
+++ b/docs/retros/sprint-130.json
@@ -135,8 +135,7 @@
     "GitHub checks for PR #469 passed after the review fix: ci, CodeQL, CodeRabbit, and GitGuardian."
   ],
   "skills_used": [
-    "slope-sprint-workflow",
-    "github:yeet"
+    "slope-sprint-workflow"
   ],
   "skills_recommended": [
     "slope-sprint-workflow"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.57.1",
+  "version": "1.57.2",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.57.1",
+  "version": "1.57.2",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
## Summary

- Bump `@slope-dev/slope` from `1.57.1` to `1.57.2`.
- Keep the bundled Codex plugin manifest aligned with the package version.
- Fix the S130 scorecard `skills_used` metadata so `validate --skills` passes before release.

## Validation

- `pnpm run build`
- `pnpm exec tsc --noEmit`
- `pnpm run typecheck`
- `pnpm test` (219 passed, 1 skipped; 3532 passed, 25 skipped)
- `node dist/cli/index.js validate --skills`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js version` (`@slope-dev/slope v1.57.2`)
- `git diff --check`
- `npm pack --dry-run` (`@slope-dev/slope@1.57.2`, 1030 files, 941.5 kB package size, 4.4 MB unpacked)
