### PR TITLE
fix(#486): require PR closeout settlement

### DIFF
--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -4,8 +4,8 @@ import { join } from 'node:path';
 import { detectLatestSprint, loadConfig, normalizeScorecard, recommendReviews } from '../../core/index.js';
 import type { ReviewRecommendation } from '../../core/index.js';
 import { reviewRunCommand } from './review-run.js';
-import { recordPrReviewComplete } from '../pr-review-state.js';
-import { branchSizeWarnings, buildPrCloseoutStatus, closeoutPolicy, formatPrCloseoutStatus } from '../pr-closeout.js';
+import { recordPrCloseoutSettled, recordPrReviewComplete } from '../pr-review-state.js';
+import { branchSizeWarnings, buildPrCloseoutStatus, canSettlePrCloseout, closeoutPolicy, formatPrCloseoutStatus } from '../pr-closeout.js';
 
 /**
  * `slope pr ...` — agent-friendly PR helpers.
@@ -17,7 +17,7 @@ import { branchSizeWarnings, buildPrCloseoutStatus, closeoutPolicy, formatPrClos
  *                                            parser would otherwise miss (#321).
  *   slope pr review [--pr=N] [--sprint=N]    Run the post-PR review workflow
  *                                            for any PR creation transport.
- *   slope pr status [--sprint=N]             Check sprint + PR closeout readiness.
+ *   slope pr status [--pr=N] [--sprint=N]    Check sprint + PR closeout readiness.
  *   slope pr issues [--pr=N]                 Print extracted issue refs (helper).
  *
  * Background: commits like `fix: ... (GH #297, #299)` or `… closes #314` mix
@@ -94,8 +94,9 @@ Usage:
   slope pr review [--pr=N] [--sprint=N]    Run review recommendation + prompt generation
                                            after PR creation, regardless of whether the
                                            PR was created by gh, MCP, or another API.
-  slope pr status [--sprint=N]             Check scorecard, sprint review, push state,
-                                           PR existence, PR review, and branch size.
+  slope pr status [--pr=N] [--sprint=N]    Check scorecard, sprint review, push state,
+                                           PR existence, PR review, checks, review
+                                           threads, and branch size.
   slope pr issues [--pr=N]                 Print extracted issue refs from the branch's
                                            commit messages.
 
@@ -471,8 +472,16 @@ async function reviewSubcommand(args: string[]): Promise<void> {
 
 async function statusSubcommand(args: string[]): Promise<void> {
   const opts = parseReviewFlags(args);
-  const status = buildPrCloseoutStatus(process.cwd(), { sprint: opts.sprint });
+  const status = buildPrCloseoutStatus(process.cwd(), { pr: opts.pr, sprint: opts.sprint });
   console.log(formatPrCloseoutStatus(status));
+  if (canSettlePrCloseout(status) && status.closeoutSettlement !== 'settled' && status.pr) {
+    recordPrCloseoutSettled(process.cwd(), {
+      pr: status.pr.number,
+      sprint: status.sprint,
+      branch: status.branch,
+    });
+    console.log('\nPR closeout settlement recorded.');
+  }
   if (status.blockers.length > 0) process.exitCode = 1;
 }
 

--- a/src/cli/guards/docs.ts
+++ b/src/cli/guards/docs.ts
@@ -106,9 +106,9 @@ export const GUARD_DOCS: Record<string, GuardDoc> = {
     level: 'full',
   },
   'pr-review': {
-    purpose: 'Prompts for the review workflow after PR creation and records pending PR-review state.',
+    purpose: 'Prompts for the review and closeout-settlement workflow after PR creation.',
     triggers: 'PostToolUse on Bash. Fires after a shell command completes (checks for `gh pr create`).',
-    behavior: 'Advisory — if the command created a PR, records it as pending in `.slope/pr-reviews.json` and injects a reminder to run `slope pr review --pr=<N>`. The post-hole guard surfaces pending records before the session ends.',
+    behavior: 'Advisory — if the command created a PR, records it as pending in `.slope/pr-reviews.json` and injects reminders to run `slope pr review --pr=<N>` and `slope pr status --pr=<N>` after checks/review threads settle. The post-hole guard surfaces pending records before the session ends.',
     configuration: 'Disable: add "pr-review" to guidance.disabled.',
     level: 'full',
   },

--- a/src/cli/guards/post-hole-enforcement.ts
+++ b/src/cli/guards/post-hole-enforcement.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import type { HookInput, GuardResult } from '../../core/index.js';
 import { findShippedSprintsOnMain } from '../../core/index.js';
 import { loadConfig } from '../config.js';
-import { pendingPrReviews } from '../pr-review-state.js';
+import { pendingPrCloseouts, pendingPrReviews } from '../pr-review-state.js';
 import type { PrReviewRecord } from '../pr-review-state.js';
 
 /**
@@ -87,11 +87,13 @@ export async function postHoleEnforcementGuard(_input: HookInput, cwd: string): 
   }
 
   const prReviewGaps = pendingPrReviews(cwd);
-  if (drifts.length === 0 && prReviewGaps.length === 0) return {};
+  const prCloseoutGaps = pendingPrCloseouts(cwd);
+  if (drifts.length === 0 && prReviewGaps.length === 0 && prCloseoutGaps.length === 0) return {};
 
   const sections: string[] = [];
   if (drifts.length > 0) sections.push(formatCloseoutDriftMessage(drifts));
   if (prReviewGaps.length > 0) sections.push(formatPendingPrReviewMessage(prReviewGaps));
+  if (prCloseoutGaps.length > 0) sections.push(formatPendingPrCloseoutMessage(prCloseoutGaps));
 
   const message = sections.join('\n\n');
 
@@ -140,6 +142,26 @@ function formatPendingPrReviewMessage(records: PrReviewRecord[]): string {
   lines.push(
     '',
     'Run the review command before presenting the PR as ready to merge.',
+  );
+  return lines.join('\n');
+}
+
+function formatPendingPrCloseoutMessage(records: PrReviewRecord[]): string {
+  const shown = records.slice(0, 5);
+  const remainder = records.length - shown.length;
+  const lines = [
+    `SLOPE PR closeout enforcement: ${records.length} reviewed PR${records.length === 1 ? '' : 's'} still need review/check settlement:`,
+    '',
+    ...shown.map(record => {
+      const sprintArg = record.sprint ? ` --sprint=${record.sprint}` : '';
+      const sprintLabel = record.sprint ? ` (S${record.sprint})` : '';
+      return `  • PR #${record.pr}${sprintLabel}: slope pr status --pr=${record.pr}${sprintArg}`;
+    }),
+  ];
+  if (remainder > 0) lines.push(`  …and ${remainder} more`);
+  lines.push(
+    '',
+    'Wait for GitHub checks and review threads to settle, address actionable feedback, then rerun the status command before presenting the PR as ready to merge.',
   );
   return lines.join('\n');
 }

--- a/src/cli/guards/pr-review.ts
+++ b/src/cli/guards/pr-review.ts
@@ -41,6 +41,7 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
       `SLOPE PR Review: A pull request was just created (${prUrl}).`,
       ...(recLine ? [`Recommended reviews based on diff: ${recLine}.`] : []),
       `Run \`slope pr review --pr=${prNumber}\` to generate the transport-independent review workflow.`,
+      `Then run \`slope pr status --pr=${prNumber}\` after checks and review threads settle before presenting the PR as ready.`,
       `After review, capture findings with \`slope review findings add\`, then \`slope review amend\` to apply them to the scorecard.`,
       'Tip: also run `slope pr finalize` to add Closes #N for any issues referenced in commits.',
     ].join(' '),

--- a/src/cli/guards/sprint-completion.ts
+++ b/src/cli/guards/sprint-completion.ts
@@ -461,6 +461,15 @@ function missingPrReviewWarning(cwd: string, sprint: number): string | null {
     || (branch && review.branch === branch),
   );
 
+  const closeoutPending = matching.find(review =>
+    review.status === 'reviewed' && review.closeout_status !== 'settled',
+  );
+  if (closeoutPending) {
+    return [
+      'SLOPE PR closeout: PR implementation review is recorded, but review/check settlement is still pending.',
+      `Run \`slope pr status --pr=${closeoutPending.pr} --sprint=${sprint}\` after checks and review threads settle before presenting PR #${closeoutPending.pr} as ready.`,
+    ].join(' ');
+  }
   if (matching.some(review => review.status === 'reviewed')) return null;
   const pending = matching.find(review => review.status === 'pending');
   const target = pending ? `PR #${pending.pr}` : 'the current branch PR';

--- a/src/cli/pr-closeout.ts
+++ b/src/cli/pr-closeout.ts
@@ -354,6 +354,7 @@ function resolveReviewerBotStatus(pr: PrMetadata | null): { status: PrReviewerBo
 
     const latestNonSettledAt = Math.max(blockedAt ?? 0, processingAt ?? 0);
     if (reviewedAt && reviewedAt > latestNonSettledAt) return { status: 'settled' };
+    if (!blockedAt && !processingAt && hasSuccessfulCodeRabbitStatus(pr)) return { status: 'settled' };
 
     if (processingAt && (!reviewedAt || processingAt >= reviewedAt)) return {
       status: 'pending',
@@ -379,6 +380,23 @@ function hasCodeRabbitSignal(pr: PrMetadata): boolean {
   return rollup.some(item => {
     const check = item as { name?: string; context?: string };
     return isCodeRabbitLogin(check.name) || isCodeRabbitLogin(check.context);
+  });
+}
+
+export function hasSuccessfulCodeRabbitStatus(pr: Pick<PrMetadata, 'statusCheckRollup'>): boolean {
+  const rollup = Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : [];
+  return rollup.some(item => {
+    const check = item as {
+      __typename?: string;
+      name?: string;
+      context?: string;
+      status?: string;
+      conclusion?: string;
+      state?: string;
+    };
+    if (!isCodeRabbitLogin(check.name) && !isCodeRabbitLogin(check.context)) return false;
+    if (check.__typename === 'StatusContext') return check.state === 'SUCCESS';
+    return check.status === 'COMPLETED' && ['SUCCESS', 'SKIPPED', 'NEUTRAL'].includes(check.conclusion ?? '');
   });
 }
 

--- a/src/cli/pr-closeout.ts
+++ b/src/cli/pr-closeout.ts
@@ -142,7 +142,9 @@ export function buildPrCloseoutStatus(cwd: string, opts: { sprint?: number; pr?:
     if (status.reviewerBot === 'pending') {
       status.blockers.push(status.reviewerBotReason ?? 'Reviewer bot has not completed its PR review.');
     }
-    if (status.reviewerBot === 'unknown') status.blockers.push('Could not determine reviewer bot status from GitHub comments.');
+    if (status.reviewerBot === 'unknown') {
+      status.blockers.push(status.reviewerBotReason ?? 'Could not determine reviewer bot status from GitHub comments.');
+    }
     if (status.pr.reviewDecision === 'CHANGES_REQUESTED') status.blockers.push('PR has requested changes; address review feedback before closeout.');
     if (status.prReviewThreads === 'pending') {
       const count = status.unresolvedReviewThreads ?? 0;
@@ -343,16 +345,29 @@ function resolveReviewerBotStatus(pr: PrMetadata | null): { status: PrReviewerBo
     const blockedAt = latestTimestamp(comments
       .filter(isBlockedCodeRabbitComment)
       .map(comment => comment.updated_at ?? comment.created_at));
-    if (!blockedAt) return { status: 'settled' };
-
-    const completedAt = latestTimestamp(reviews
+    const processingAt = latestTimestamp(comments
+      .filter(isProcessingCodeRabbitComment)
+      .map(comment => comment.updated_at ?? comment.created_at));
+    const reviewedAt = latestTimestamp(reviews
       .filter(review => isCurrentCodeRabbitReview(review, pr.headRefOid))
       .map(review => review.submitted_at));
-    if (completedAt && completedAt > blockedAt) return { status: 'settled' };
 
-    return {
+    const latestNonSettledAt = Math.max(blockedAt ?? 0, processingAt ?? 0);
+    if (reviewedAt && reviewedAt > latestNonSettledAt) return { status: 'settled' };
+
+    if (processingAt && (!reviewedAt || processingAt >= reviewedAt)) return {
+      status: 'pending',
+      reason: 'CodeRabbit review is still in progress.',
+    };
+
+    if (blockedAt && (!reviewedAt || blockedAt >= reviewedAt)) return {
       status: 'pending',
       reason: 'CodeRabbit reported a review limit or credit block; retrigger reviewer bot review before closeout.',
+    };
+
+    return {
+      status: 'unknown',
+      reason: 'Could not confirm reviewer bot review for the current PR head.',
     };
   } catch {
     return { status: 'unknown' };
@@ -376,9 +391,17 @@ export function isBlockedCodeRabbitComment(comment: GitHubComment): boolean {
     || /more reviews will be available/i.test(body);
 }
 
+function isProcessingCodeRabbitComment(comment: GitHubComment): boolean {
+  if (!isCodeRabbitLogin(comment.user?.login)) return false;
+  const body = comment.body ?? '';
+  return /review in progress by coderabbit\.ai/i.test(body)
+    || /currently processing new changes/i.test(body);
+}
+
 function isCurrentCodeRabbitReview(review: GitHubReview, headRefOid: string | undefined): boolean {
   if (!isCodeRabbitLogin(review.user?.login)) return false;
-  return !headRefOid || review.commit_id === headRefOid;
+  if (!headRefOid) return false;
+  return review.commit_id === headRefOid;
 }
 
 function isCodeRabbitLogin(value: string | undefined): boolean {

--- a/src/cli/pr-closeout.ts
+++ b/src/cli/pr-closeout.ts
@@ -31,6 +31,7 @@ export interface PrMetadata {
 
 export type PrCheckStatus = 'unknown' | 'pending' | 'failing' | 'passing';
 export type PrReviewThreadStatus = 'unknown' | 'pending' | 'settled';
+export type PrReviewerBotStatus = 'unknown' | 'pending' | 'settled';
 export type PrCloseoutSettlementStatus = 'missing' | 'pending' | 'settled';
 
 export interface PrCloseoutStatus {
@@ -44,6 +45,8 @@ export interface PrCloseoutStatus {
   pr: PrMetadata | null;
   prReview: 'missing' | 'pending' | 'reviewed';
   prChecks: PrCheckStatus;
+  reviewerBot: PrReviewerBotStatus;
+  reviewerBotReason?: string;
   prReviewThreads: PrReviewThreadStatus;
   unresolvedReviewThreads?: number;
   closeoutSettlement: PrCloseoutSettlementStatus;
@@ -87,6 +90,7 @@ export function buildPrCloseoutStatus(cwd: string, opts: { sprint?: number; pr?:
   const prReview = resolvePrReviewStatus(cwd, { pr: pr?.number, sprint, branch });
   const closeoutSettlement = resolvePrCloseoutSettlement(cwd, { pr: pr?.number, sprint, branch });
   const prChecks = resolvePrChecks(pr);
+  const reviewerBot = resolveReviewerBotStatus(pr);
   const reviewThreads = resolvePrReviewThreads(pr);
 
   const scorecardPath = sprint
@@ -107,6 +111,8 @@ export function buildPrCloseoutStatus(cwd: string, opts: { sprint?: number; pr?:
     pr,
     prReview,
     prChecks,
+    reviewerBot: reviewerBot.status,
+    reviewerBotReason: reviewerBot.reason,
     prReviewThreads: reviewThreads.status,
     unresolvedReviewThreads: reviewThreads.unresolved,
     closeoutSettlement,
@@ -132,6 +138,10 @@ export function buildPrCloseoutStatus(cwd: string, opts: { sprint?: number; pr?:
     if (status.prChecks === 'pending') status.blockers.push('PR checks are still pending; wait for GitHub checks to finish.');
     if (status.prChecks === 'failing') status.blockers.push('PR checks are failing; fix failing checks before closeout.');
     if (status.prChecks === 'unknown') status.warnings.push('Could not determine PR check status from GitHub.');
+    if (status.reviewerBot === 'pending') {
+      status.blockers.push(status.reviewerBotReason ?? 'Reviewer bot has not completed its PR review.');
+    }
+    if (status.reviewerBot === 'unknown') status.blockers.push('Could not determine reviewer bot status from GitHub comments.');
     if (status.pr.reviewDecision === 'CHANGES_REQUESTED') status.blockers.push('PR has requested changes; address review feedback before closeout.');
     if (status.prReviewThreads === 'pending') {
       const count = status.unresolvedReviewThreads ?? 0;
@@ -148,6 +158,7 @@ export function canSettlePrCloseout(status: PrCloseoutStatus): boolean {
     status.pr
       && status.prReview === 'reviewed'
       && status.prChecks === 'passing'
+      && status.reviewerBot === 'settled'
       && status.prReviewThreads === 'settled'
       && status.pr.reviewDecision !== 'CHANGES_REQUESTED'
       && status.blockers.length === 0,
@@ -167,6 +178,7 @@ export function formatPrCloseoutStatus(status: PrCloseoutStatus): string {
     `PR:              ${status.pr ? `#${status.pr.number}${status.pr.state ? ` ${status.pr.state}` : ''}${status.pr.url ? ` ${status.pr.url}` : ''}` : 'missing'}`,
     `PR review:       ${status.prReview}`,
     `PR checks:       ${status.prChecks}`,
+    `Reviewer bot:    ${formatReviewerBotStatus(status)}`,
     `Review threads:  ${formatReviewThreadStatus(status)}`,
     `Review decision: ${status.pr?.reviewDecision ?? 'unknown'}`,
     `Closeout:        ${status.closeoutSettlement}`,
@@ -192,6 +204,11 @@ function formatReviewThreadStatus(status: PrCloseoutStatus): string {
   if (status.prReviewThreads !== 'pending') return status.prReviewThreads;
   const count = status.unresolvedReviewThreads ?? 0;
   return `${status.prReviewThreads} (${count} unresolved)`;
+}
+
+function formatReviewerBotStatus(status: PrCloseoutStatus): string {
+  if (status.reviewerBot !== 'pending' || !status.reviewerBotReason) return status.reviewerBot;
+  return `${status.reviewerBot} (${status.reviewerBotReason})`;
 }
 
 function formatBranchSize(size: BranchSize): string {
@@ -269,6 +286,101 @@ function resolvePrChecks(pr: PrMetadata | null): PrCheckStatus {
   if (hasFailing) return 'failing';
   if (hasPending) return 'pending';
   return 'passing';
+}
+
+interface GitHubComment {
+  body?: string;
+  created_at?: string;
+  user?: {
+    login?: string;
+  };
+}
+
+interface GitHubReview {
+  body?: string;
+  submitted_at?: string;
+  user?: {
+    login?: string;
+  };
+}
+
+function resolveReviewerBotStatus(pr: PrMetadata | null): { status: PrReviewerBotStatus; reason?: string } {
+  if (!pr?.url) return { status: 'unknown' };
+  const repo = parseGitHubRepo(pr.url);
+  if (!repo) return { status: 'unknown' };
+  if (!hasCodeRabbitSignal(pr)) return { status: 'settled' };
+
+  try {
+    const commentsRaw = execFileSync('gh', [
+      'api',
+      '--method',
+      'GET',
+      `repos/${repo.owner}/${repo.repo}/issues/${pr.number}/comments`,
+      '-F',
+      'per_page=100',
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const reviewsRaw = execFileSync('gh', [
+      'api',
+      '--method',
+      'GET',
+      `repos/${repo.owner}/${repo.repo}/pulls/${pr.number}/reviews`,
+      '-F',
+      'per_page=100',
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const comments = JSON.parse(commentsRaw) as GitHubComment[];
+    const reviews = JSON.parse(reviewsRaw) as GitHubReview[];
+    if (!Array.isArray(comments) || !Array.isArray(reviews)) return { status: 'unknown' };
+
+    const blockedAt = latestTimestamp(comments.filter(isBlockedCodeRabbitComment).map(comment => comment.created_at));
+    if (!blockedAt) return { status: 'settled' };
+
+    const completedAt = latestTimestamp(reviews
+      .filter(review => isCodeRabbitLogin(review.user?.login))
+      .map(review => review.submitted_at));
+    if (completedAt && completedAt > blockedAt) return { status: 'settled' };
+
+    return {
+      status: 'pending',
+      reason: 'CodeRabbit reported a review limit or credit block; retrigger reviewer bot review before closeout.',
+    };
+  } catch {
+    return { status: 'unknown' };
+  }
+}
+
+function hasCodeRabbitSignal(pr: PrMetadata): boolean {
+  const rollup = Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : [];
+  return rollup.some(item => {
+    const check = item as { name?: string; context?: string };
+    return isCodeRabbitLogin(check.name) || isCodeRabbitLogin(check.context);
+  });
+}
+
+export function isBlockedCodeRabbitComment(comment: GitHubComment): boolean {
+  if (!isCodeRabbitLogin(comment.user?.login)) return false;
+  const body = comment.body ?? '';
+  return /review limit reached/i.test(body)
+    || /couldn'?t start this review/i.test(body)
+    || /run out of usage credits/i.test(body)
+    || /more reviews will be available/i.test(body);
+}
+
+function isCodeRabbitLogin(value: string | undefined): boolean {
+  return Boolean(value && /coderabbit/i.test(value));
+}
+
+function latestTimestamp(values: Array<string | undefined>): number | undefined {
+  const timestamps = values
+    .map(value => value ? Date.parse(value) : Number.NaN)
+    .filter(value => Number.isFinite(value));
+  if (timestamps.length === 0) return undefined;
+  return Math.max(...timestamps);
 }
 
 function resolvePrReviewThreads(pr: PrMetadata | null): { status: PrReviewThreadStatus; unresolved?: number } {

--- a/src/cli/pr-closeout.ts
+++ b/src/cli/pr-closeout.ts
@@ -23,6 +23,7 @@ export interface PrMetadata {
   state?: string;
   baseRefName?: string;
   headRefName?: string;
+  headRefOid?: string;
   mergeStateStatus?: string;
   mergeable?: string;
   reviewDecision?: string;
@@ -239,7 +240,7 @@ function currentPr(prNumber?: number): PrMetadata | null {
       'view',
       ...(prNumber ? [String(prNumber)] : []),
       '--json',
-      'number,url,state,baseRefName,headRefName,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup',
+      'number,url,state,baseRefName,headRefName,headRefOid,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup',
     ];
     const raw = execFileSync('gh', args, {
       encoding: 'utf8',
@@ -291,6 +292,7 @@ function resolvePrChecks(pr: PrMetadata | null): PrCheckStatus {
 interface GitHubComment {
   body?: string;
   created_at?: string;
+  updated_at?: string;
   user?: {
     login?: string;
   };
@@ -298,6 +300,7 @@ interface GitHubComment {
 
 interface GitHubReview {
   body?: string;
+  commit_id?: string;
   submitted_at?: string;
   user?: {
     login?: string;
@@ -337,11 +340,13 @@ function resolveReviewerBotStatus(pr: PrMetadata | null): { status: PrReviewerBo
     const reviews = JSON.parse(reviewsRaw) as GitHubReview[];
     if (!Array.isArray(comments) || !Array.isArray(reviews)) return { status: 'unknown' };
 
-    const blockedAt = latestTimestamp(comments.filter(isBlockedCodeRabbitComment).map(comment => comment.created_at));
+    const blockedAt = latestTimestamp(comments
+      .filter(isBlockedCodeRabbitComment)
+      .map(comment => comment.updated_at ?? comment.created_at));
     if (!blockedAt) return { status: 'settled' };
 
     const completedAt = latestTimestamp(reviews
-      .filter(review => isCodeRabbitLogin(review.user?.login))
+      .filter(review => isCurrentCodeRabbitReview(review, pr.headRefOid))
       .map(review => review.submitted_at));
     if (completedAt && completedAt > blockedAt) return { status: 'settled' };
 
@@ -369,6 +374,11 @@ export function isBlockedCodeRabbitComment(comment: GitHubComment): boolean {
     || /couldn'?t start this review/i.test(body)
     || /run out of usage credits/i.test(body)
     || /more reviews will be available/i.test(body);
+}
+
+function isCurrentCodeRabbitReview(review: GitHubReview, headRefOid: string | undefined): boolean {
+  if (!isCodeRabbitLogin(review.user?.login)) return false;
+  return !headRefOid || review.commit_id === headRefOid;
 }
 
 function isCodeRabbitLogin(value: string | undefined): boolean {

--- a/src/cli/pr-closeout.ts
+++ b/src/cli/pr-closeout.ts
@@ -23,7 +23,15 @@ export interface PrMetadata {
   state?: string;
   baseRefName?: string;
   headRefName?: string;
+  mergeStateStatus?: string;
+  mergeable?: string;
+  reviewDecision?: string;
+  statusCheckRollup?: unknown[];
 }
+
+export type PrCheckStatus = 'unknown' | 'pending' | 'failing' | 'passing';
+export type PrReviewThreadStatus = 'unknown' | 'pending' | 'settled';
+export type PrCloseoutSettlementStatus = 'missing' | 'pending' | 'settled';
 
 export interface PrCloseoutStatus {
   sprint?: number;
@@ -35,6 +43,10 @@ export interface PrCloseoutStatus {
   unpushedCommits?: number;
   pr: PrMetadata | null;
   prReview: 'missing' | 'pending' | 'reviewed';
+  prChecks: PrCheckStatus;
+  prReviewThreads: PrReviewThreadStatus;
+  unresolvedReviewThreads?: number;
+  closeoutSettlement: PrCloseoutSettlementStatus;
   branchSize: BranchSize;
   branchSizeWarnings: string[];
   blockers: string[];
@@ -64,15 +76,18 @@ export function branchSizeWarnings(size: BranchSize, policy: PrCloseoutPolicy): 
   return warnings;
 }
 
-export function buildPrCloseoutStatus(cwd: string, opts: { sprint?: number } = {}): PrCloseoutStatus {
+export function buildPrCloseoutStatus(cwd: string, opts: { sprint?: number; pr?: number } = {}): PrCloseoutStatus {
   const config = loadConfig(cwd);
   const policy = closeoutPolicy(cwd);
   const sprint = opts.sprint ?? inferSprint(cwd);
   const branch = currentBranch(cwd);
-  const pr = currentPr();
+  const pr = currentPr(opts.pr);
   const base = pr?.baseRefName ? `origin/${pr.baseRefName}` : inferBaseRef(cwd);
   const branchSize = collectBranchSize(cwd, base);
   const prReview = resolvePrReviewStatus(cwd, { pr: pr?.number, sprint, branch });
+  const closeoutSettlement = resolvePrCloseoutSettlement(cwd, { pr: pr?.number, sprint, branch });
+  const prChecks = resolvePrChecks(pr);
+  const reviewThreads = resolvePrReviewThreads(pr);
 
   const scorecardPath = sprint
     ? join(cwd, config.scorecardDir, config.scorecardPattern.replaceAll('*', String(sprint)))
@@ -91,6 +106,10 @@ export function buildPrCloseoutStatus(cwd: string, opts: { sprint?: number } = {
     unpushedCommits: countUnpushedCommits(cwd),
     pr,
     prReview,
+    prChecks,
+    prReviewThreads: reviewThreads.status,
+    unresolvedReviewThreads: reviewThreads.unresolved,
+    closeoutSettlement,
     branchSize,
     branchSizeWarnings: branchSizeWarnings(branchSize, policy),
     blockers: [],
@@ -109,8 +128,30 @@ export function buildPrCloseoutStatus(cwd: string, opts: { sprint?: number } = {
       ? 'PR review is pending; run slope pr review.'
       : 'No PR implementation review record found; run slope pr review.');
   }
+  if (status.pr) {
+    if (status.prChecks === 'pending') status.blockers.push('PR checks are still pending; wait for GitHub checks to finish.');
+    if (status.prChecks === 'failing') status.blockers.push('PR checks are failing; fix failing checks before closeout.');
+    if (status.prChecks === 'unknown') status.warnings.push('Could not determine PR check status from GitHub.');
+    if (status.pr.reviewDecision === 'CHANGES_REQUESTED') status.blockers.push('PR has requested changes; address review feedback before closeout.');
+    if (status.prReviewThreads === 'pending') {
+      const count = status.unresolvedReviewThreads ?? 0;
+      status.blockers.push(`${count} unresolved PR review thread${count === 1 ? '' : 's'} remain; address or resolve review feedback before closeout.`);
+    }
+    if (status.prReviewThreads === 'unknown') status.warnings.push('Could not determine unresolved PR review thread status from GitHub.');
+  }
   status.warnings.push(...status.branchSizeWarnings);
   return status;
+}
+
+export function canSettlePrCloseout(status: PrCloseoutStatus): boolean {
+  return Boolean(
+    status.pr
+      && status.prReview === 'reviewed'
+      && status.prChecks === 'passing'
+      && status.prReviewThreads === 'settled'
+      && status.pr.reviewDecision !== 'CHANGES_REQUESTED'
+      && status.blockers.length === 0,
+  );
 }
 
 export function formatPrCloseoutStatus(status: PrCloseoutStatus): string {
@@ -125,6 +166,10 @@ export function formatPrCloseoutStatus(status: PrCloseoutStatus): string {
     `Push state:      ${formatPushState(status.unpushedCommits)}`,
     `PR:              ${status.pr ? `#${status.pr.number}${status.pr.state ? ` ${status.pr.state}` : ''}${status.pr.url ? ` ${status.pr.url}` : ''}` : 'missing'}`,
     `PR review:       ${status.prReview}`,
+    `PR checks:       ${status.prChecks}`,
+    `Review threads:  ${formatReviewThreadStatus(status)}`,
+    `Review decision: ${status.pr?.reviewDecision ?? 'unknown'}`,
+    `Closeout:        ${status.closeoutSettlement}`,
     `Branch size:     ${formatBranchSize(status.branchSize)}`,
   ];
 
@@ -141,6 +186,12 @@ export function formatPrCloseoutStatus(status: PrCloseoutStatus): string {
 function formatPushState(unpushed: number | undefined): string {
   if (typeof unpushed !== 'number') return 'unknown';
   return unpushed === 0 ? 'ok' : `${unpushed} unpushed`;
+}
+
+function formatReviewThreadStatus(status: PrCloseoutStatus): string {
+  if (status.prReviewThreads !== 'pending') return status.prReviewThreads;
+  const count = status.unresolvedReviewThreads ?? 0;
+  return `${status.prReviewThreads} (${count} unresolved)`;
 }
 
 function formatBranchSize(size: BranchSize): string {
@@ -164,9 +215,16 @@ function currentBranch(cwd: string): string | undefined {
   }
 }
 
-function currentPr(): PrMetadata | null {
+function currentPr(prNumber?: number): PrMetadata | null {
   try {
-    const raw = execFileSync('gh', ['pr', 'view', '--json', 'number,url,state,baseRefName,headRefName'], {
+    const args = [
+      'pr',
+      'view',
+      ...(prNumber ? [String(prNumber)] : []),
+      '--json',
+      'number,url,state,baseRefName,headRefName,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup',
+    ];
+    const raw = execFileSync('gh', args, {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
@@ -175,6 +233,105 @@ function currentPr(): PrMetadata | null {
   } catch {
     return null;
   }
+}
+
+function resolvePrChecks(pr: PrMetadata | null): PrCheckStatus {
+  if (!pr) return 'unknown';
+  const rollup = Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : undefined;
+  if (!rollup) return 'unknown';
+  if (rollup.length === 0) return 'passing';
+
+  let hasPending = false;
+  let hasFailing = false;
+  for (const item of rollup) {
+    const check = item as {
+      __typename?: string;
+      status?: string;
+      conclusion?: string;
+      state?: string;
+    };
+
+    if (check.__typename === 'StatusContext') {
+      if (check.state === 'PENDING') hasPending = true;
+      else if (check.state && check.state !== 'SUCCESS') hasFailing = true;
+      continue;
+    }
+
+    if (check.status && check.status !== 'COMPLETED') {
+      hasPending = true;
+      continue;
+    }
+    if (check.conclusion && !['SUCCESS', 'SKIPPED', 'NEUTRAL'].includes(check.conclusion)) {
+      hasFailing = true;
+    }
+  }
+
+  if (hasFailing) return 'failing';
+  if (hasPending) return 'pending';
+  return 'passing';
+}
+
+function resolvePrReviewThreads(pr: PrMetadata | null): { status: PrReviewThreadStatus; unresolved?: number } {
+  if (!pr?.url) return { status: 'unknown' };
+  const repo = parseGitHubRepo(pr.url);
+  if (!repo) return { status: 'unknown' };
+
+  try {
+    const query = `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewThreads(first: 100) {
+              nodes {
+                isResolved
+                isOutdated
+              }
+            }
+          }
+        }
+      }
+    `;
+    const raw = execFileSync('gh', [
+      'api',
+      'graphql',
+      '-f',
+      `query=${query}`,
+      '-F',
+      `owner=${repo.owner}`,
+      '-F',
+      `repo=${repo.repo}`,
+      '-F',
+      `number=${pr.number}`,
+    ], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const parsed = JSON.parse(raw) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviewThreads?: {
+              nodes?: Array<{ isResolved?: boolean; isOutdated?: boolean }>;
+            };
+          };
+        };
+      };
+    };
+    const nodes = parsed.data?.repository?.pullRequest?.reviewThreads?.nodes;
+    if (!Array.isArray(nodes)) return { status: 'unknown' };
+    const unresolved = nodes.filter(node => !node.isResolved && !node.isOutdated).length;
+    return unresolved > 0
+      ? { status: 'pending', unresolved }
+      : { status: 'settled', unresolved: 0 };
+  } catch {
+    return { status: 'unknown' };
+  }
+}
+
+function parseGitHubRepo(url: string): { owner: string; repo: string } | null {
+  const match = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/\d+/);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2] };
 }
 
 function countUnpushedCommits(cwd: string): number | undefined {
@@ -224,13 +381,24 @@ function collectBranchSize(cwd: string, base: string | undefined): BranchSize {
 }
 
 function resolvePrReviewStatus(cwd: string, input: { pr?: number; sprint?: number; branch?: string }): 'missing' | 'pending' | 'reviewed' {
+  const matching = matchingPrReviews(cwd, input);
+  if (matching.some(review => review.status === 'reviewed')) return 'reviewed';
+  if (matching.some(review => review.status === 'pending')) return 'pending';
+  return 'missing';
+}
+
+function resolvePrCloseoutSettlement(cwd: string, input: { pr?: number; sprint?: number; branch?: string }): PrCloseoutSettlementStatus {
+  const matching = matchingPrReviews(cwd, input);
+  if (matching.some(review => review.closeout_status === 'settled')) return 'settled';
+  if (matching.length > 0) return 'pending';
+  return 'missing';
+}
+
+function matchingPrReviews(cwd: string, input: { pr?: number; sprint?: number; branch?: string }) {
   const reviews = loadPrReviewState(cwd).reviews;
-  const matching = reviews.filter(review =>
+  return reviews.filter(review =>
     (input.pr != null && review.pr === input.pr)
     || (input.sprint != null && review.sprint === input.sprint)
     || (input.branch != null && review.branch === input.branch),
   );
-  if (matching.some(review => review.status === 'reviewed')) return 'reviewed';
-  if (matching.some(review => review.status === 'pending')) return 'pending';
-  return 'missing';
 }

--- a/src/cli/pr-review-state.ts
+++ b/src/cli/pr-review-state.ts
@@ -151,7 +151,7 @@ export function pendingPrReviews(cwd: string, sprint?: number): PrReviewRecord[]
 export function pendingPrCloseouts(cwd: string, sprint?: number): PrReviewRecord[] {
   return loadPrReviewState(cwd).reviews
     .filter(review => review.status === 'reviewed')
-    .filter(review => review.closeout_status !== 'settled')
+    .filter(review => review.closeout_status === 'pending')
     .filter(review => sprint == null || review.sprint == null || review.sprint === sprint)
     .sort((a, b) => b.pr - a.pr);
 }

--- a/src/cli/pr-review-state.ts
+++ b/src/cli/pr-review-state.ts
@@ -8,8 +8,10 @@ export interface PrReviewRecord {
   sprint?: number;
   branch?: string;
   status: 'pending' | 'reviewed';
+  closeout_status?: 'pending' | 'settled';
   created_at: string;
   reviewed_at?: string;
+  closeout_settled_at?: string;
   review_type?: 'architect' | 'code' | 'both';
 }
 
@@ -37,6 +39,11 @@ function isPrReviewRecord(value: unknown): value is PrReviewRecord {
     record
       && typeof record.pr === 'number'
       && (record.status === 'pending' || record.status === 'reviewed')
+      && (
+        record.closeout_status == null
+        || record.closeout_status === 'pending'
+        || record.closeout_status === 'settled'
+      )
       && typeof record.created_at === 'string',
   );
 }
@@ -59,12 +66,14 @@ export function recordPrReviewPending(cwd: string, input: { pr: number; sprint?:
     existing.sprint = input.sprint ?? existing.sprint;
     existing.branch = input.branch ?? existing.branch;
     if (existing.status !== 'reviewed') existing.status = 'pending';
+    if (existing.closeout_status !== 'settled') existing.closeout_status = 'pending';
   } else {
     state.reviews.push({
       pr: input.pr,
       sprint: input.sprint,
       branch: input.branch,
       status: 'pending',
+      closeout_status: 'pending',
       created_at: now,
     });
   }
@@ -86,12 +95,14 @@ export function recordPrReviewComplete(
     existing.status = 'reviewed';
     existing.reviewed_at = now;
     existing.review_type = input.reviewType ?? existing.review_type;
+    if (existing.closeout_status !== 'settled') existing.closeout_status = 'pending';
   } else {
     state.reviews.push({
       pr: input.pr,
       sprint: input.sprint,
       branch: input.branch,
       status: 'reviewed',
+      closeout_status: 'pending',
       created_at: now,
       reviewed_at: now,
       review_type: input.reviewType,
@@ -101,9 +112,46 @@ export function recordPrReviewComplete(
   savePrReviewState(cwd, state);
 }
 
+export function recordPrCloseoutSettled(
+  cwd: string,
+  input: { pr: number; sprint?: number; branch?: string },
+): void {
+  const state = loadPrReviewState(cwd);
+  const now = new Date().toISOString();
+  const existing = state.reviews.find(review => review.pr === input.pr);
+
+  if (existing) {
+    existing.sprint = input.sprint ?? existing.sprint;
+    existing.branch = input.branch ?? existing.branch;
+    existing.closeout_status = 'settled';
+    existing.closeout_settled_at = now;
+  } else {
+    state.reviews.push({
+      pr: input.pr,
+      sprint: input.sprint,
+      branch: input.branch,
+      status: 'reviewed',
+      closeout_status: 'settled',
+      created_at: now,
+      reviewed_at: now,
+      closeout_settled_at: now,
+    });
+  }
+
+  savePrReviewState(cwd, state);
+}
+
 export function pendingPrReviews(cwd: string, sprint?: number): PrReviewRecord[] {
   return loadPrReviewState(cwd).reviews
     .filter(review => review.status === 'pending')
+    .filter(review => sprint == null || review.sprint == null || review.sprint === sprint)
+    .sort((a, b) => b.pr - a.pr);
+}
+
+export function pendingPrCloseouts(cwd: string, sprint?: number): PrReviewRecord[] {
+  return loadPrReviewState(cwd).reviews
+    .filter(review => review.status === 'reviewed')
+    .filter(review => review.closeout_status !== 'settled')
     .filter(review => sprint == null || review.sprint == null || review.sprint === sprint)
     .sort((a, b) => b.pr - a.pr);
 }

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -720,6 +720,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
         { flag: '--type=<type>', desc: 'architect, code, or both' },
       ]},
       { name: 'status', desc: 'Check PR closeout readiness', flags: [
+        { flag: '--pr=<N>', desc: 'PR number (default: resolved from current branch)' },
         { flag: '--sprint=<N>', desc: 'Sprint number for scorecard/review checks' },
       ]},
       { name: 'issues', desc: 'Print extracted issue refs from the branch commits' },

--- a/tests/cli/guards/post-hole-enforcement.test.ts
+++ b/tests/cli/guards/post-hole-enforcement.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import { postHoleEnforcementGuard } from '../../../src/cli/guards/post-hole-enforcement.js';
-import { recordPrReviewComplete, recordPrReviewPending } from '../../../src/cli/pr-review-state.js';
+import { recordPrCloseoutSettled, recordPrReviewComplete, recordPrReviewPending } from '../../../src/cli/pr-review-state.js';
 import type { HookInput } from '../../../src/core/index.js';
 
 function makeTmpRepo(): string {
@@ -89,10 +89,23 @@ describe('postHoleEnforcementGuard', () => {
     expect(result.context).toContain('slope pr review --pr=42 --sprint=7');
   });
 
-  it('does not warn when created PR review is recorded complete', async () => {
+  it('warns when PR review is recorded but closeout settlement is still pending', async () => {
     writeRoadmap(cwd, [{ id: 7, status: 'planned' }]);
     recordPrReviewPending(cwd, { pr: 42, sprint: 7, branch: 'fix/test' });
     recordPrReviewComplete(cwd, { pr: 42, sprint: 7, reviewType: 'both' });
+
+    const result = await postHoleEnforcementGuard(stopInput, cwd);
+    expect(result.context).toContain('SLOPE PR closeout enforcement');
+    expect(result.context).toContain('PR #42');
+    expect(result.context).toContain('slope pr status --pr=42 --sprint=7');
+    expect(result.context).toContain('review/check settlement');
+  });
+
+  it('does not warn when created PR review and closeout settlement are recorded complete', async () => {
+    writeRoadmap(cwd, [{ id: 7, status: 'planned' }]);
+    recordPrReviewPending(cwd, { pr: 42, sprint: 7, branch: 'fix/test' });
+    recordPrReviewComplete(cwd, { pr: 42, sprint: 7, reviewType: 'both' });
+    recordPrCloseoutSettled(cwd, { pr: 42, sprint: 7, branch: 'fix/test' });
 
     const result = await postHoleEnforcementGuard(stopInput, cwd);
     expect(result).toEqual({});

--- a/tests/cli/guards/pr-review-recommend.test.ts
+++ b/tests/cli/guards/pr-review-recommend.test.ts
@@ -88,6 +88,7 @@ describe('prReviewGuard recommendations (GH #302)', () => {
       cwd,
     );
     expect(result.context).toContain('slope pr review --pr=42');
+    expect(result.context).toContain('slope pr status --pr=42');
   });
 });
 

--- a/tests/cli/guards/pr-review.test.ts
+++ b/tests/cli/guards/pr-review.test.ts
@@ -32,6 +32,7 @@ describe('prReviewGuard', () => {
     expect(result.suggestion).toBeUndefined();
     expect(result.context).toContain('pull/42');
     expect(result.context).toContain('slope pr review --pr=42');
+    expect(result.context).toContain('slope pr status --pr=42');
   });
 
   it('formats as PostToolUse additionalContext instead of a block decision', async () => {
@@ -113,6 +114,7 @@ describe('prReviewGuard', () => {
         pr: 42,
         sprint: 100,
         status: 'pending',
+        closeout_status: 'pending',
       });
     } finally {
       rmSync(cwd, { recursive: true, force: true });

--- a/tests/cli/guards/sprint-completion.test.ts
+++ b/tests/cli/guards/sprint-completion.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync
 import { homedir } from 'node:os';
 import { join, relative } from 'node:path';
 import { sprintCompletionGuard } from '../../../src/cli/guards/sprint-completion.js';
-import { recordPrReviewComplete } from '../../../src/cli/pr-review-state.js';
+import { recordPrCloseoutSettled, recordPrReviewComplete } from '../../../src/cli/pr-review-state.js';
 import { saveSprintState, createSprintState, loadSprintState } from '../../../src/cli/sprint-state.js';
 import type { HookInput } from '../../../src/core/index.js';
 
@@ -505,13 +505,26 @@ describe('sprint-completion guard', () => {
       expect(result.context).toContain('slope pr review');
     });
 
-    it('does not warn when PR implementation review is already recorded', async () => {
+    it('warns when PR implementation review is recorded but closeout settlement is still pending', async () => {
       recordPrReviewComplete(tmpDir, { pr: 42, sprint: 22, reviewType: 'both' });
 
       const result = await sprintCompletionGuard(makePostToolUse('slope review docs/retros/sprint-22.json', 0), tmpDir);
 
       expect(result.context).toContain('Review generated');
       expect(result.context).not.toContain('sprint retrospective review is not PR implementation review');
+      expect(result.context).toContain('review/check settlement is still pending');
+      expect(result.context).toContain('slope pr status --pr=42 --sprint=22');
+    });
+
+    it('does not warn when PR implementation review and closeout settlement are already recorded', async () => {
+      recordPrReviewComplete(tmpDir, { pr: 42, sprint: 22, reviewType: 'both' });
+      recordPrCloseoutSettled(tmpDir, { pr: 42, sprint: 22 });
+
+      const result = await sprintCompletionGuard(makePostToolUse('slope review docs/retros/sprint-22.json', 0), tmpDir);
+
+      expect(result.context).toContain('Review generated');
+      expect(result.context).not.toContain('sprint retrospective review is not PR implementation review');
+      expect(result.context).not.toContain('review/check settlement is still pending');
     });
   });
 });

--- a/tests/cli/pr-finalize.test.ts
+++ b/tests/cli/pr-finalize.test.ts
@@ -5,7 +5,7 @@ import {
   existingAutoCloseRefs,
   formatReviewRecommendations,
 } from '../../src/cli/commands/pr.js';
-import { branchSizeWarnings, formatPrCloseoutStatus } from '../../src/cli/pr-closeout.js';
+import { branchSizeWarnings, canSettlePrCloseout, formatPrCloseoutStatus } from '../../src/cli/pr-closeout.js';
 
 describe('extractIssueRefs (GH #321)', () => {
   it('extracts a single issue ref', () => {
@@ -108,6 +108,9 @@ describe('pr closeout status helpers (S130)', () => {
       unpushedCommits: 0,
       pr: { number: 468, state: 'OPEN', url: 'https://github.com/org/repo/pull/468' },
       prReview: 'missing',
+      prChecks: 'unknown',
+      prReviewThreads: 'unknown',
+      closeoutSettlement: 'missing',
       branchSize: { base: 'origin/main', commits: 4, files: 8 },
       branchSizeWarnings: [],
       blockers: ['No PR implementation review record found; run slope pr review.'],
@@ -116,6 +119,44 @@ describe('pr closeout status helpers (S130)', () => {
 
     expect(output).toContain('PR closeout status');
     expect(output).toContain('PR review:       missing');
+    expect(output).toContain('PR checks:       unknown');
+    expect(output).toContain('Review threads:  unknown');
+    expect(output).toContain('Closeout:        missing');
     expect(output).toContain('Not ready for PR closeout.');
+  });
+
+  it('requires checks and review threads to settle before closeout can settle', () => {
+    const status = {
+      sprint: 130,
+      branch: 'feat/closeout',
+      scorecardPath: '/repo/docs/retros/sprint-130.json',
+      scorecardExists: true,
+      sprintReviewPath: '/repo/docs/retros/sprint-130-review.md',
+      sprintReviewExists: true,
+      unpushedCommits: 0,
+      pr: { number: 468, state: 'OPEN', url: 'https://github.com/org/repo/pull/468' },
+      prReview: 'reviewed' as const,
+      prChecks: 'pending' as const,
+      prReviewThreads: 'settled' as const,
+      closeoutSettlement: 'pending' as const,
+      branchSize: { base: 'origin/main', commits: 4, files: 8 },
+      branchSizeWarnings: [],
+      blockers: ['PR checks are still pending; wait for GitHub checks to finish.'],
+      warnings: [],
+    };
+
+    expect(canSettlePrCloseout(status)).toBe(false);
+    expect(canSettlePrCloseout({
+      ...status,
+      prChecks: 'passing',
+      blockers: [],
+    })).toBe(true);
+    expect(canSettlePrCloseout({
+      ...status,
+      prChecks: 'passing',
+      prReviewThreads: 'pending',
+      unresolvedReviewThreads: 1,
+      blockers: ['1 unresolved PR review thread remains; address or resolve review feedback before closeout.'],
+    })).toBe(false);
   });
 });

--- a/tests/cli/pr-finalize.test.ts
+++ b/tests/cli/pr-finalize.test.ts
@@ -5,7 +5,7 @@ import {
   existingAutoCloseRefs,
   formatReviewRecommendations,
 } from '../../src/cli/commands/pr.js';
-import { branchSizeWarnings, canSettlePrCloseout, formatPrCloseoutStatus, isBlockedCodeRabbitComment } from '../../src/cli/pr-closeout.js';
+import { branchSizeWarnings, canSettlePrCloseout, formatPrCloseoutStatus, hasSuccessfulCodeRabbitStatus, isBlockedCodeRabbitComment } from '../../src/cli/pr-closeout.js';
 
 describe('extractIssueRefs (GH #321)', () => {
   it('extracts a single issue ref', () => {
@@ -208,6 +208,22 @@ describe('pr closeout status helpers (S130)', () => {
     expect(isBlockedCodeRabbitComment({
       user: { login: 'github-actions[bot]' },
       body: "Review limit reached: we couldn't start this review.",
+    })).toBe(false);
+  });
+
+  it('recognizes successful current-head CodeRabbit status contexts', () => {
+    expect(hasSuccessfulCodeRabbitStatus({
+      statusCheckRollup: [{ __typename: 'StatusContext', context: 'CodeRabbit', state: 'SUCCESS' }],
+    })).toBe(true);
+
+    expect(hasSuccessfulCodeRabbitStatus({
+      statusCheckRollup: [{ __typename: 'StatusContext', context: 'CodeRabbit', state: 'PENDING' }],
+    })).toBe(false);
+    expect(hasSuccessfulCodeRabbitStatus({
+      statusCheckRollup: [{ __typename: 'CheckRun', name: 'CodeRabbit', status: 'COMPLETED', conclusion: 'SUCCESS' }],
+    })).toBe(true);
+    expect(hasSuccessfulCodeRabbitStatus({
+      statusCheckRollup: [{ __typename: 'StatusContext', context: 'ci', state: 'SUCCESS' }],
     })).toBe(false);
   });
 });

--- a/tests/cli/pr-finalize.test.ts
+++ b/tests/cli/pr-finalize.test.ts
@@ -5,7 +5,7 @@ import {
   existingAutoCloseRefs,
   formatReviewRecommendations,
 } from '../../src/cli/commands/pr.js';
-import { branchSizeWarnings, canSettlePrCloseout, formatPrCloseoutStatus } from '../../src/cli/pr-closeout.js';
+import { branchSizeWarnings, canSettlePrCloseout, formatPrCloseoutStatus, isBlockedCodeRabbitComment } from '../../src/cli/pr-closeout.js';
 
 describe('extractIssueRefs (GH #321)', () => {
   it('extracts a single issue ref', () => {
@@ -109,6 +109,7 @@ describe('pr closeout status helpers (S130)', () => {
       pr: { number: 468, state: 'OPEN', url: 'https://github.com/org/repo/pull/468' },
       prReview: 'missing',
       prChecks: 'unknown',
+      reviewerBot: 'unknown',
       prReviewThreads: 'unknown',
       closeoutSettlement: 'missing',
       branchSize: { base: 'origin/main', commits: 4, files: 8 },
@@ -120,6 +121,7 @@ describe('pr closeout status helpers (S130)', () => {
     expect(output).toContain('PR closeout status');
     expect(output).toContain('PR review:       missing');
     expect(output).toContain('PR checks:       unknown');
+    expect(output).toContain('Reviewer bot:    unknown');
     expect(output).toContain('Review threads:  unknown');
     expect(output).toContain('Closeout:        missing');
     expect(output).toContain('Not ready for PR closeout.');
@@ -137,6 +139,7 @@ describe('pr closeout status helpers (S130)', () => {
       pr: { number: 468, state: 'OPEN', url: 'https://github.com/org/repo/pull/468' },
       prReview: 'reviewed' as const,
       prChecks: 'pending' as const,
+      reviewerBot: 'settled' as const,
       prReviewThreads: 'settled' as const,
       closeoutSettlement: 'pending' as const,
       branchSize: { base: 'origin/main', commits: 4, files: 8 },
@@ -157,6 +160,54 @@ describe('pr closeout status helpers (S130)', () => {
       prReviewThreads: 'pending',
       unresolvedReviewThreads: 1,
       blockers: ['1 unresolved PR review thread remains; address or resolve review feedback before closeout.'],
+    })).toBe(false);
+    expect(canSettlePrCloseout({
+      ...status,
+      prChecks: 'passing',
+      reviewerBot: 'unknown',
+      blockers: ['Could not determine reviewer bot status from GitHub comments.'],
+    })).toBe(false);
+  });
+
+  it('blocks settlement when reviewer bot review is rate limited', () => {
+    const status = {
+      sprint: 130,
+      branch: 'feat/closeout',
+      scorecardPath: '/repo/docs/retros/sprint-130.json',
+      scorecardExists: true,
+      sprintReviewPath: '/repo/docs/retros/sprint-130-review.md',
+      sprintReviewExists: true,
+      unpushedCommits: 0,
+      pr: { number: 468, state: 'OPEN', url: 'https://github.com/org/repo/pull/468' },
+      prReview: 'reviewed' as const,
+      prChecks: 'passing' as const,
+      reviewerBot: 'pending' as const,
+      reviewerBotReason: 'CodeRabbit reported a review limit or credit block; retrigger reviewer bot review before closeout.',
+      prReviewThreads: 'settled' as const,
+      closeoutSettlement: 'pending' as const,
+      branchSize: { base: 'origin/main', commits: 4, files: 8 },
+      branchSizeWarnings: [],
+      blockers: ['CodeRabbit reported a review limit or credit block; retrigger reviewer bot review before closeout.'],
+      warnings: [],
+    };
+
+    expect(canSettlePrCloseout(status)).toBe(false);
+    expect(formatPrCloseoutStatus(status)).toContain('Reviewer bot:    pending (CodeRabbit reported');
+  });
+
+  it('detects CodeRabbit comments that mean no review actually ran', () => {
+    expect(isBlockedCodeRabbitComment({
+      user: { login: 'coderabbitai[bot]' },
+      body: "Review limit reached: we couldn't start this review because usage credits ran out.",
+    })).toBe(true);
+
+    expect(isBlockedCodeRabbitComment({
+      user: { login: 'coderabbitai[bot]' },
+      body: 'Walkthrough: implementation summary and recommendations.',
+    })).toBe(false);
+    expect(isBlockedCodeRabbitComment({
+      user: { login: 'github-actions[bot]' },
+      body: "Review limit reached: we couldn't start this review.",
     })).toBe(false);
   });
 });

--- a/tests/cli/pr-review-state.test.ts
+++ b/tests/cli/pr-review-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -47,6 +47,21 @@ describe('pr review state', () => {
     expect(state.reviews[0].status).toBe('reviewed');
     expect(state.reviews[0].closeout_status).toBe('settled');
     expect(state.reviews[0].closeout_settled_at).toBeDefined();
+    expect(pendingPrCloseouts(cwd, 100)).toEqual([]);
+  });
+
+  it('does not treat legacy reviewed records without closeout status as pending closeouts', () => {
+    mkdirSync(join(cwd, '.slope'), { recursive: true });
+    writeFileSync(join(cwd, '.slope', 'pr-reviews.json'), JSON.stringify({
+      reviews: [{
+        pr: 41,
+        sprint: 100,
+        status: 'reviewed',
+        created_at: new Date().toISOString(),
+        reviewed_at: new Date().toISOString(),
+      }],
+    }));
+
     expect(pendingPrCloseouts(cwd, 100)).toEqual([]);
   });
 

--- a/tests/cli/pr-review-state.test.ts
+++ b/tests/cli/pr-review-state.test.ts
@@ -4,7 +4,9 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   loadPrReviewState,
+  pendingPrCloseouts,
   pendingPrReviews,
+  recordPrCloseoutSettled,
   recordPrReviewComplete,
   recordPrReviewPending,
 } from '../../src/cli/pr-review-state.js';
@@ -30,8 +32,22 @@ describe('pr review state', () => {
 
     expect(state.reviews).toHaveLength(1);
     expect(state.reviews[0].status).toBe('reviewed');
+    expect(state.reviews[0].closeout_status).toBe('pending');
     expect(state.reviews[0].reviewed_at).toBeDefined();
     expect(pendingPrReviews(cwd, 100)).toEqual([]);
+    expect(pendingPrCloseouts(cwd, 100).map(review => review.pr)).toEqual([42]);
+  });
+
+  it('marks closeout settlement separately from review completion', () => {
+    recordPrReviewPending(cwd, { pr: 42, sprint: 100, branch: 'fix/test' });
+    recordPrReviewComplete(cwd, { pr: 42, sprint: 100, reviewType: 'both' });
+    recordPrCloseoutSettled(cwd, { pr: 42, sprint: 100, branch: 'fix/test' });
+
+    const state = loadPrReviewState(cwd);
+    expect(state.reviews[0].status).toBe('reviewed');
+    expect(state.reviews[0].closeout_status).toBe('settled');
+    expect(state.reviews[0].closeout_settled_at).toBeDefined();
+    expect(pendingPrCloseouts(cwd, 100)).toEqual([]);
   });
 
   it('does not downgrade an already reviewed PR back to pending', () => {


### PR DESCRIPTION
## Summary
- add a separate PR closeout settlement state so `slope pr review` no longer implies checks/review threads are settled
- teach `slope pr status` to inspect GitHub checks, requested changes, unresolved review threads, and reviewer-bot settlement before recording closeout
- detect false-green CodeRabbit states such as rate-limit/credit blocks and stale bot reviews from older PR heads
- avoid re-flagging legacy reviewed PR records that predate `closeout_status`
- surface pending closeout settlement from PR creation, sprint completion, and post-hole enforcement guidance

## Validation
- pnpm vitest run tests/cli/pr-review-state.test.ts tests/cli/guards/pr-review.test.ts tests/cli/guards/pr-review-recommend.test.ts tests/cli/guards/post-hole-enforcement.test.ts tests/cli/guards/sprint-completion.test.ts tests/cli/pr-finalize.test.ts
- pnpm vitest run tests/cli/commands/guard.test.ts tests/cli/pr-help.test.ts tests/cli/guard-status.test.ts tests/cli/guards.test.ts
- pnpm vitest run tests/cli/pr-review-state.test.ts tests/cli/pr-finalize.test.ts
- pnpm run typecheck
- pnpm run build
- pnpm test
- git diff --check
- gh pr checks 487
- python3 .../gh-address-comments/scripts/fetch_comments.py --pr 487 --repo srbryers/slope
- pnpm exec slope pr status --pr=487 (currently blocks on CodeRabbit rate-limit for final follow-up commit)

Closes #486