### PR TITLE
fix(#480): persist sprint workflow runs from variables

### DIFF
--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -440,6 +440,65 @@ function getStore(cwd: string) {
   return createStore({ storePath: config.store_path ?? '.slope/slope.db', cwd });
 }
 
+function roadmapTicketKeysForSprint(cwd: string, sprintId: string | undefined): string[] {
+  if (!sprintId) return [];
+  const sprintNumber = parseSprintNumber(sprintId);
+  if (sprintNumber === null) return [];
+
+  const config = loadConfig(cwd);
+  if (!config.roadmapPath) return [];
+
+  const roadmapPath = join(cwd, config.roadmapPath);
+  if (!existsSync(roadmapPath)) return [];
+
+  try {
+    const raw = JSON.parse(readFileSync(roadmapPath, 'utf8'));
+    const parsed = parseRoadmap(raw);
+    const roadmap = parsed.roadmap ?? castRoadmapStructure(raw);
+    const sprint = roadmap?.sprints.find(s => s.id === sprintNumber);
+    return sprint?.tickets.map(t => t.key).filter(Boolean) ?? [];
+  } catch {
+    return [];
+  }
+}
+
+function applyWorkflowVariableDefaults(
+  def: WorkflowDefinition,
+  vars: Record<string, string>,
+  cwd: string,
+  sprintId: string | undefined,
+): void {
+  if (sprintId && !('sprint_id' in vars)) {
+    vars.sprint_id = sprintId;
+  }
+
+  const ticketsSpec = def.variables?.tickets;
+  if (ticketsSpec?.required && !('tickets' in vars)) {
+    const tickets = roadmapTicketKeysForSprint(cwd, sprintId);
+    if (tickets.length > 0) {
+      vars.tickets = tickets.join(',');
+    }
+  }
+}
+
+function positionalSprintArg(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--var') {
+      i++;
+      continue;
+    }
+    if (!arg.startsWith('--')) return arg;
+  }
+  return undefined;
+}
+
+function sprintIdFromRunArgs(args: string[]): string | undefined {
+  const sprintFlag = args.find(a => a.startsWith('--sprint='));
+  if (sprintFlag) return sprintFlag.slice('--sprint='.length);
+  return positionalSprintArg(args);
+}
+
 const SPRINT_PHASE_ORDER: Record<SprintPhase, number> = {
   planning: 0,
   reviewing: 1,
@@ -492,7 +551,7 @@ function syncSprintStateWithWorkflow(cwd: string, sprintId: string | undefined, 
 }
 
 async function runWorkflowCommand(args: string[], cwd: string): Promise<void> {
-  const sprintArg = args.find(a => a.startsWith('--sprint=') || !a.startsWith('--'));
+  const explicitSprintId = sprintIdFromRunArgs(args);
   const workflowArg = args.find(a => a.startsWith('--workflow='));
   const varArgs: string[] = [];
   for (let i = 0; i < args.length; i++) {
@@ -509,12 +568,11 @@ async function runWorkflowCommand(args: string[], cwd: string): Promise<void> {
     process.exit(1);
   }
 
-  const sprintId = sprintArg?.startsWith('--') ? undefined : sprintArg;
   const workflowName = workflowArg.slice('--workflow='.length);
 
   // Parse variables
   const vars: Record<string, string> = {};
-  if (sprintId) vars.sprint_id = sprintId;
+  if (explicitSprintId) vars.sprint_id = explicitSprintId;
   for (const v of varArgs) {
     const kv = v.slice('--var='.length);
     const eq = kv.indexOf('=');
@@ -522,6 +580,7 @@ async function runWorkflowCommand(args: string[], cwd: string): Promise<void> {
       vars[kv.slice(0, eq)] = kv.slice(eq + 1);
     }
   }
+  const sprintId = explicitSprintId ?? vars.sprint_id;
 
 
   // Load and validate workflow
@@ -534,6 +593,8 @@ async function runWorkflowCommand(args: string[], cwd: string): Promise<void> {
     }
     process.exit(1);
   }
+
+  applyWorkflowVariableDefaults(def, vars, cwd, sprintId);
 
   // Resolve variables
   const resolved = resolveVariables(def, vars);

--- a/tests/cli/sprint-workflow.test.ts
+++ b/tests/cli/sprint-workflow.test.ts
@@ -95,6 +95,28 @@ function writeRoadmap(sprint: number, status = 'planned'): void {
   writeFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), JSON.stringify(roadmap, null, 2));
 }
 
+function writeProjectWorkflow(name: string): void {
+  mkdirSync(join(tmpDir, '.slope', 'workflows'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'workflows', `${name}.yaml`), `
+name: ${name}
+version: "1"
+variables:
+  sprint_id:
+    required: true
+    type: string
+  tickets:
+    required: true
+    type: array
+phases:
+  - id: per_ticket
+    repeat_for: tickets
+    steps:
+      - id: implement
+        type: agent_work
+        prompt: "Implement the ticket"
+`);
+}
+
 describe('slope sprint run', () => {
   it('starts a workflow execution', async () => {
     const output = await captureLog(() =>
@@ -127,6 +149,46 @@ describe('slope sprint run', () => {
     );
     expect(output).toContain('sprint-lightweight');
     expect(output).toContain('started');
+  });
+
+  it('persists execution under sprint_id when sprint is only passed via --var (#480)', async () => {
+    await captureLog(() =>
+      sprintCommand(['run', '--workflow=sprint-lightweight', '--var', 'sprint_id=S64', '--var', 'tickets=T1'])
+    );
+
+    const store = createStore({ storePath: '.slope/slope.db', cwd: tmpDir });
+    try {
+      const exec = await store.getExecutionBySprint('S64');
+      expect(exec).not.toBeNull();
+      expect(exec!.variables.sprint_id).toBe('S64');
+      expect(exec!.sprint_id).toBe('S64');
+    } finally {
+      store.close();
+    }
+
+    const output = await captureLog(() =>
+      sprintCommand(['status', 'S64'])
+    );
+    expect(output).toContain('Execution:');
+    expect(output).toContain('Sprint:    S64');
+  });
+
+  it('defaults required tickets from the roadmap when omitted (#480)', async () => {
+    writeRoadmap(64);
+    writeProjectWorkflow('ticket-default-test');
+
+    await captureLog(() =>
+      sprintCommand(['run', '--workflow=ticket-default-test', '--var', 'sprint_id=S64'])
+    );
+
+    const store = createStore({ storePath: '.slope/slope.db', cwd: tmpDir });
+    try {
+      const exec = await store.getExecutionBySprint('S64');
+      expect(exec).not.toBeNull();
+      expect(exec!.variables.tickets).toBe('S64-1,S64-2,S64-3');
+    } finally {
+      store.close();
+    }
   });
 
   it('syncs sprint-state to implementing when workflow starts in per_ticket', async () => {


### PR DESCRIPTION
## Summary

Fixes the sprint workflow run path so executions started with `--var sprint_id=...` are persisted under the intended sprint id.

## Root Cause

`runWorkflowCommand` only used an explicit positional or `--sprint=` sprint id when persisting the workflow execution. When the sprint id was supplied only through `--var sprint_id=S64`, the execution was stored without a `sprint_id`, so `slope sprint status S64` and `slope sprint skip S64` could not find it.

The positional parser also treated the payload after `--var` as a positional sprint argument, which made var-only invocations fragile.

## Changes

- Derive the persisted execution sprint id from `--var sprint_id=...` when no explicit sprint argument is present.
- Skip `--var` payload tokens during positional sprint detection.
- Default the required `tickets` workflow variable from roadmap ticket keys for the sprint when omitted.
- Add regression coverage for var-only persistence and roadmap-derived ticket defaults.

## Validation

- `pnpm vitest run tests/cli/sprint-workflow.test.ts`
- `pnpm vitest run tests/cli/sprint-workflow.test.ts tests/core/workflow.test.ts tests/core/workflow-engine.test.ts tests/store/index.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test` (3,537 passed, 25 skipped)

Closes #480.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `slope sprint run` command with improved CLI argument parsing for sprint IDs
  * Auto-population of workflow variables from roadmap data
  * Support for specifying sprint ID via `--var` parameter
  * Automatic ticket loading from configured roadmap when required by workflows

* **Tests**
  * Added test coverage for sprint variable handling and roadmap integration scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->