### PR TITLE
fix(#474): silence duplicate hazard context

### DIFF
--- a/src/cli/guards/hazard.ts
+++ b/src/cli/guards/hazard.ts
@@ -129,9 +129,15 @@ export async function hazardGuard(input: HookInput, cwd: string): Promise<GuardR
 
     const fullContext = formatHazardContext(area, allWarnings);
 
-    // Session dedup: if this exact context was already injected, return compressed reference
+    // Duplicate hazard payloads add transcript noise on Edit/Write; record the
+    // dedup metric but do not inject another context block.
     const dedup = dedupGuardContext(cwd, input.session_id, 'hazard', fullContext);
-    if (dedup) return { context: dedup, metricReason: 'deduped' };
+    if (dedup) {
+      if (dedup.startsWith('SLOPE hazard: (same as prior warning')) {
+        return { metricReason: 'deduped' };
+      }
+      return { context: dedup, metricReason: 'deduped' };
+    }
 
     return { context: fullContext, metricReason: 'matched' };
   }

--- a/tests/cli/commands/guard.test.ts
+++ b/tests/cli/commands/guard.test.ts
@@ -206,6 +206,43 @@ describe('guardCommand dispatcher path', () => {
     });
   });
 
+  it('does not emit hook output for duplicate hazard context', async () => {
+    writeFileSync(join(cwd, '.slope', 'common-issues.json'), JSON.stringify({
+      recurring_patterns: [
+        {
+          id: 1,
+          title: 'Core issue',
+          category: 'testing',
+          sprints_hit: [8],
+          gotcha_refs: [],
+          description: 'Affects core package testing',
+          prevention: 'Run tests after editing core',
+        },
+      ],
+    }));
+
+    const input = makeHookInput(cwd, {
+      tool_input: { file_path: join(cwd, 'packages/core/src/foo.ts') },
+    });
+
+    const first = await runGuardCommandWithInput(['hazard'], input);
+    const firstParsed = JSON.parse(first);
+    expect(firstParsed.hookSpecificOutput.additionalContext).toContain('SLOPE hazards');
+
+    const second = await runGuardCommandWithInput(['hazard'], input);
+    expect(second).toBe('');
+
+    const metrics = readFileSync(join(cwd, '.slope', 'guard-metrics.jsonl'), 'utf8')
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line));
+    expect(metrics.at(-1)).toMatchObject({
+      guard: 'hazard',
+      decision: 'silent',
+      reason: 'deduped',
+    });
+  });
+
   it('keeps claim-required effective when batched with suppressed write guards', async () => {
     const output = await runGuardCommandWithInput(
       ['__batch', 'workflow-step-gate', 'claim-required'],

--- a/tests/cli/guards.test.ts
+++ b/tests/cli/guards.test.ts
@@ -342,7 +342,7 @@ describe('hazardGuard', () => {
     expect(result.blockReason).toBeUndefined();
   });
 
-  it('tags repeated hazard context as deduped for metrics', async () => {
+  it('silences repeated hazard context and tags it as deduped for metrics', async () => {
     mkdirSync(join(tmpDir, '.slope'), { recursive: true });
     writeFileSync(join(tmpDir, '.slope/common-issues.json'), JSON.stringify({
       recurring_patterns: [
@@ -363,7 +363,7 @@ describe('hazardGuard', () => {
     const second = await hazardGuard(input, tmpDir);
 
     expect(first.metricReason).toBe('matched');
-    expect(second.context).toContain('same as prior warning');
+    expect(second.context).toBeUndefined();
     expect(second.metricReason).toBe('deduped');
   });
 


### PR DESCRIPTION
## Summary

- Silence duplicate hazard guard context after the first matching injection in a session
- Preserve dedup metrics as silent events so guard metrics still show repeated matches
- Add unit and dispatcher coverage for the duplicate hazard path

Fixes #474

## Verification

- pnpm exec vitest run tests/cli/guards.test.ts tests/cli/commands/guard.test.ts
- pnpm run typecheck
- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Duplicate hazard warnings are now silently suppressed on subsequent occurrences. When the same hazard is detected multiple times in a session, only the first occurrence is displayed, eliminating redundant warning messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->