### PR TITLE
fix(#483): respect worktree sprint completion context

### DIFF
--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -1019,6 +1019,11 @@ export async function sprintCommand(args: string[]): Promise<void> {
   const cwd = process.cwd();
   const sub = args[0];
 
+  if (!sub || sub === '--help' || sub === '-h') {
+    printSprintUsage();
+    return;
+  }
+
   switch (sub) {
     case 'start':
       await startCommand(args.slice(1), cwd);
@@ -1040,9 +1045,19 @@ export async function sprintCommand(args: string[]): Promise<void> {
     case 'status':
       await workflowStatusCommand(args.slice(1), cwd);
       break;
-    case 'reset':
+    case 'reset': {
+      const resetArgs = args.slice(1);
+      if (resetArgs.includes('--help') || resetArgs.includes('-h')) {
+        printSprintUsage();
+        break;
+      }
+      if (resetArgs.length > 0) {
+        printSprintUsage();
+        process.exit(1);
+      }
       resetCommand(cwd);
       break;
+    }
     case 'run':
       await runWorkflowCommand(args.slice(1), cwd);
       break;
@@ -1065,7 +1080,14 @@ export async function sprintCommand(args: string[]): Promise<void> {
       await validateSprintCommand(args.slice(1), cwd);
       break;
     default:
-      console.log(`
+      printSprintUsage();
+      process.exit(1);
+      break;
+  }
+}
+
+function printSprintUsage(): void {
+  console.log(`
 slope sprint — Sprint lifecycle management
 
 Legacy commands:
@@ -1086,7 +1108,4 @@ Workflow commands:
   slope sprint workflow cleanup --stale [--dry-run]         Pause stale completed/superseded executions
   slope sprint skip <id> --step=<s> --reason="..."          Skip a blocking step
 `);
-      if (sub) process.exit(1);
-      break;
-  }
 }

--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -1105,6 +1105,8 @@ Workflow commands:
   slope sprint status [sprint_id]    Show workflow execution progress
   slope sprint resume <sprint_id>    Resume a paused workflow execution
   slope sprint pause <sprint_id>     Pause a running workflow execution
+  slope sprint context <sprint_id>   Show current workflow step and remaining work
+  slope sprint validate <sprint_id>  Validate workflow, plan, scorecard, and tests
   slope sprint workflow cleanup --stale [--dry-run]         Pause stale completed/superseded executions
   slope sprint skip <id> --step=<s> --reason="..."          Skip a blocking step
 `);

--- a/src/cli/guards/sprint-completion.ts
+++ b/src/cli/guards/sprint-completion.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { isAbsolute, join, resolve } from 'node:path';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { loadConfig } from '../config.js';
@@ -98,10 +99,22 @@ function handlePreToolUse(input: HookInput, cwd: string): GuardResult {
   };
 }
 
-function prCreateCommandContext(input: HookInput, cwd: string): { cwd: string } | null {
-  const command = commandText(input);
-  if (!command) return null;
+interface ShellCommandSegment {
+  cwd: string;
+  segment: string;
+  words: string[];
+}
 
+function prCreateCommandContext(input: HookInput, cwd: string): { cwd: string } | null {
+  const segment = commandSegments(input, cwd).find(({ words }) => isGhPrCreateCommand(words));
+  return segment ? { cwd: segment.cwd } : null;
+}
+
+function commandSegments(input: HookInput, cwd: string): ShellCommandSegment[] {
+  const command = commandText(input);
+  if (!command) return [];
+
+  const segments: ShellCommandSegment[] = [];
   let commandCwd = toolInputCwd(input, cwd);
   for (const segment of splitShellSegments(command)) {
     const words = tokenizeShellWords(segment);
@@ -113,10 +126,10 @@ function prCreateCommandContext(input: HookInput, cwd: string): { cwd: string } 
       continue;
     }
 
-    if (isGhPrCreateCommand(words)) return { cwd: commandCwd };
+    segments.push({ cwd: commandCwd, segment, words });
   }
 
-  return null;
+  return segments;
 }
 
 function commandText(input: HookInput): string {
@@ -142,7 +155,14 @@ function toolInputCwd(input: HookInput, cwd: string): string {
 }
 
 function resolveCommandCwd(baseCwd: string, target: string): string {
-  return isAbsolute(target) ? target : resolve(baseCwd, target);
+  const expanded = expandHomePath(target);
+  return isAbsolute(expanded) ? expanded : resolve(baseCwd, expanded);
+}
+
+function expandHomePath(target: string): string {
+  if (target === '~') return homedir();
+  if (target.startsWith('~/')) return join(homedir(), target.slice(2));
+  return target;
 }
 
 function cdCommandTarget(words: string[]): string | null {
@@ -321,34 +341,41 @@ function scorecardExists(sprint: number, cwd: string): boolean {
 
 /** Auto-detect test pass, validate success, and PR merge from Bash output. */
 function handlePostToolUse(input: HookInput, cwd: string): GuardResult {
-  const command = input.tool_input?.command as string | undefined;
-  if (!command) return {};
+  const segments = commandSegments(input, cwd);
+  if (segments.length === 0) return {};
 
   // Detect PR merge → transition to scoring phase
-  if (/gh\s+pr\s+merge/.test(command)) {
-    return handlePrMerge(input, cwd);
+  const prMergeCommand = segments.find(({ segment }) => /gh\s+pr\s+merge/.test(segment));
+  if (prMergeCommand) {
+    return handlePrMerge(input, prMergeCommand.cwd);
   }
 
   // Detect slope validate success → auto-update roadmap
-  if (/\bslope\s+validate\b/.test(command)) {
-    return handleValidateSuccess(input, cwd);
+  const validateCommand = segments.find(({ segment }) => /\bslope\s+validate\b/.test(segment));
+  if (validateCommand) {
+    return handleValidateSuccess(input, validateCommand.cwd);
   }
 
   // Detect slope review completion → mark review_md gate
-  if (/\bslope\s+review\b/.test(command) && !/\bslope\s+review\s+(start|round|status|reset|recommend|findings|amend|defer|deferred|resolve)\b/.test(command)) {
-    return handleReviewCompletion(input, cwd);
+  const reviewCommand = segments.find(({ segment }) =>
+    /\bslope\s+review\b/.test(segment)
+    && !/\bslope\s+review\s+(start|round|status|reset|recommend|findings|amend|defer|deferred|resolve)\b/.test(segment),
+  );
+  if (reviewCommand) {
+    return handleReviewCompletion(input, reviewCommand.cwd);
   }
 
   // Detect slope auto-card completion → suggest validate next
-  if (/\bslope\s+auto-card\b/.test(command)) {
-    return handleAutoCardCompletion(input, cwd);
+  const autoCardCommand = segments.find(({ segment }) => /\bslope\s+auto-card\b/.test(segment));
+  if (autoCardCommand) {
+    return handleAutoCardCompletion(input, autoCardCommand.cwd);
   }
 
   // Check if command looks like a test runner
-  const isTestCommand = /\b(jest|vitest|bun\s+test|npx\s+jest|npx\s+vitest)\b/.test(command);
-  if (!isTestCommand) return {};
+  const testCommand = segments.find(({ segment }) => /\b(jest|vitest|bun\s+test|npx\s+jest|npx\s+vitest)\b/.test(segment));
+  if (!testCommand) return {};
 
-  const state = loadSprintState(cwd);
+  const state = loadSprintState(testCommand.cwd);
   if (!state) return {};
   if (state.gates.tests) return {}; // Already marked
 
@@ -358,7 +385,7 @@ function handlePostToolUse(input: HookInput, cwd: string): GuardResult {
 
   // If exit code is explicitly 0, or if stdout contains pass indicators without failures
   if (exitCode === 0 || exitCode === '0') {
-    updateGate(cwd, 'tests', true);
+    updateGate(testCommand.cwd, 'tests', true);
     return { context: 'SLOPE: Tests passed — gate marked complete.' };
   }
 

--- a/src/cli/guards/sprint-completion.ts
+++ b/src/cli/guards/sprint-completion.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { loadPrReviewState } from '../pr-review-state.js';
@@ -53,20 +53,21 @@ function checkStaleness(sprint: number, cwd: string): string | null {
 
 /** Block `gh pr create` when gates are incomplete or scorecard is missing. */
 function handlePreToolUse(input: HookInput, cwd: string): GuardResult {
-  const command = input.tool_input?.command as string | undefined;
-  if (!command || !command.includes('gh pr create')) return {};
+  const commandContext = prCreateCommandContext(input, cwd);
+  if (!commandContext) return {};
+  const guardCwd = commandContext.cwd;
 
-  const state = loadSprintState(cwd);
+  const state = loadSprintState(guardCwd);
   if (!state) return {};
   if (state.phase === 'complete') return {}; // Sprint fully complete — skip all checks
 
   // Check scorecard existence independently of gates
-  const scorecardMissing = !scorecardExists(state.sprint, cwd);
+  const scorecardMissing = !scorecardExists(state.sprint, guardCwd);
   const gatesComplete = isSprintComplete(state);
 
   if (gatesComplete && !scorecardMissing) return {};
 
-  const staleWarning = checkStaleness(state.sprint, cwd);
+  const staleWarning = checkStaleness(state.sprint, guardCwd);
   const lines: string[] = [];
 
   if (scorecardMissing) {
@@ -95,6 +96,167 @@ function handlePreToolUse(input: HookInput, cwd: string): GuardResult {
     decision: 'deny',
     blockReason: lines.join('\n'),
   };
+}
+
+function prCreateCommandContext(input: HookInput, cwd: string): { cwd: string } | null {
+  const command = commandText(input);
+  if (!command) return null;
+
+  let commandCwd = toolInputCwd(input, cwd);
+  for (const segment of splitShellSegments(command)) {
+    const words = tokenizeShellWords(segment);
+    if (words.length === 0) continue;
+
+    const cdTarget = cdCommandTarget(words);
+    if (cdTarget) {
+      commandCwd = resolveCommandCwd(commandCwd, cdTarget);
+      continue;
+    }
+
+    if (isGhPrCreateCommand(words)) return { cwd: commandCwd };
+  }
+
+  return null;
+}
+
+function commandText(input: HookInput): string {
+  const toolInput = input.tool_input;
+  if (!toolInput || typeof toolInput !== 'object') return '';
+  for (const key of ['command', 'cmd', 'input']) {
+    const value = toolInput[key];
+    if (typeof value === 'string') return value;
+  }
+  return '';
+}
+
+function toolInputCwd(input: HookInput, cwd: string): string {
+  const toolInput = input.tool_input;
+  if (!toolInput || typeof toolInput !== 'object') return cwd;
+  for (const key of ['workdir', 'cwd']) {
+    const value = toolInput[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return resolveCommandCwd(cwd, value.trim());
+    }
+  }
+  return cwd;
+}
+
+function resolveCommandCwd(baseCwd: string, target: string): string {
+  return isAbsolute(target) ? target : resolve(baseCwd, target);
+}
+
+function cdCommandTarget(words: string[]): string | null {
+  const start = skipCommandPrefix(words, 0);
+  if (words[start] !== 'cd') return null;
+
+  let targetIndex = start + 1;
+  if (words[targetIndex] === '--') targetIndex++;
+  const target = words[targetIndex];
+  if (!target || target === '-') return null;
+  return target;
+}
+
+function isGhPrCreateCommand(words: string[]): boolean {
+  let i = skipCommandPrefix(words, 0);
+  if (words[i] !== 'gh') return false;
+  i++;
+
+  i = skipGhGlobalFlags(words, i);
+  return words[i] === 'pr' && words[i + 1] === 'create';
+}
+
+const GH_GLOBAL_FLAGS_WITH_VALUE = new Set([
+  '-R',
+  '--repo',
+  '--hostname',
+  '--config',
+]);
+
+function skipGhGlobalFlags(words: string[], start: number): number {
+  let i = start;
+  while (words[i]?.startsWith('-')) {
+    const flag = words[i];
+    if (flag === '--') return i + 1;
+    if (flag.includes('=')) {
+      i++;
+    } else if (GH_GLOBAL_FLAGS_WITH_VALUE.has(flag)) {
+      i += 2;
+    } else {
+      i++;
+    }
+  }
+  return i;
+}
+
+function splitShellSegments(command: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+    if (char === '\\' && quote !== "'") {
+      current += char;
+      if (i + 1 < command.length) current += command[++i];
+      continue;
+    }
+    if ((char === '"' || char === "'") && (!quote || quote === char)) {
+      quote = quote ? null : char;
+      current += char;
+      continue;
+    }
+    if (!quote && (char === ';' || char === '\n' || char === '&' || char === '|')) {
+      if (current.trim()) segments.push(current.trim());
+      current = '';
+      if ((char === '&' && command[i + 1] === '&') || (char === '|' && command[i + 1] === '|')) i++;
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.trim()) segments.push(current.trim());
+  return segments;
+}
+
+function tokenizeShellWords(segment: string): string[] {
+  const words: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < segment.length; i++) {
+    const char = segment[i];
+    if (char === '\\' && quote !== "'") {
+      if (i + 1 < segment.length) current += segment[++i];
+      continue;
+    }
+    if ((char === '"' || char === "'") && (!quote || quote === char)) {
+      quote = quote ? null : char;
+      continue;
+    }
+    if (!quote && /\s/.test(char)) {
+      if (current) {
+        words.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (current) words.push(current);
+  return words;
+}
+
+function skipCommandPrefix(words: string[], start: number): number {
+  let i = start;
+  if (words[i] === 'env') i++;
+  while (isEnvAssignment(words[i])) i++;
+  if (words[i] === 'command') i++;
+  return i;
+}
+
+function isEnvAssignment(word: string | undefined): boolean {
+  return !!word && /^[A-Za-z_][A-Za-z0-9_]*=/.test(word);
 }
 
 /** Warn at session end when mid-sprint with incomplete gates or missing scorecard.

--- a/tests/cli/guards/sprint-completion.test.ts
+++ b/tests/cli/guards/sprint-completion.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, relative } from 'node:path';
 import { sprintCompletionGuard } from '../../../src/cli/guards/sprint-completion.js';
 import { recordPrReviewComplete } from '../../../src/cli/pr-review-state.js';
 import { saveSprintState, createSprintState, loadSprintState } from '../../../src/cli/sprint-state.js';
 import type { HookInput } from '../../../src/core/index.js';
 
 const tmpDir = join(import.meta.dirname ?? __dirname, '.tmp-sprint-completion-test');
+const cleanupDirs: string[] = [];
 
 function makePreToolUse(command: string): HookInput {
   return {
@@ -62,7 +64,11 @@ function writeScorecardAt(cwd: string, sprint: number): void {
 }
 
 function writeRoadmap(sprints: Array<{ id: number; status?: string }>): void {
-  const dir = join(tmpDir, 'docs', 'backlog');
+  writeRoadmapAt(tmpDir, sprints);
+}
+
+function writeRoadmapAt(cwd: string, sprints: Array<{ id: number; status?: string }>): void {
+  const dir = join(cwd, 'docs', 'backlog');
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, 'roadmap.json'), JSON.stringify({
     name: 'Test',
@@ -81,6 +87,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  for (const dir of cleanupDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
   rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -207,6 +216,32 @@ describe('sprint-completion guard', () => {
       );
       expect(result).toEqual({});
     });
+
+    it('expands tilde shell cd targets before checking gh pr create state', async () => {
+      const homeWorktreeDir = mkdtempSync(join(homedir(), '.slope-pr-worktree-'));
+      cleanupDirs.push(homeWorktreeDir);
+      const homeRelativePath = relative(homedir(), homeWorktreeDir);
+      writeConfigAt(homeWorktreeDir);
+
+      const incorrectlyResolvedDir = join(tmpDir, '~', homeRelativePath);
+      writeConfigAt(incorrectlyResolvedDir);
+      saveSprintState(incorrectlyResolvedDir, createSprintState(161, 'implementing'));
+
+      const worktreeState = createSprintState(161, 'implementing');
+      worktreeState.gates.tests = true;
+      worktreeState.gates.code_review = true;
+      worktreeState.gates.architect_review = true;
+      worktreeState.gates.scorecard = true;
+      worktreeState.gates.review_md = true;
+      saveSprintState(homeWorktreeDir, worktreeState);
+      writeScorecardAt(homeWorktreeDir, 161);
+
+      const result = await sprintCompletionGuard(
+        makePreToolUse(`cd ~/${homeRelativePath} && gh pr create --title "S161"`),
+        tmpDir,
+      );
+      expect(result).toEqual({});
+    });
   });
 
   describe('Stop only blocks during implementing/scoring phases', () => {
@@ -249,6 +284,21 @@ describe('sprint-completion guard', () => {
     it('marks tests gate on vitest exit 0', async () => {
       const result = await sprintCompletionGuard(makePostToolUse('npx vitest', 0), tmpDir);
       expect(result.context).toContain('Tests passed');
+    });
+
+    it('uses the shell cd target as the sprint-state cwd when marking tests complete', async () => {
+      const worktreeDir = join(tmpDir, 'post-tool-worktree');
+      writeConfigAt(worktreeDir);
+      saveSprintState(worktreeDir, createSprintState(160, 'implementing'));
+
+      const result = await sprintCompletionGuard(
+        makePostToolUse(`cd "${worktreeDir}" && npx vitest`, 0),
+        tmpDir,
+      );
+
+      expect(result.context).toContain('Tests passed');
+      expect(loadSprintState(worktreeDir)!.gates.tests).toBe(true);
+      expect(loadSprintState(tmpDir)!.gates.tests).toBe(false);
     });
 
     it('does not mark gate on test failure (exit 1)', async () => {
@@ -376,6 +426,28 @@ describe('sprint-completion guard', () => {
 
       const roadmap = JSON.parse(readFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), 'utf8'));
       expect(roadmap.sprints[0].status).toBe('complete');
+    });
+
+    it('uses the shell cd target as the cwd when slope validate updates roadmap', async () => {
+      const worktreeDir = join(tmpDir, 'validate-worktree');
+      writeConfigAt(worktreeDir);
+      saveSprintState(worktreeDir, createSprintState(160, 'implementing'));
+      writeRoadmapAt(worktreeDir, [{ id: 160, status: 'planned' }]);
+
+      saveSprintState(tmpDir, createSprintState(22, 'implementing'));
+      writeRoadmap([{ id: 22, status: 'planned' }]);
+
+      const result = await sprintCompletionGuard(
+        makePostToolUse(`cd "${worktreeDir}" && slope validate`, 0),
+        tmpDir,
+      );
+
+      expect(result.context).toContain('Sprint 160');
+
+      const worktreeRoadmap = JSON.parse(readFileSync(join(worktreeDir, 'docs', 'backlog', 'roadmap.json'), 'utf8'));
+      const launcherRoadmap = JSON.parse(readFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), 'utf8'));
+      expect(worktreeRoadmap.sprints[0].status).toBe('complete');
+      expect(launcherRoadmap.sprints[0].status).toBe('planned');
     });
 
     it('does not update roadmap on slope validate failure', async () => {

--- a/tests/cli/guards/sprint-completion.test.ts
+++ b/tests/cli/guards/sprint-completion.test.ts
@@ -38,8 +38,12 @@ function makePostToolUse(command: string, exitCode: number | string): HookInput 
 }
 
 function writeConfig(): void {
-  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
-  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+  writeConfigAt(tmpDir);
+}
+
+function writeConfigAt(cwd: string): void {
+  mkdirSync(join(cwd, '.slope'), { recursive: true });
+  writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({
     scorecardDir: 'docs/retros',
     scorecardPattern: 'sprint-*.json',
     minSprint: 1,
@@ -48,7 +52,11 @@ function writeConfig(): void {
 }
 
 function writeScorecard(sprint: number): void {
-  const dir = join(tmpDir, 'docs', 'retros');
+  writeScorecardAt(tmpDir, sprint);
+}
+
+function writeScorecardAt(cwd: string, sprint: number): void {
+  const dir = join(cwd, 'docs', 'retros');
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, `sprint-${sprint}.json`), JSON.stringify({ sprint_number: sprint, score: 4, par: 4 }));
 }
@@ -161,6 +169,42 @@ describe('sprint-completion guard', () => {
 
     it('does not block non-PR Bash commands', async () => {
       const result = await sprintCompletionGuard(makePreToolUse('git push -u origin main'), tmpDir);
+      expect(result).toEqual({});
+    });
+
+    it('does not block gh issue create when gh pr create appears only in quoted body text', async () => {
+      const result = await sprintCompletionGuard(
+        makePreToolUse('gh issue create --title "bug" --body "gh pr create is blocked by sprint-completion"'),
+        tmpDir,
+      );
+      expect(result).toEqual({});
+    });
+
+    it('uses the shell cd target as the sprint-state and scorecard cwd for gh pr create', async () => {
+      const worktreeDir = join(tmpDir, 'linked-worktree');
+      writeConfigAt(worktreeDir);
+
+      const staleMainState = createSprintState(160, 'implementing');
+      staleMainState.gates.tests = true;
+      staleMainState.gates.code_review = true;
+      staleMainState.gates.architect_review = true;
+      staleMainState.gates.scorecard = true;
+      staleMainState.gates.review_md = true;
+      saveSprintState(tmpDir, staleMainState);
+
+      const worktreeState = createSprintState(160, 'implementing');
+      worktreeState.gates.tests = true;
+      worktreeState.gates.code_review = true;
+      worktreeState.gates.architect_review = true;
+      worktreeState.gates.scorecard = true;
+      worktreeState.gates.review_md = true;
+      saveSprintState(worktreeDir, worktreeState);
+      writeScorecardAt(worktreeDir, 160);
+
+      const result = await sprintCompletionGuard(
+        makePreToolUse(`cd "${worktreeDir}" && gh pr create --title "S160"`),
+        tmpDir,
+      );
       expect(result).toEqual({});
     });
   });

--- a/tests/cli/sprint-workflow.test.ts
+++ b/tests/cli/sprint-workflow.test.ts
@@ -488,6 +488,8 @@ describe('slope sprint (help)', () => {
     expect(output).toContain('slope sprint phase');
     expect(output).toContain('slope sprint resume');
     expect(output).toContain('slope sprint skip');
+    expect(output).toContain('slope sprint context');
+    expect(output).toContain('slope sprint validate');
     expect(output).toContain('--workflow');
   });
 

--- a/tests/cli/sprint-workflow.test.ts
+++ b/tests/cli/sprint-workflow.test.ts
@@ -490,4 +490,39 @@ describe('slope sprint (help)', () => {
     expect(output).toContain('slope sprint skip');
     expect(output).toContain('--workflow');
   });
+
+  it('prints reset help without clearing sprint state (#483)', async () => {
+    await captureLog(() =>
+      sprintCommand(['start', '--number=160', '--phase=implementing'])
+    );
+
+    const output = await captureLog(() =>
+      sprintCommand(['reset', '--help'])
+    );
+    const state = JSON.parse(readFileSync(join(tmpDir, '.slope', 'sprint-state.json'), 'utf8'));
+
+    expect(output).toContain('slope sprint reset');
+    expect(output).toContain('Clear sprint state');
+    expect(state.sprint).toBe(160);
+    expect(state.phase).toBe('implementing');
+  });
+
+  it('rejects unknown reset flags without clearing sprint state (#483)', async () => {
+    await captureLog(() =>
+      sprintCommand(['start', '--number=160', '--phase=implementing'])
+    );
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => { throw new ProcessExitError(code as number); });
+    try {
+      await expect(captureLog(() =>
+        sprintCommand(['reset', '--bogus'])
+      )).rejects.toThrow(ProcessExitError);
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const state = JSON.parse(readFileSync(join(tmpDir, '.slope', 'sprint-state.json'), 'utf8'));
+    expect(state.sprint).toBe(160);
+    expect(state.phase).toBe('implementing');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the sprint-completion guard and sprint reset safety issues reported in #483.

## Changes

- Parse Bash commands structurally instead of using a raw substring check for `gh pr create`.
- Avoid blocking unrelated `gh` commands when `gh pr create` appears only inside quoted issue/body text.
- Resolve `gh pr create` checks relative to an explicit Bash `workdir`/`cwd` or a preceding `cd <worktree>` shell segment, so scorecard/state checks use the active worktree context instead of the launcher checkout.
- Make `slope sprint reset --help` print usage without clearing sprint state.
- Reject unknown `slope sprint reset` flags before clearing sprint state.

## Validation

- `pnpm vitest run tests/cli/guards/sprint-completion.test.ts tests/cli/sprint-workflow.test.ts`
- `pnpm vitest run tests/cli/commands/guard.test.ts tests/cli/guards/worktree-check.test.ts tests/cli/guards/phase-boundary.test.ts tests/cli/sprint-state.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`
- `pnpm test` (3,541 passed, 25 skipped)

Closes #483.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sprint commands now handle --help / -h immediately; usage now lists context and validate.

* **Bug Fixes**
  * Sprint guard resolves the effective working directory from parsed shell commands (handles cd, tilde, quoted args) and applies gate/state updates using that directory.
  * Reset rejects extra args and exits with error without clearing sprint state; unknown subcommands now print usage and exit with code 1.

* **Tests**
  * Expanded tests for help text, reset behavior, working-directory resolution, tilde expansion, and post-tool use state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->