### PR TITLE
fix(S133): PR review state and runtime health

### DIFF
--- a/docs/retros/sprint-133-review.md
+++ b/docs/retros/sprint-133-review.md
@@ -1,0 +1,21 @@
+## Sprint 133 Review: PR review state and runtime health
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 0 |
+| Score | 1 |
+| Label | Eagle |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S133-1 | Driver | Green | — | 10 files changed (Clean git signals but no CI confirmation — defaulting to green) |
+

--- a/docs/retros/sprint-133.json
+++ b/docs/retros/sprint-133.json
@@ -1,0 +1,47 @@
+{
+  "sprint_number": 133,
+  "player": "sebastianbryers",
+  "theme": "PR review state and runtime health",
+  "par": 3,
+  "slope": 0,
+  "score": 1,
+  "score_label": "eagle",
+  "date": "2026-06-03",
+  "shots": [
+    {
+      "ticket_key": "S133-1",
+      "title": "fix(S133): keep PR prompt state pending and surface ABI recovery",
+      "club": "driver",
+      "result": "green",
+      "hazards": [],
+      "notes": "10 files changed (Clean git signals but no CI confirmation — defaulting to green)"
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [],
+  "slope_factors": [],
+  "_auto_generated": true,
+  "_commits": 1,
+  "_ci_signal": null,
+  "_pr_signal": null,
+  "_note": "Auto-generated from git only (no CI). Shots default to green. Provide --test-output for better scoring."
+}

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { detectLatestSprint, loadConfig, normalizeScorecard, recommendReviews } from '../../core/index.js';
 import type { ReviewRecommendation } from '../../core/index.js';
 import { reviewRunCommand } from './review-run.js';
-import { recordPrCloseoutSettled, recordPrReviewComplete } from '../pr-review-state.js';
+import { recordPrCloseoutSettled, recordPrReviewPromptsGenerated } from '../pr-review-state.js';
 import { branchSizeWarnings, buildPrCloseoutStatus, canSettlePrCloseout, closeoutPolicy, formatPrCloseoutStatus } from '../pr-closeout.js';
 
 /**
@@ -102,6 +102,9 @@ Usage:
 
 Defaults:
   --pr   Resolved from current branch via \`gh pr view --json number\`.
+
+State:
+  Prompt generation records PR review as pending. Complete review rounds before PR closeout.
 `);
 }
 
@@ -440,7 +443,7 @@ async function reviewSubcommand(args: string[]): Promise<void> {
   if (opts.json) {
     reviewArgs.push('--json');
     await reviewRunCommand(reviewArgs);
-    recordPrReviewComplete(process.cwd(), {
+    recordPrReviewPromptsGenerated(process.cwd(), {
       pr: plan.pr,
       sprint: plan.sprint,
       branch: currentBranch(),
@@ -462,7 +465,7 @@ async function reviewSubcommand(args: string[]): Promise<void> {
   console.log('\nReview prompts:\n');
 
   await reviewRunCommand(reviewArgs);
-  recordPrReviewComplete(process.cwd(), {
+  recordPrReviewPromptsGenerated(process.cwd(), {
     pr: plan.pr,
     sprint: plan.sprint,
     branch: currentBranch(),

--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -37,6 +37,7 @@ function getDefinition(exec: WorkflowExecution, cwd: string): { def: WorkflowDef
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { createStore } from '../../store/index.js';
+import { formatCliError } from '../error-reporter.js';
 import {
   blockingRoadmapIssuesForSprint,
   collectSiblingWorktreeReality,
@@ -633,9 +634,10 @@ async function runWorkflowCommand(args: string[], cwd: string): Promise<void> {
 
 async function workflowStatusCommand(args: string[], cwd: string): Promise<void> {
   const sprintArg = args.find(a => !a.startsWith('--'));
-  const store = getStore(cwd);
+  let store: ReturnType<typeof getStore> | null = null;
 
   try {
+    store = getStore(cwd);
     if (sprintArg) {
       const exec = await store.getExecutionBySprint(sprintArg);
       if (!exec) {
@@ -655,8 +657,13 @@ async function workflowStatusCommand(args: string[], cwd: string): Promise<void>
         printExecution(exec);
       }
     }
+  } catch (err) {
+    for (const line of formatCliError(err, cwd)) {
+      console.error(line);
+    }
+    process.exitCode = 1;
   } finally {
-    store.close();
+    store?.close();
   }
 }
 

--- a/src/cli/commands/store.ts
+++ b/src/cli/commands/store.ts
@@ -55,6 +55,11 @@ export function storeRecoverySuggestions(message: string, cwd: string): string[]
   if (!isNativeSqliteSetupError(message)) return [];
 
   const suggestions: string[] = [];
+  suggestions.push(`Active Node: ${process.version} (NODE_MODULE_VERSION ${process.versions.modules ?? 'unknown'}).`);
+
+  const abi = nativeAbiDetails(message);
+  if (abi) suggestions.push(abi);
+
   const installCommand = detectInstallCommand(cwd);
   if (!existsSync(join(cwd, 'node_modules'))) {
     suggestions.push(`Install this worktree's dependencies first: ${installCommand}.`);
@@ -69,6 +74,12 @@ export function storeRecoverySuggestions(message: string, cwd: string): string[]
 
   suggestions.push('In fresh parallel worktrees, prefer the worktree-local SLOPE binary after dependencies are installed.');
   return suggestions;
+}
+
+function nativeAbiDetails(message: string): string | null {
+  const match = message.match(/NODE_MODULE_VERSION\s+(\d+).*?requires NODE_MODULE_VERSION\s+(\d+)/i);
+  if (!match) return null;
+  return `Native binding ABI mismatch: compiled NODE_MODULE_VERSION ${match[1]}, runtime requires NODE_MODULE_VERSION ${match[2]}.`;
 }
 
 export async function storeCommand(args: string[]): Promise<void> {

--- a/src/cli/pr-closeout.ts
+++ b/src/cli/pr-closeout.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { detectLatestSprint } from '../core/index.js';
 import { loadConfig } from './config.js';
 import { loadPrReviewState } from './pr-review-state.js';
+import { loadReviewState } from './commands/review-state.js';
 import { isActiveSprintState, loadSprintState } from './sprint-state.js';
 
 export interface PrCloseoutPolicy {
@@ -546,8 +547,15 @@ function collectBranchSize(cwd: string, base: string | undefined): BranchSize {
 function resolvePrReviewStatus(cwd: string, input: { pr?: number; sprint?: number; branch?: string }): 'missing' | 'pending' | 'reviewed' {
   const matching = matchingPrReviews(cwd, input);
   if (matching.some(review => review.status === 'reviewed')) return 'reviewed';
-  if (matching.some(review => review.status === 'pending')) return 'pending';
+  if (matching.some(review => review.status === 'pending')) {
+    return completedReviewRounds(cwd) ? 'reviewed' : 'pending';
+  }
   return 'missing';
+}
+
+function completedReviewRounds(cwd: string): boolean {
+  const state = loadReviewState(cwd);
+  return Boolean(state && state.rounds_completed >= state.rounds_required);
 }
 
 function resolvePrCloseoutSettlement(cwd: string, input: { pr?: number; sprint?: number; branch?: string }): PrCloseoutSettlementStatus {

--- a/src/cli/pr-review-state.ts
+++ b/src/cli/pr-review-state.ts
@@ -10,6 +10,7 @@ export interface PrReviewRecord {
   status: 'pending' | 'reviewed';
   closeout_status?: 'pending' | 'settled';
   created_at: string;
+  prompts_generated_at?: string;
   reviewed_at?: string;
   closeout_settled_at?: string;
   review_type?: 'architect' | 'code' | 'both';
@@ -75,6 +76,37 @@ export function recordPrReviewPending(cwd: string, input: { pr: number; sprint?:
       status: 'pending',
       closeout_status: 'pending',
       created_at: now,
+    });
+  }
+
+  savePrReviewState(cwd, state);
+}
+
+export function recordPrReviewPromptsGenerated(
+  cwd: string,
+  input: { pr: number; sprint?: number; branch?: string; reviewType?: 'architect' | 'code' | 'both' },
+): void {
+  const state = loadPrReviewState(cwd);
+  const now = new Date().toISOString();
+  const existing = state.reviews.find(review => review.pr === input.pr);
+
+  if (existing) {
+    existing.sprint = input.sprint ?? existing.sprint;
+    existing.branch = input.branch ?? existing.branch;
+    existing.prompts_generated_at = now;
+    existing.review_type = input.reviewType ?? existing.review_type;
+    if (existing.status !== 'reviewed') existing.status = 'pending';
+    if (existing.closeout_status !== 'settled') existing.closeout_status = 'pending';
+  } else {
+    state.reviews.push({
+      pr: input.pr,
+      sprint: input.sprint,
+      branch: input.branch,
+      status: 'pending',
+      closeout_status: 'pending',
+      created_at: now,
+      prompts_generated_at: now,
+      review_type: input.reviewType,
     });
   }
 

--- a/tests/cli/error-reporter.test.ts
+++ b/tests/cli/error-reporter.test.ts
@@ -22,6 +22,7 @@ describe('formatCliError', () => {
 
       expect(lines[0]).toContain('Could not locate the bindings file');
       expect(lines).toContain('Recovery:');
+      expect(lines.join('\n')).toContain(`Active Node: ${process.version}`);
       expect(lines).toContain('  - Install this worktree\'s dependencies first: pnpm install.');
       expect(lines.join('\n')).toContain('package.json engines.node (>=22 <23)');
     } finally {
@@ -58,6 +59,7 @@ describe('formatCliError', () => {
       const output = errorSpy.mock.calls.map(call => call.join(' ')).join('\n');
       expect(output).toContain('Error: ERR_DLOPEN_FAILED');
       expect(output).toContain('Recovery:');
+      expect(output).toContain(`Active Node: ${process.version}`);
       expect(output).toContain('npm ci');
     } finally {
       process.chdir(originalCwd);

--- a/tests/cli/pr-finalize.test.ts
+++ b/tests/cli/pr-finalize.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   defaultReviewType,
   extractIssueRefs,
   existingAutoCloseRefs,
   formatReviewRecommendations,
 } from '../../src/cli/commands/pr.js';
-import { branchSizeWarnings, canSettlePrCloseout, formatPrCloseoutStatus, hasSuccessfulCodeRabbitStatus, isBlockedCodeRabbitComment } from '../../src/cli/pr-closeout.js';
+import { branchSizeWarnings, buildPrCloseoutStatus, canSettlePrCloseout, formatPrCloseoutStatus, hasSuccessfulCodeRabbitStatus, isBlockedCodeRabbitComment } from '../../src/cli/pr-closeout.js';
+import { recordPrReviewPromptsGenerated } from '../../src/cli/pr-review-state.js';
+import { saveReviewState } from '../../src/cli/commands/review-state.js';
 
 describe('extractIssueRefs (GH #321)', () => {
   it('extracts a single issue ref', () => {
@@ -225,5 +230,31 @@ describe('pr closeout status helpers (S130)', () => {
     expect(hasSuccessfulCodeRabbitStatus({
       statusCheckRollup: [{ __typename: 'StatusContext', context: 'ci', state: 'SUCCESS' }],
     })).toBe(false);
+  });
+
+  it('treats prompt-only PR review state as pending until review rounds are complete', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'slope-pr-closeout-rounds-'));
+    try {
+      mkdirSync(join(cwd, '.slope'), { recursive: true });
+      writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({
+        currentSprint: 130,
+        scorecardDir: 'docs/retros',
+        scorecardPattern: 'sprint-*.json',
+      }));
+      recordPrReviewPromptsGenerated(cwd, { pr: 468, sprint: 130, branch: 'feat/closeout', reviewType: 'both' });
+
+      expect(buildPrCloseoutStatus(cwd, { sprint: 130 }).prReview).toBe('pending');
+
+      saveReviewState(cwd, {
+        rounds_required: 2,
+        rounds_completed: 2,
+        tier: 'standard',
+        started_at: new Date().toISOString(),
+      });
+
+      expect(buildPrCloseoutStatus(cwd, { sprint: 130 }).prReview).toBe('reviewed');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/cli/pr-review-state.test.ts
+++ b/tests/cli/pr-review-state.test.ts
@@ -9,6 +9,7 @@ import {
   recordPrCloseoutSettled,
   recordPrReviewComplete,
   recordPrReviewPending,
+  recordPrReviewPromptsGenerated,
 } from '../../src/cli/pr-review-state.js';
 
 describe('pr review state', () => {
@@ -70,5 +71,17 @@ describe('pr review state', () => {
     recordPrReviewPending(cwd, { pr: 42, sprint: 100, branch: 'fix/test' });
 
     expect(loadPrReviewState(cwd).reviews[0].status).toBe('reviewed');
+  });
+
+  it('records generated review prompts without marking the PR reviewed', () => {
+    recordPrReviewPromptsGenerated(cwd, { pr: 42, sprint: 100, branch: 'fix/test', reviewType: 'both' });
+
+    const state = loadPrReviewState(cwd);
+    expect(state.reviews[0].status).toBe('pending');
+    expect(state.reviews[0].closeout_status).toBe('pending');
+    expect(state.reviews[0].prompts_generated_at).toBeDefined();
+    expect(state.reviews[0].review_type).toBe('both');
+    expect(pendingPrReviews(cwd, 100).map(review => review.pr)).toEqual([42]);
+    expect(pendingPrCloseouts(cwd, 100)).toEqual([]);
   });
 });

--- a/tests/cli/sprint-status-native-error.test.ts
+++ b/tests/cli/sprint-status-native-error.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const createStoreMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/store/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/store/index.js')>();
+  return {
+    ...actual,
+    createStore: createStoreMock,
+  };
+});
+
+let tmpDir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-sprint-status-native-'));
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  mkdirSync(join(tmpDir, 'node_modules'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({ currentSprint: 133 }));
+  writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ engines: { node: '>=22 <23' } }));
+  writeFileSync(join(tmpDir, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  vi.restoreAllMocks();
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  process.exitCode = undefined;
+});
+
+describe('slope sprint status native SQLite recovery', () => {
+  it('prints explicit ABI recovery guidance for stale better-sqlite3 bindings', async () => {
+    createStoreMock.mockImplementation(() => {
+      throw new Error("The module '/tmp/better_sqlite3.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 127. This version of Node.js requires NODE_MODULE_VERSION 147.");
+    });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { sprintCommand } = await import('../../src/cli/commands/sprint.js');
+
+    await sprintCommand(['status']);
+
+    const output = errSpy.mock.calls.map(call => call.join(' ')).join('\n');
+    expect(output).toContain('NODE_MODULE_VERSION 127');
+    expect(output).toContain(`Active Node: ${process.version}`);
+    expect(output).toContain('compiled NODE_MODULE_VERSION 127');
+    expect(output).toContain('runtime requires NODE_MODULE_VERSION 147');
+    expect(output).toContain('pnpm install');
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/tests/cli/store.test.ts
+++ b/tests/cli/store.test.ts
@@ -139,6 +139,9 @@ describe('slope store status', () => {
     spy.mockRestore();
     const parsed = JSON.parse(logs.join('\n'));
     expect(parsed.error).toContain('NODE_MODULE_VERSION');
+    expect(parsed.recovery.join('\n')).toContain(`Active Node: ${process.version}`);
+    expect(parsed.recovery.join('\n')).toContain('compiled NODE_MODULE_VERSION 127');
+    expect(parsed.recovery.join('\n')).toContain('runtime requires NODE_MODULE_VERSION 141');
     expect(parsed.recovery).toContain('Install this worktree\'s dependencies first: pnpm install.');
     expect(parsed.recovery.join('\n')).toContain('package.json engines.node (>=22 <23)');
   });


### PR DESCRIPTION
## Summary
- record PR review prompt generation as pending instead of reviewed
- let completed review rounds satisfy PR closeout review state
- enrich native SQLite recovery guidance with active Node and ABI details
- catch stale better-sqlite3 binding failures in slope sprint status
- add S133 scorecard and review artifacts

## Verification
- pnpm vitest run tests/cli/pr-review-state.test.ts tests/cli/pr-finalize.test.ts tests/cli/pr-help.test.ts tests/cli/sprint-status-native-error.test.ts tests/cli/error-reporter.test.ts tests/cli/store.test.ts tests/cli/sprint-workflow.test.ts
- pnpm typecheck
- pnpm build
- node dist/cli/index.js validate --sprint=133
- node dist/cli/index.js review docs/retros/sprint-133.json

Closes #489
Closes #492