### PR TITLE
chore(S132-1): bump release version to 1.57.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.57.2",
+  "version": "1.57.3",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.57.2",
+  "version": "1.57.3",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
## Summary
- Bump @slope-dev/slope from 1.57.2 to 1.57.3
- Bump bundled Codex plugin metadata to 1.57.3

## Release contents
- fix(#474): silence duplicate hazard context
- fix(#477): prefer safe worktree location

## Validation
- pnpm run build
- pnpm run typecheck
- pnpm test
- node dist/cli/index.js validate --skills
- node dist/cli/index.js roadmap validate
- node dist/cli/index.js map --check
- git diff --check
- npm pack --dry-run