### PR TITLE
fix(S132): scorecard and review closeout correctness

### DIFF
--- a/docs/retros/sprint-132-review.md
+++ b/docs/retros/sprint-132-review.md
@@ -1,0 +1,21 @@
+## Sprint 132 Review: Scorecard and review closeout correctness
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 0 |
+| Score | 1 |
+| Label | Eagle |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S132-1 | Driver | Green | — | 11 files changed (Clean git signals but no CI confirmation — defaulting to green) |
+

--- a/docs/retros/sprint-132.json
+++ b/docs/retros/sprint-132.json
@@ -1,0 +1,47 @@
+{
+  "sprint_number": 132,
+  "player": "sebastianbryers",
+  "theme": "Scorecard and review closeout correctness",
+  "par": 3,
+  "slope": 0,
+  "score": 1,
+  "score_label": "eagle",
+  "date": "2026-06-03",
+  "shots": [
+    {
+      "ticket_key": "S132-1",
+      "title": "fix(S132): normalize ticket scorecards and review artifacts",
+      "club": "driver",
+      "result": "green",
+      "hazards": [],
+      "notes": "11 files changed (Clean git signals but no CI confirmation — defaulting to green)"
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [],
+  "slope_factors": [],
+  "_auto_generated": true,
+  "_commits": 1,
+  "_ci_signal": null,
+  "_pr_signal": null,
+  "_note": "Auto-generated from git only (no CI). Shots default to green. Provide --test-output for better scoring."
+}

--- a/src/cli/commands/review.ts
+++ b/src/cli/commands/review.ts
@@ -1,12 +1,12 @@
-import { readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { formatSprintReview, compareSprintIds, parseSprintNumber } from '../../core/index.js';
-import type { GolfScorecard, ProjectStats } from '../../core/index.js';
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, join } from 'node:path';
+import { formatSprintReview, compareSprintIds, normalizeScorecard, parseSprintNumber } from '../../core/index.js';
+import type { GolfScorecard } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { resolveMetaphor } from '../metaphor.js';
 import { updateGate } from '../sprint-state.js';
 
-export function reviewCommand(path?: string, mode?: string, metaphorFlag?: string): void {
+export function reviewCommand(path?: string, mode?: string, metaphorFlag?: string, outputPath?: string | null): void {
   const config = loadConfig();
   const cwd = process.cwd();
   const metaphor = resolveMetaphor(metaphorFlag ? [`--metaphor=${metaphorFlag}`] : [], config.metaphor);
@@ -50,12 +50,21 @@ export function reviewCommand(path?: string, mode?: string, metaphorFlag?: strin
     process.exit(1);
   }
 
-  const card: GolfScorecard = { ...raw, sprint_number: raw.sprint_number ?? raw.sprint };
+  const card: GolfScorecard = normalizeScorecard(raw);
 
   const reviewMode = mode === 'plain' ? 'plain' : 'technical';
   const review = formatSprintReview(card, undefined, undefined, reviewMode, metaphor);
   console.log('');
   console.log(review);
+
+  if (outputPath !== null) {
+    const reviewPath = outputPath
+      ? isAbsolute(outputPath) ? outputPath : join(cwd, outputPath)
+      : join(cwd, config.scorecardDir, `sprint-${card.sprint_number}-review.md`);
+    mkdirSync(dirname(reviewPath), { recursive: true });
+    writeFileSync(reviewPath, review + '\n');
+    console.log(`\nReview written: ${reviewPath.replace(cwd + '/', '')}`);
+  }
 
   // Mark review_md gate complete
   updateGate(cwd, 'review_md', true);

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -1,13 +1,27 @@
 import { readFileSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
-import { DEFAULT_SKILLS_PATH, discoverScorecardFiles, loadSkillRegistry, skillIds, validateScorecard } from '../../core/index.js';
+import {
+  DEFAULT_SKILLS_PATH,
+  discoverScorecardFiles,
+  loadSkillRegistry,
+  parseSprintNumber,
+  skillIds,
+  sprintNumberFromScorecardFile,
+  validateScorecard,
+} from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { updateGate } from '../sprint-state.js';
 
 export function validateCommand(input?: string | string[]): void {
   const args = Array.isArray(input) ? input : input ? [input] : [];
   const validateSkills = args.includes('--skills');
-  const path = args.find(arg => !arg.startsWith('--'));
+  const sprintArgIndex = args.findIndex(arg => arg === '--sprint' || arg.startsWith('--sprint='));
+  const requestedSprint = parseRequestedSprint(args, sprintArgIndex);
+  const path = args.find((arg, index) => {
+    if (arg.startsWith('--')) return false;
+    if (sprintArgIndex >= 0 && args[sprintArgIndex] === '--sprint' && index === sprintArgIndex + 1) return false;
+    return true;
+  });
   const cwd = process.cwd();
   const config = loadConfig();
   const files: string[] = [];
@@ -28,10 +42,17 @@ export function validateCommand(input?: string | string[]): void {
   if (path) {
     files.push(isAbsolute(path) ? path : join(cwd, path));
   } else {
-    files.push(...discoverScorecardFiles(config, cwd));
+    const discovered = discoverScorecardFiles(config, cwd);
+    files.push(...(requestedSprint == null
+      ? discovered
+      : discovered.filter(file => sprintNumberFromScorecardFile(file, config) === requestedSprint)));
   }
 
   if (files.length === 0) {
+    if (requestedSprint != null) {
+      console.log(`\nNo scorecard found for Sprint ${requestedSprint}.\n`);
+      process.exit(1);
+    }
     console.log('\nNo scorecards found to validate.\n');
     process.exit(0);
   }
@@ -80,4 +101,18 @@ export function validateCommand(input?: string | string[]): void {
   }
 
   process.exit(allValid && registryAvailable ? 0 : 1);
+}
+
+function parseRequestedSprint(args: string[], sprintArgIndex: number): number | null {
+  if (sprintArgIndex < 0) return null;
+  const arg = args[sprintArgIndex];
+  const raw = arg.startsWith('--sprint=')
+    ? arg.slice('--sprint='.length)
+    : args[sprintArgIndex + 1];
+  const sprint = parseSprintNumber(raw ?? '');
+  if (sprint == null) {
+    console.error('Error: --sprint must be a valid sprint number.');
+    process.exit(1);
+  }
+  return sprint;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -134,8 +134,10 @@ switch (subcommand) {
       const plainFlag = reviewArgs.includes('--plain');
       const metaphorArg = reviewArgs.find((a: string) => a.startsWith('--metaphor='));
       const metaphorVal = metaphorArg?.slice('--metaphor='.length);
+      const outputArg = reviewArgs.find((a: string) => a.startsWith('--output='));
+      const outputPath = reviewArgs.includes('--stdout') ? null : outputArg?.slice('--output='.length);
       const path = reviewArgs.find((a: string) => !a.startsWith('--'));
-      reviewCommand(path, plainFlag ? 'plain' : undefined, metaphorVal);
+      reviewCommand(path, plainFlag ? 'plain' : undefined, metaphorVal, outputPath);
     }
     break;
   }

--- a/src/core/formatter.ts
+++ b/src/core/formatter.ts
@@ -2,7 +2,6 @@ import type {
   GolfScorecard,
   MissDirection,
   ShotResult,
-  ShotRecord,
   ClubSelection,
   ScoreLabel,
   ClubRecommendation,
@@ -10,6 +9,7 @@ import type {
 } from './types.js';
 import type { MetaphorDefinition } from './metaphor.js';
 import { normalizeStats } from './builder.js';
+import { normalizeScorecardShots } from './loader.js';
 
 // --- Input types ---
 
@@ -77,56 +77,6 @@ function safeBunkerLabel(b: unknown): string {
   return String(b);
 }
 
-/** Resolve shot records from a scorecard, accepting either the canonical
- *  `shots` field or a legacy `tickets` field. External-repo scorecards in
- *  the wild use `tickets` with `id`/`approach` keys; this remaps them to
- *  ShotRecord shape so the formatter doesn't render an empty table.
- *  See GH #298. */
-// Canonical enum members — used to validate legacy `tickets` field values
-// before casting. Out-of-enum strings fall back to safe defaults (no
-// silent acceptance of unknown values).
-const VALID_CLUBS = new Set<ShotRecord['club']>(['driver', 'long_iron', 'short_iron', 'wedge', 'putter']);
-const VALID_RESULTS = new Set<ShotRecord['result']>([
-  'in_the_hole', 'green', 'fairway',
-  'missed_long', 'missed_short', 'missed_left', 'missed_right',
-]);
-
-function normalizeShotsFromCard(card: GolfScorecard & { tickets?: unknown[] }): ShotRecord[] {
-  const canonical = card.shots;
-  if (Array.isArray(canonical) && canonical.length > 0) return canonical;
-
-  const legacy = card.tickets;
-  if (!Array.isArray(legacy) || legacy.length === 0) return canonical ?? [];
-
-  return legacy.map((t, i) => {
-    const obj = (t ?? {}) as Record<string, unknown>;
-    const ticketKey =
-      (typeof obj.ticket_key === 'string' && obj.ticket_key) ||
-      (typeof obj.id === 'string' && obj.id) ||
-      (typeof obj.key === 'string' && obj.key) ||
-      `T${i + 1}`;
-    const rawClub =
-      (typeof obj.club === 'string' && obj.club) ||
-      (typeof obj.approach === 'string' && obj.approach) ||
-      'short_iron';
-    const club: ShotRecord['club'] = VALID_CLUBS.has(rawClub as ShotRecord['club'])
-      ? (rawClub as ShotRecord['club'])
-      : 'short_iron';
-    const rawResult = typeof obj.result === 'string' ? obj.result : 'green';
-    const result: ShotRecord['result'] = VALID_RESULTS.has(rawResult as ShotRecord['result'])
-      ? (rawResult as ShotRecord['result'])
-      : 'green';
-    return {
-      ticket_key: ticketKey as string,
-      title: (typeof obj.title === 'string' && obj.title) || `Ticket ${ticketKey}`,
-      club,
-      result,
-      hazards: Array.isArray(obj.hazards) ? (obj.hazards as ShotRecord['hazards']) : [],
-      ...(typeof obj.notes === 'string' ? { notes: obj.notes } : {}),
-    };
-  });
-}
-
 // --- Formatter ---
 
 /**
@@ -150,7 +100,7 @@ export function formatSprintReview(
   // Accept legacy/alternate `tickets` field as an alias for `shots` so
   // scorecards from external repos that use the older naming still render
   // correctly (GH #298). Field-name remapping handles common variants.
-  const shots = normalizeShotsFromCard(card);
+  const shots = normalizeScorecardShots(card);
   const stats = normalizeStats(card.stats, shots.length);
   const conditions = card.conditions ?? [];
   const bunkerLocations = card.bunker_locations ?? [];
@@ -367,7 +317,7 @@ function formatPlainReview(
   deltas?: ProjectStatsDelta,
 ): string {
   const sprintNum = card.sprint_number ?? (card as any).sprint;
-  const shots = card.shots ?? [];
+  const shots = normalizeScorecardShots(card);
   const lines: string[] = [];
 
   lines.push(`## Sprint ${sprintNum}: ${card.theme}`);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -207,7 +207,15 @@ export { parseTestPlan, getTestPlanSummary, getAreasNeedingTest } from './test-p
 export type { TestPlanArea, TestPlanSection, TestPlanSummary, ParsedTestPlan } from './test-plan.js';
 
 // Loader
-export { loadScorecards, detectLatestSprint, resolveCurrentSprint, normalizeScorecard, discoverScorecardFiles } from './loader.js';
+export {
+  loadScorecards,
+  detectLatestSprint,
+  resolveCurrentSprint,
+  normalizeScorecard,
+  normalizeScorecardShots,
+  discoverScorecardFiles,
+  sprintNumberFromScorecardFile,
+} from './loader.js';
 
 // Metaphor
 export {

--- a/src/core/loader.ts
+++ b/src/core/loader.ts
@@ -1,8 +1,8 @@
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import type { GolfScorecard } from './types.js';
+import type { ClubSelection, GolfScorecard, HazardHit, ShotRecord, ShotResult } from './types.js';
 import type { SlopeConfig } from './config.js';
-import { normalizeStats } from './builder.js';
+import { computeStatsFromShots, normalizeStats } from './builder.js';
 import { computePar, computeScoreLabel } from './handicap.js';
 import { compareSprintIds, nextCanonicalSprintId } from './roadmap.js';
 
@@ -11,6 +11,24 @@ type ScorecardCandidate = {
   sprintNumber: number;
   priority: number;
   label: string;
+};
+
+const VALID_CLUBS = new Set<ClubSelection>(['driver', 'long_iron', 'short_iron', 'wedge', 'putter']);
+const VALID_RESULTS = new Set<ShotResult>([
+  'in_the_hole',
+  'green',
+  'fairway',
+  'missed_long',
+  'missed_short',
+  'missed_left',
+  'missed_right',
+]);
+
+const LEGACY_RESULT_ALIASES: Record<string, ShotResult> = {
+  long: 'missed_long',
+  short: 'missed_short',
+  left: 'missed_left',
+  right: 'missed_right',
 };
 
 /**
@@ -41,6 +59,23 @@ export function loadScorecards(config: SlopeConfig, cwd: string = process.cwd())
 
 export function discoverScorecardFiles(config: SlopeConfig, cwd: string = process.cwd()): string[] {
   return discoverScorecardCandidatesForConfig(config, cwd).map((candidate) => candidate.path);
+}
+
+export function sprintNumberFromScorecardFile(file: string, config: SlopeConfig): number | null {
+  const patternParts = config.scorecardPattern.split('*');
+  const prefix = patternParts[0] ?? '';
+  const suffix = patternParts[1] ?? '';
+  const regex = new RegExp(`^${escapeRegex(prefix)}(\\d+(?:\\.\\d+)?)${escapeRegex(suffix)}$`);
+  const normalized = file.replace(/\\/g, '/');
+  const filename = normalized.split('/').at(-1) ?? file;
+  const topLevelMatch = filename.match(regex);
+  if (topLevelMatch?.[1]) return parseFloat(topLevelMatch[1]);
+
+  const parts = normalized.split('/');
+  const parent = parts.at(-2) ?? '';
+  const nestedMatch = parent.match(/^s(?:print-)?(\d+(?:\.\d+)?)$/i);
+  if (filename === 'scorecard.json' && nestedMatch?.[1]) return parseFloat(nestedMatch[1]);
+  return null;
 }
 
 function discoverScorecardCandidatesForConfig(config: SlopeConfig, cwd: string): ScorecardCandidate[] {
@@ -102,14 +137,18 @@ export function resolveCurrentSprint(config: SlopeConfig, cwd: string = process.
  */
 export function normalizeScorecard(raw: Record<string, unknown>): GolfScorecard {
   const card = { ...raw } as Record<string, unknown>;
-  const shotCount = (card.shots as unknown[])?.length ?? 0;
-  const ticketCount = (card.tickets as unknown[])?.length ?? shotCount;
+  const shots = normalizeScorecardShots(card);
+  const shotCount = shots.length;
 
   // Normalize sprint_number
   card.sprint_number = card.sprint_number ?? card.sprint;
 
+  if ((!Array.isArray(card.shots) || card.shots.length === 0) && shotCount > 0) {
+    card.shots = shots;
+  }
+
   if (typeof card.par !== 'number' || Number.isNaN(card.par)) {
-    card.par = computePar(ticketCount);
+    card.par = computePar(shotCount);
   }
 
   if (typeof card.score !== 'number' || Number.isNaN(card.score)) {
@@ -124,6 +163,8 @@ export function normalizeScorecard(raw: Record<string, unknown>): GolfScorecard 
   if (card.hole_stats && !card.stats) {
     card.stats = normalizeStats(card.hole_stats, shotCount);
     delete card.hole_stats;
+  } else if (isEmptyStats(card.stats)) {
+    card.stats = computeStatsFromShots(shots);
   } else {
     // Always normalize — handles both existing stats and missing stats (zeroed defaults)
     card.stats = normalizeStats(card.stats, shotCount);
@@ -132,8 +173,73 @@ export function normalizeScorecard(raw: Record<string, unknown>): GolfScorecard 
   return card as unknown as GolfScorecard;
 }
 
+export function normalizeScorecardShots(card: Record<string, unknown> | (Partial<GolfScorecard> & { tickets?: unknown[] })): ShotRecord[] {
+  const canonical = (card as { shots?: unknown }).shots;
+  if (Array.isArray(canonical) && canonical.length > 0) {
+    return canonical as ShotRecord[];
+  }
+
+  const legacy = (card as { tickets?: unknown }).tickets;
+  if (!Array.isArray(legacy) || legacy.length === 0) {
+    return Array.isArray(canonical) ? (canonical as ShotRecord[]) : [];
+  }
+
+  return legacy.map((ticket, index) => {
+    const obj = (ticket ?? {}) as Record<string, unknown>;
+    const ticketKey =
+      nonEmptyString(obj.ticket_key) ??
+      nonEmptyString(obj.id) ??
+      nonEmptyString(obj.key) ??
+      `T${index + 1}`;
+    const rawClub = nonEmptyString(obj.club) ?? nonEmptyString(obj.approach) ?? 'short_iron';
+    const rawResult = nonEmptyString(obj.result) ?? 'green';
+
+    return {
+      ticket_key: ticketKey,
+      title: nonEmptyString(obj.title) ?? `Ticket ${ticketKey}`,
+      club: normalizeClub(rawClub),
+      result: normalizeResult(rawResult),
+      hazards: normalizeHazards(obj.hazards),
+      ...(typeof obj.notes === 'string' ? { notes: obj.notes } : {}),
+    };
+  });
+}
+
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function normalizeClub(value: string): ClubSelection {
+  return VALID_CLUBS.has(value as ClubSelection) ? value as ClubSelection : 'short_iron';
+}
+
+function normalizeResult(value: string): ShotResult {
+  const alias = LEGACY_RESULT_ALIASES[value];
+  if (alias) return alias;
+  return VALID_RESULTS.has(value as ShotResult) ? value as ShotResult : 'green';
+}
+
+function normalizeHazards(value: unknown): HazardHit[] {
+  if (!Array.isArray(value)) return [];
+  const hazards: HazardHit[] = [];
+  for (const hazard of value) {
+    if (typeof hazard === 'string') {
+      hazards.push({ type: 'rough', description: hazard });
+      continue;
+    }
+    if (!hazard || typeof hazard !== 'object') continue;
+    hazards.push(hazard as HazardHit);
+  }
+  return hazards;
+}
+
+function isEmptyStats(value: unknown): boolean {
+  if (value == null) return true;
+  return typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0;
 }
 
 function discoverScorecardCandidates(dir: string, regex: RegExp): ScorecardCandidate[] {

--- a/tests/cli/review-amend.test.ts
+++ b/tests/cli/review-amend.test.ts
@@ -111,6 +111,35 @@ describe('review amend', () => {
     expect(logged).toContain('No review findings to amend');
   });
 
+  it('amends legacy ticket-style scorecards by normalizing tickets to shots', async () => {
+    mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+    writeFileSync(join(tmpDir, '.slope/config.json'), JSON.stringify({ scorecardDir: 'docs/retros' }));
+    mkdirSync(join(tmpDir, 'docs/retros'), { recursive: true });
+    writeFileSync(join(tmpDir, 'docs/retros/sprint-197.json'), JSON.stringify({
+      sprint_number: 197,
+      theme: 'Legacy tickets',
+      par: 3,
+      slope: 2,
+      score: 3,
+      score_label: 'par',
+      date: '2026-06-03',
+      tickets: [
+        { id: 'S197-1', title: 'Ticket 1', approach: 'wedge', result: 'green', hazards: [] },
+      ],
+    }));
+    writeFileSync(join(tmpDir, '.slope/review-findings.json'), JSON.stringify({
+      sprint_number: 197,
+      findings: [{ review_type: 'architect', ticket_key: 'S197-1', severity: 'moderate', description: 'test', resolved: true }],
+    }));
+
+    await runCommand(['amend', '--sprint=197']);
+
+    const amended = JSON.parse(readFileSync(join(tmpDir, 'docs/retros/sprint-197.json'), 'utf8')) as GolfScorecard;
+    expect(amended.shots).toHaveLength(1);
+    expect(amended.shots[0].ticket_key).toBe('S197-1');
+    expect(amended.shots[0].hazards[0].description).toContain('[architect review] test');
+  });
+
   it('GH #292: errors clearly when scorecard has no shots array (sub-sprint parent stub)', async () => {
     // Repro: parent scorecard sprint-180.json with no `shots` field.
     // Was crashing as "Cannot read properties of undefined (reading 'map')".

--- a/tests/cli/review-command.test.ts
+++ b/tests/cli/review-command.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildScorecard } from '../../src/core/builder.js';
+import { reviewCommand } from '../../src/cli/commands/review.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-review-command-'));
+  vi.spyOn(process, 'cwd').mockImplementation(() => tmpDir);
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  mkdirSync(join(tmpDir, 'docs', 'retros'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+    scorecardDir: 'docs/retros',
+    scorecardPattern: 'sprint-*.json',
+    minSprint: 1,
+  }));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('reviewCommand', () => {
+  it('writes the canonical sprint review markdown by default', () => {
+    const card = buildScorecard({
+      sprint_number: 132,
+      theme: 'Review materialization',
+      par: 3,
+      slope: 1,
+      date: '2026-06-03',
+      shots: [{
+        ticket_key: 'S132-1',
+        title: 'Generate review',
+        club: 'wedge',
+        result: 'in_the_hole',
+        hazards: [],
+      }],
+    });
+    const scorecardPath = join(tmpDir, 'docs', 'retros', 'sprint-132.json');
+    writeFileSync(scorecardPath, JSON.stringify(card, null, 2));
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    reviewCommand(scorecardPath);
+    logSpy.mockRestore();
+
+    const reviewPath = join(tmpDir, 'docs', 'retros', 'sprint-132-review.md');
+    expect(existsSync(reviewPath)).toBe(true);
+    expect(readFileSync(reviewPath, 'utf8')).toContain('## Sprint 132 Review: Review materialization');
+  });
+});

--- a/tests/cli/validate-skills.test.ts
+++ b/tests/cli/validate-skills.test.ts
@@ -148,4 +148,20 @@ describe('slope validate --skills', () => {
     expect(() => validateCommand()).toThrow('process.exit(0)');
     expect(exitCode).toBe(0);
   });
+
+  it('validates only the requested sprint with --sprint=N', () => {
+    writeScorecard([], 348);
+    mkdirSync(join(tmpDir, 'docs', 'retros'), { recursive: true });
+    writeFileSync(join(tmpDir, 'docs', 'retros', 'sprint-349.json'), '{not-json');
+
+    expect(() => validateCommand(['--sprint=348'])).toThrow('process.exit(0)');
+    expect(exitCode).toBe(0);
+  });
+
+  it('fails when --sprint requests a missing scorecard', () => {
+    writeScorecard([], 348);
+
+    expect(() => validateCommand(['--sprint=349'])).toThrow('process.exit(1)');
+    expect(exitCode).toBe(1);
+  });
 });

--- a/tests/core/formatter.test.ts
+++ b/tests/core/formatter.test.ts
@@ -564,6 +564,37 @@ describe('formatSprintReview legacy tickets field', () => {
     expect(output).toContain('| T1 | short_iron | green |');
   });
 
+  it('maps legacy miss direction results to canonical missed results', () => {
+    const card = {
+      ...makeCard({ shots: [] as ShotRecord[] }),
+      tickets: [
+        { id: 'S197-1', title: 'Overbuilt', approach: 'short_iron', result: 'long' },
+        { id: 'S197-2', title: 'Underscoped', approach: 'short_iron', result: 'short' },
+        { id: 'S197-3', title: 'Wrong path', approach: 'short_iron', result: 'left' },
+        { id: 'S197-4', title: 'Drift', approach: 'short_iron', result: 'right' },
+      ],
+    } as unknown as GolfScorecard;
+
+    const output = formatSprintReview(card, makeProjectStats());
+    expect(output).toContain('| S197-1 | short_iron | missed_long |');
+    expect(output).toContain('| S197-2 | short_iron | missed_short |');
+    expect(output).toContain('| S197-3 | short_iron | missed_left |');
+    expect(output).toContain('| S197-4 | short_iron | missed_right |');
+  });
+
+  it('plain mode also reads from legacy tickets', () => {
+    const card = {
+      ...makeCard({ shots: [] as ShotRecord[] }),
+      tickets: [
+        { id: 'S197-1', title: 'rock-coral A/B scene', approach: 'wedge', result: 'in_the_hole' },
+      ],
+    } as unknown as GolfScorecard;
+
+    const output = formatSprintReview(card, makeProjectStats(), undefined, 'plain');
+    expect(output).toContain('**Tickets:** 1 delivered');
+    expect(output).toContain('| S197-1 | Simple fix | Completed perfectly |');
+  });
+
   it('returns empty shots when neither shots nor tickets are populated', () => {
     const card = makeCard({ shots: [] as ShotRecord[] });
     const output = formatSprintReview(card, makeProjectStats());

--- a/tests/core/loader.test.ts
+++ b/tests/core/loader.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { loadScorecards, detectLatestSprint, discoverScorecardFiles } from '../../src/core/loader.js';
+import { loadScorecards, detectLatestSprint, discoverScorecardFiles, normalizeScorecard } from '../../src/core/loader.js';
 import type { SlopeConfig } from '../../src/core/config.js';
 
 const TMP = join(__dirname, '__loader_tmp__');
@@ -105,6 +105,26 @@ describe('loadScorecards — numeric sort', () => {
     const cards = loadScorecards(baseConfig, TMP);
     expect(cards[0].score).toBe(4);
     expect(cards[0].score_label).toBe('par');
+  });
+
+  it('normalizes stats totals from legacy tickets when shots are absent', () => {
+    const card = normalizeScorecard({
+      sprint_number: 197,
+      theme: 'Legacy tickets',
+      slope: 2,
+      date: '2026-06-03',
+      tickets: [
+        { id: 'S197-1', title: 'Ticket 1', approach: 'short_iron', result: 'green' },
+        { id: 'S197-2', title: 'Ticket 2', approach: 'short_iron', result: 'short' },
+      ],
+      stats: {},
+    });
+
+    expect(card.shots).toHaveLength(2);
+    expect(card.shots[1].result).toBe('missed_short');
+    expect(card.stats.fairways_total).toBe(2);
+    expect(card.stats.greens_total).toBe(2);
+    expect(card.stats.miss_directions.short).toBe(1);
   });
 
   it('loads and sorts decimal scorecard filenames for inserted sub-sprints', () => {


### PR DESCRIPTION
## Summary\n- normalize legacy ticket-style scorecards through loader/formatter/review-amend/recommend paths\n- add validate --sprint scoping for top-level and nested scorecards\n- materialize canonical sprint review markdown from slope review\n- add S132 scorecard and review artifacts\n\n## Verification\n- pnpm vitest run tests/core/loader.test.ts tests/core/formatter.test.ts tests/cli/validate-skills.test.ts tests/cli/review-amend.test.ts tests/cli/review-command.test.ts\n- pnpm typecheck\n- pnpm build\n- node dist/cli/index.js validate --sprint=132\n- node dist/cli/index.js review docs/retros/sprint-132.json\n\nCloses #485\nCloses #488\nCloses #491