### PR TITLE
docs(S131): record guard recovery patch release

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -2961,6 +2961,9 @@
       "par": 3,
       "slope": 1,
       "type": "release",
+      "status": "complete",
+      "score": 3,
+      "score_label": "par",
       "depends_on": [
         130
       ],

--- a/docs/retros/sprint-131.json
+++ b/docs/retros/sprint-131.json
@@ -1,0 +1,137 @@
+{
+  "sprint_number": 131,
+  "player": "codex",
+  "theme": "Guard Recovery Patch Release",
+  "par": 3,
+  "slope": 1,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-05-31",
+  "shots": [
+    {
+      "ticket_key": "S131-1",
+      "title": "Bump @slope-dev/slope and bundled Codex plugin for the guard recovery patch release",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Release validation caught the S130 scorecard referencing an external GitHub plugin skill that is not in the repo skill registry; the scorecard metadata was corrected before publishing."
+        }
+      ],
+      "notes": "Used scripts/version-bump.mjs to move package.json and the bundled Codex plugin manifest from 1.57.1 to 1.57.2, then fixed the S130 skills_used metadata so validate --skills passed."
+    },
+    {
+      "ticket_key": "S131-2",
+      "title": "Run release validation, publish the patch release, and verify npm",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Merged PR #473, published GitHub release v1.57.2, watched the trusted-publisher npm workflow pass, verified npm latest is 1.57.2, and smoke-tested the installed package."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 2,
+    "fairways_total": 2,
+    "greens_in_regulation": 2,
+    "greens_total": 2,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "type": "release",
+  "conditions": [
+    {
+      "type": "workflow",
+      "impact": "minor",
+      "description": "The release branch included a small scorecard metadata correction because the merged S130 closeout had passed normal validation but failed skill-aware release validation."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "External plugin skill names should not be recorded in scorecard skills_used unless the repo skill registry can validate them.",
+      "outcome": "S131 removed the invalid github:yeet skill reference from S130 and preserved GitHub usage in narrative notes instead."
+    },
+    {
+      "type": "lessons",
+      "description": "Release closeout should wait for npm metadata and installed-package verification.",
+      "outcome": "S131 completed only after npm latest returned 1.57.2 and npm exec ran the published slope binary successfully."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Build, typecheck, full pnpm test, SLOPE validation, roadmap validation, map check, whitespace check, npm pack dry run, PR CI, and release workflow tests passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "release",
+      "description": "GitHub release v1.57.2 and npm trusted publishing completed successfully; npm latest now resolves to 1.57.2.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Mostly clean: the release machinery worked, and the only adjustment was a useful skill-validation catch from the previous sprint scorecard.",
+    "advice_for_next_player": "Keep validate --skills in the release gate, and keep scorecard skills_used limited to skills present in .slope/skills.json.",
+    "what_surprised_you": "The external GitHub plugin skill reference was valid in the Codex session but not in SLOPE's repo-local skill registry.",
+    "excited_about_next": "The guard recovery and closeout fixes are now available from npm, so the next sprint can move back to planned roadmap work."
+  },
+  "bunker_locations": [
+    "Scorecard skills_used currently validates against the repo skill registry, not every plugin skill available in the Codex runtime.",
+    "Release scorecards should wait for registry verification before claiming publish success."
+  ],
+  "yardage_book_updates": [
+    "Version bump path remains node scripts/version-bump.mjs <version>, updating package.json and templates/codex/plugins/slope/.codex-plugin/plugin.json together.",
+    "The v1.57.2 release path uses GitHub release publishing with npm trusted publisher OIDC.",
+    "npm exec --yes --package @slope-dev/slope@<version> -- slope version remains the installed-package smoke test.",
+    "Keep node dist/cli/index.js validate --skills in the release gate because normal validation does not catch unknown skill references."
+  ],
+  "course_management_notes": [
+    "PR #472 merged on 2026-05-31 at commit 20bc62a2b020370e0192216755c848c7072db774 and closed #470 and #471.",
+    "Before release, npm latest reported 1.57.1.",
+    "Bumped @slope-dev/slope and templates/codex/plugins/slope/.codex-plugin/plugin.json from 1.57.1 to 1.57.2.",
+    "Committed the version bump as be6ca53: chore(S131-1): bump release version to 1.57.2.",
+    "node dist/cli/index.js validate --skills initially failed because S130 referenced github:yeet in skills_used.",
+    "Corrected docs/retros/sprint-130.json and committed the fix as 2dbcc92: docs(S131-2): fix S130 skill validation.",
+    "pnpm run build passed locally.",
+    "pnpm exec tsc --noEmit passed locally.",
+    "pnpm run typecheck passed locally.",
+    "pnpm test passed locally: 219 test files passed, 1 skipped test file, 3532 passed tests, and 25 skipped tests.",
+    "node dist/cli/index.js validate --skills passed after the S130 metadata correction.",
+    "node dist/cli/index.js roadmap validate passed with standing roadmap warnings only.",
+    "node dist/cli/index.js map --check passed: Overall CURRENT.",
+    "node dist/cli/index.js version returned @slope-dev/slope v1.57.2.",
+    "git diff --check passed.",
+    "npm pack --dry-run passed for @slope-dev/slope@1.57.2 with 1030 files, package size 941.5 kB, and unpacked size 4.4 MB.",
+    "PR #473 merged on 2026-05-31 at commit 20b7aea281923702cd2447fac981c9dc21d512da.",
+    "GitHub release v1.57.2 published on 2026-05-31: https://github.com/srbryers/slope/releases/tag/v1.57.2.",
+    "Publish to npm workflow run 26712031923 passed in 2m40s.",
+    "npm view @slope-dev/slope version returned 1.57.2 and the latest dist-tag points to 1.57.2.",
+    "npm view @slope-dev/slope@1.57.2 recorded publish time 2026-05-31T12:03:31.901Z, integrity sha512-1/bx7v+IMfhub2MNkApodvwIPWM+ZhC01cu0jKN/rvN99yVJrlVn8wCJDffmxo+jCfJ//7EjnOVDC61Mxjg8FQ==, and shasum 876411d0440f65139d1b5724884907a111a74c64.",
+    "npm exec --yes --package @slope-dev/slope@1.57.2 -- slope version returned @slope-dev/slope v1.57.2."
+  ],
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "slope-performance-analysis"
+  ],
+  "skill_gaps_found": [],
+  "slope_factors": [
+    "patch_release",
+    "trusted_publisher_release",
+    "registry_verification",
+    "scorecard_metadata_repair"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add the S131 release scorecard for the v1.57.2 guard recovery patch release.
- Mark S131 complete in the roadmap with par score metadata.

## Validation

- `slope validate docs/retros/sprint-131.json --skills`
- `slope validate --skills`
- `slope roadmap validate`
- `git diff --check`
