### PR TITLE
fix(#477): prefer safe worktree location

### DIFF
--- a/src/cli/commands/worktree.ts
+++ b/src/cli/commands/worktree.ts
@@ -448,7 +448,7 @@ Options:
   start:
     --branch=<name>      New branch name for the worktree
     --base=<ref>         Base ref (default: origin default branch, main, or HEAD)
-    --path=<path>        Worktree path (default: .slope/worktrees/<branch>)
+    --path=<path>        Worktree path (default: .slope/worktrees/<branch>, outside Claude Code's protected .claude/ tree)
     --role=<role>        Session role: primary, secondary, observer (default: secondary)
     --ide=<id>           IDE/harness id (default: SLOPE_IDE or unknown)
     --target=<claim>     Optional ticket or area claim to register

--- a/src/cli/guards/docs.ts
+++ b/src/cli/guards/docs.ts
@@ -129,7 +129,7 @@ export const GUARD_DOCS: Record<string, GuardDoc> = {
   'worktree-check': {
     purpose: 'Blocks concurrent sessions from operating in the same directory without worktree isolation. Prevents file conflicts between agents.',
     triggers: 'PreToolUse on Read, Glob, Grep, Edit, Write, Bash. Fires on most tool calls.',
-    behavior: 'Block — if another session is active in the same directory, denies the tool call and requires `EnterWorktree` for isolation.',
+    behavior: 'Block — if another session is active in the same directory, denies the tool call and points agents to `slope worktree start`, which defaults to `.slope/worktrees/` outside Claude Code\'s protected `.claude/` tree.',
     configuration: 'Disable: add "worktree-check" to guidance.disabled.',
     level: 'full',
   },

--- a/src/cli/guards/worktree-check.ts
+++ b/src/cli/guards/worktree-check.ts
@@ -122,7 +122,7 @@ export async function worktreeCheckGuard(input: HookInput, cwd: string): Promise
       // Do NOT write sentinel — denied sessions should re-check next invocation
       return {
         decision: 'deny',
-        blockReason: `BLOCKED: Another session is active in this directory:\n${sessionList}\n\nYou MUST use \`EnterWorktree\` to create an isolated working copy before proceeding. If this harness does not expose EnterWorktree, run \`slope worktree start --branch=<branch> --role=secondary --ide=<ide>\` from the primary checkout. If the listed session is stale, run \`slope session list\` and then \`slope session end --session-id=<id>\`. Do not attempt implementation work until you are in a worktree.`,
+        blockReason: `BLOCKED: Another session is active in this directory:\n${sessionList}\n\nCreate an isolated working copy before proceeding:\n  slope worktree start --branch=<branch> --role=secondary --ide=<ide>\n\nSLOPE worktrees default to .slope/worktrees/<branch>, outside Claude Code's protected .claude/ tree. Avoid Claude Code's native .claude/worktrees/ default because ordinary source edits there can trigger self-configuration permission prompts. If the listed session is stale, run \`slope session list\` and then \`slope session end --session-id=<id>\`. Do not attempt implementation work until you are in a worktree.`,
       };
     }
 

--- a/src/cli/guards/worktree-reuse.ts
+++ b/src/cli/guards/worktree-reuse.ts
@@ -3,6 +3,9 @@ import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 import type { HookInput, GuardResult } from '../../core/index.js';
 
+const SAFE_WORKTREE_DIR = '.slope/worktrees';
+const CLAUDE_PROTECTED_WORKTREE_DIR = '.claude/worktrees';
+
 /**
  * Worktree-reuse guard: fires PreToolUse on EnterWorktree.
  * When the requested worktree name already exists, injects context
@@ -15,11 +18,13 @@ export async function worktreeReuseGuard(input: HookInput, cwd: string): Promise
 
   // Check if a worktree with this name already exists
   const projectDir = resolveProjectDir(cwd);
-  const worktreePath = join(projectDir, '.claude', 'worktrees', name);
+  const safeWorktreePath = join(projectDir, SAFE_WORKTREE_DIR, name);
+  const existing = findExistingWorktree(projectDir, name);
 
-  if (!existsSync(worktreePath)) return {};
+  if (!existing) return {};
 
   // Worktree exists — check its state
+  const { path: worktreePath, isClaudeProtected } = existing;
   let branch = 'unknown';
   let behind = 0;
   let baseBranch = 'main';
@@ -48,6 +53,25 @@ export async function worktreeReuseGuard(input: HookInput, cwd: string): Promise
     ? `\n\nThe worktree is ${behind} commit(s) behind origin/${baseBranch}. To sync:\n  cd "${worktreePath}" && git rebase origin/${baseBranch}`
     : '';
 
+  if (isClaudeProtected) {
+    const branchArg = branch === 'unknown' ? '<branch>' : branch;
+    return {
+      decision: 'deny',
+      blockReason: [
+        `SLOPE: Worktree "${name}" already exists under Claude Code's protected config tree: ${worktreePath} (branch: ${branch}).`,
+        '',
+        `Claude Code treats paths under .claude/ as self-configuration edits, so ordinary source edits there can prompt on every Edit/Write.`,
+        '',
+        `Prefer SLOPE worktrees outside .claude/:`,
+        `  slope worktree start --branch=${branchArg} --path="${join(SAFE_WORKTREE_DIR, name)}" --role=secondary --ide=claude-code`,
+        '',
+        `To relocate the existing worktree:`,
+        `  mkdir -p "${join(projectDir, SAFE_WORKTREE_DIR)}" && git worktree move "${worktreePath}" "${safeWorktreePath}"`,
+        syncHint,
+      ].join('\n'),
+    };
+  }
+
   return {
     decision: 'deny',
     blockReason: [
@@ -61,6 +85,14 @@ export async function worktreeReuseGuard(input: HookInput, cwd: string): Promise
       `  git worktree remove "${worktreePath}"`,
     ].join('\n'),
   };
+}
+
+function findExistingWorktree(projectDir: string, name: string): { path: string; isClaudeProtected: boolean } | null {
+  const candidates = [
+    { path: join(projectDir, SAFE_WORKTREE_DIR, name), isClaudeProtected: false },
+    { path: join(projectDir, CLAUDE_PROTECTED_WORKTREE_DIR, name), isClaudeProtected: true },
+  ];
+  return candidates.find(candidate => existsSync(candidate.path)) ?? null;
 }
 
 /** Resolve the project root (handles being inside a worktree) */
@@ -80,16 +112,18 @@ function resolveProjectDir(cwd: string): string {
 /** List existing persistent worktrees with status info */
 export function listWorktrees(cwd: string): Array<{ name: string; path: string; branch: string; behind: number }> {
   const projectDir = resolveProjectDir(cwd);
-  const worktreeDir = join(projectDir, '.claude', 'worktrees');
-  if (!existsSync(worktreeDir)) return [];
+  const worktreeDirs = [
+    join(projectDir, SAFE_WORKTREE_DIR),
+    join(projectDir, CLAUDE_PROTECTED_WORKTREE_DIR),
+  ].filter(path => existsSync(path));
 
-  const entries = readdirSync(worktreeDir).filter(name => {
-    const fullPath = join(worktreeDir, name);
-    return statSync(fullPath).isDirectory();
-  });
+  const entries = worktreeDirs.flatMap(worktreeDir =>
+    readdirSync(worktreeDir)
+      .filter(name => statSync(join(worktreeDir, name)).isDirectory())
+      .map(name => ({ name, fullPath: join(worktreeDir, name) })),
+  );
 
-  return entries.map(name => {
-    const fullPath = join(worktreeDir, name);
+  return entries.map(({ name, fullPath }) => {
     let branch = 'unknown';
     let behind = 0;
     try {

--- a/tests/cli/guards/worktree-check.test.ts
+++ b/tests/cli/guards/worktree-check.test.ts
@@ -123,7 +123,9 @@ describe('worktreeCheckGuard', () => {
     const result = await worktreeCheckGuard(makeInput(), '/tmp/test');
     expect(result.decision).toBe('deny');
     expect(result.blockReason).toContain('other-session');
-    expect(result.blockReason).toContain('EnterWorktree');
+    expect(result.blockReason).toContain('slope worktree start');
+    expect(result.blockReason).toContain('.slope/worktrees/<branch>');
+    expect(result.blockReason).toContain("Avoid Claude Code's native .claude/worktrees/");
   });
 
   it('allows EnterWorktree recovery even when another session exists', async () => {

--- a/tests/cli/guards/worktree-reuse.test.ts
+++ b/tests/cli/guards/worktree-reuse.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(() => {
+    throw new Error('not a git repo');
+  }),
+}));
+
+import { worktreeReuseGuard } from '../../../src/cli/guards/worktree-reuse.js';
+import type { HookInput } from '../../../src/core/index.js';
+
+let cwd: string;
+
+function makeInput(name: string): HookInput {
+  return {
+    session_id: 'test-session',
+    cwd,
+    hook_event_name: 'PreToolUse',
+    tool_name: 'EnterWorktree',
+    tool_input: { name },
+  };
+}
+
+describe('worktreeReuseGuard', () => {
+  beforeEach(() => {
+    cwd = join(tmpdir(), `slope-worktree-reuse-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(cwd, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('prefers existing SLOPE worktrees outside .claude', async () => {
+    mkdirSync(join(cwd, '.slope', 'worktrees', 'ticket-477'), { recursive: true });
+    mkdirSync(join(cwd, '.claude', 'worktrees', 'ticket-477'), { recursive: true });
+
+    const result = await worktreeReuseGuard(makeInput('ticket-477'), cwd);
+
+    expect(result.decision).toBe('deny');
+    expect(result.blockReason).toContain(join(cwd, '.slope', 'worktrees', 'ticket-477'));
+    expect(result.blockReason).not.toContain(join(cwd, '.claude', 'worktrees', 'ticket-477'));
+  });
+
+  it('warns when an existing worktree is under Claude protected config', async () => {
+    mkdirSync(join(cwd, '.claude', 'worktrees', 'ticket-477'), { recursive: true });
+
+    const result = await worktreeReuseGuard(makeInput('ticket-477'), cwd);
+
+    expect(result.decision).toBe('deny');
+    expect(result.blockReason).toContain('protected config tree');
+    expect(result.blockReason).toContain('self-configuration edits');
+    expect(result.blockReason).toContain('prompt on every Edit/Write');
+    expect(result.blockReason).toContain('slope worktree start');
+    expect(result.blockReason).toContain(join('.slope', 'worktrees', 'ticket-477'));
+    expect(result.blockReason).toContain('git worktree move');
+  });
+});


### PR DESCRIPTION
## Summary

- Prefer SLOPE's .slope/worktrees location in worktree guard guidance
- Detect legacy .claude/worktrees entries and explain why they trigger Claude Code self-config prompts
- Add relocation guidance plus focused guard regressions

Fixes #477

## Verification

- pnpm exec vitest run tests/cli/guards/worktree-reuse.test.ts tests/cli/guards/worktree-check.test.ts tests/cli/commands/worktree.test.ts tests/cli/commands/worktree-start.test.ts
- pnpm run typecheck
- pnpm test