### PR TITLE
fix(S134): warning hygiene and briefing map safety

### DIFF
--- a/docs/retros/sprint-134-review.md
+++ b/docs/retros/sprint-134-review.md
@@ -6,16 +6,17 @@
 |---|---|
 | Par | 3 |
 | Slope | 0 |
-| Score | 1 |
-| Label | Eagle |
-| Fairway % | 100% (1/1) |
-| GIR % | 100% (1/1) |
+| Score | 2 |
+| Label | Birdie |
+| Fairway % | 100% (2/2) |
+| GIR % | 100% (2/2) |
 | Putts | 0 |
 | Penalties | 0 |
 
-### Shot-by-Shot (Tickets Delivered: 1)
+### Shot-by-Shot (Tickets Delivered: 2)
 
 | Ticket | Club | Result | Hazards | Notes |
 |---|---|---|---|---|
 | S134-1 | Short Iron | Green | — | 4 files changed (Clean git signals but no CI confirmation — defaulting to green) |
+| S134-2 | Wedge | Green | — | Addressed CodeQL PR review comments by using execFileSync with argv for built CLI test runs. |
 

--- a/docs/retros/sprint-134-review.md
+++ b/docs/retros/sprint-134-review.md
@@ -1,0 +1,21 @@
+## Sprint 134 Review: Warning hygiene and briefing/map safety
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 0 |
+| Score | 1 |
+| Label | Eagle |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S134-1 | Short Iron | Green | — | 4 files changed (Clean git signals but no CI confirmation — defaulting to green) |
+

--- a/docs/retros/sprint-134.json
+++ b/docs/retros/sprint-134.json
@@ -1,0 +1,47 @@
+{
+  "sprint_number": 134,
+  "player": "sebastianbryers",
+  "theme": "Warning hygiene and briefing/map safety",
+  "par": 3,
+  "slope": 0,
+  "score": 1,
+  "score_label": "eagle",
+  "date": "2026-06-03",
+  "shots": [
+    {
+      "ticket_key": "S134-1",
+      "title": "fix(S134): cap briefing hazards and guard zero-source maps",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "4 files changed (Clean git signals but no CI confirmation — defaulting to green)"
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [],
+  "slope_factors": [],
+  "_auto_generated": true,
+  "_commits": 1,
+  "_ci_signal": null,
+  "_pr_signal": null,
+  "_note": "Auto-generated from git only (no CI). Shots default to green. Provide --test-output for better scoring."
+}

--- a/docs/retros/sprint-134.json
+++ b/docs/retros/sprint-134.json
@@ -4,8 +4,8 @@
   "theme": "Warning hygiene and briefing/map safety",
   "par": 3,
   "slope": 0,
-  "score": 1,
-  "score_label": "eagle",
+  "score": 2,
+  "score_label": "birdie",
   "date": "2026-06-03",
   "shots": [
     {
@@ -15,13 +15,21 @@
       "result": "green",
       "hazards": [],
       "notes": "4 files changed (Clean git signals but no CI confirmation — defaulting to green)"
+    },
+    {
+      "ticket_key": "S134-2",
+      "title": "fix(S134): avoid shell-built CLI invocations in map tests",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [],
+      "notes": "Addressed CodeQL PR review comments by using execFileSync with argv for built CLI test runs."
     }
   ],
   "stats": {
-    "fairways_hit": 1,
-    "fairways_total": 1,
-    "greens_in_regulation": 1,
-    "greens_total": 1,
+    "fairways_hit": 2,
+    "fairways_total": 2,
+    "greens_in_regulation": 2,
+    "greens_total": 2,
     "putts": 0,
     "penalties": 0,
     "hazards_hit": 0,
@@ -40,7 +48,7 @@
   "course_management_notes": [],
   "slope_factors": [],
   "_auto_generated": true,
-  "_commits": 1,
+  "_commits": 2,
   "_ci_signal": null,
   "_pr_signal": null,
   "_note": "Auto-generated from git only (no CI). Shots default to green. Provide --test-output for better scoring."

--- a/src/cli/commands/map.ts
+++ b/src/cli/commands/map.ts
@@ -761,6 +761,7 @@ export async function mapCommand(args: string[]): Promise<void> {
   const config = loadConfig(cwd);
   const outputPath = flags.output || join(cwd, 'CODEBASE.md');
   const isCheck = flags.check === 'true';
+  const force = flags.force === 'true';
 
   if (args.includes('--help') || args.includes('-h')) {
     printUsage();
@@ -803,6 +804,11 @@ export async function mapCommand(args: string[]): Promise<void> {
   const meta = gatherMetadata(cwd, config, identity);
 
   if (!identity.isSlopeSelf) {
+    if (meta.source_files === 0 && existsSync(outputPath) && !force && !isSlopeShapedMap(readFileSync(outputPath, 'utf8'))) {
+      console.log('\x1b[33mRefusing to overwrite existing CODEBASE.md with a zero-source map.\x1b[0m');
+      console.log('  No TypeScript source files were detected. Re-run with `slope map --force` if a docs-only map is intentional.\n');
+      process.exit(1);
+    }
     // Downstream project — always (re)generate from the generic template.
     // Surgical section updates would require the existing map to have the
     // right markers, and v1.55.1 wrote SLOPE-internal sections into other
@@ -849,6 +855,11 @@ export async function mapCommand(args: string[]): Promise<void> {
   console.log(`\nMap written to ${relative(cwd, outputPath)}\n`);
 }
 
+function isSlopeShapedMap(content: string): boolean {
+  return /^# SLOPE Codebase Map\b/m.test(content)
+    || content.includes('Sprint Lifecycle & Operational Performance Engine');
+}
+
 function printUsage(): void {
   console.log(`
 slope map — Generate/update the SLOPE codebase map
@@ -857,6 +868,7 @@ Usage:
   slope map                   Generate or update CODEBASE.md
   slope map --check           Check staleness (exit 1 if stale)
   slope map --output=<path>   Custom output path (default: CODEBASE.md)
+  slope map --force           Allow replacing an existing map when no source files are detected
 
 The codebase map provides a compact (~500 line) overview of the project
 for agent navigation. Auto-generated sections are updated in place;

--- a/src/core/briefing.ts
+++ b/src/core/briefing.ts
@@ -92,6 +92,8 @@ export interface SkillBriefingResult {
 
 // --- Library functions ---
 
+const DEFAULT_BRIEFING_HAZARD_LIMIT = 12;
+
 /**
  * Filter common issues to only those relevant to the sprint's work.
  * Matches by category list and/or keyword search in title/description/prevention.
@@ -435,11 +437,23 @@ export function formatBriefing(opts: {
   }
 
   if (filteredBunkers.length > 0 || filteredShotHazards.length > 0) {
-    for (const h of filteredShotHazards) {
-      lines.push(`  [S${h.sprint}] ${h.type}: ${h.description}`);
+    const hazardLines = [
+      ...filteredShotHazards.map(h => ({
+        sprint: h.sprint,
+        line: `  [S${h.sprint}] ${h.type}: ${h.description}`,
+      })),
+      ...filteredBunkers.map(b => ({
+        sprint: b.sprint,
+        line: `  [S${b.sprint}] ${b.location}`,
+      })),
+    ].sort((a, b) => b.sprint - a.sprint);
+
+    for (const entry of hazardLines.slice(0, DEFAULT_BRIEFING_HAZARD_LIMIT)) {
+      lines.push(entry.line);
     }
-    for (const b of filteredBunkers) {
-      lines.push(`  [S${b.sprint}] ${b.location}`);
+    const omitted = hazardLines.length - DEFAULT_BRIEFING_HAZARD_LIMIT;
+    if (omitted > 0) {
+      lines.push(`  ... ${omitted} older hazard${omitted === 1 ? '' : 's'} omitted. Use --keywords=<term> or --categories=<category> to focus the briefing.`);
     }
   } else {
     lines.push('  No bunker locations recorded.');

--- a/tests/cli/commands/map.test.ts
+++ b/tests/cli/commands/map.test.ts
@@ -111,6 +111,30 @@ describe('slope map in a non-SLOPE repo (#351)', () => {
     }
   });
 
+  it('does not overwrite an existing map with zero-source output unless forced', () => {
+    const cwd = setupNonSlopeRepo({ name: 'docs-only-tool' });
+    try {
+      writeFileSync(join(cwd, 'CODEBASE.md'), '# Useful existing map\n\nKeep this.\n');
+
+      let output = '';
+      try {
+        execSync(`node ${SLOPE_BIN} map`, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+      } catch (err) {
+        output = `${(err as { stdout?: Buffer | string }).stdout ?? ''}${(err as { stderr?: Buffer | string }).stderr ?? ''}`;
+      }
+
+      expect(output).toContain('Refusing to overwrite existing CODEBASE.md with a zero-source map');
+      expect(readFileSync(join(cwd, 'CODEBASE.md'), 'utf8')).toContain('Useful existing map');
+
+      execSync(`node ${SLOPE_BIN} map --force`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      const forced = readFileSync(join(cwd, 'CODEBASE.md'), 'utf8');
+      expect(forced).toContain('# docs-only-tool Codebase Map');
+      expect(forced).toContain('No packages, apps, or top-level src/ directory detected');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('uses directory basename when package.json is missing entirely', () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-map-bare-'));
     try {

--- a/tests/cli/commands/map.test.ts
+++ b/tests/cli/commands/map.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const REPO_ROOT = resolve(__dirname, '..', '..', '..');
 const SLOPE_BIN = resolve(REPO_ROOT, 'dist', 'cli', 'index.js');
+
+function runSlopeMap(cwd: string, args: string[] = [], options: { encoding?: BufferEncoding } = {}) {
+  return execFileSync(process.execPath, [SLOPE_BIN, 'map', ...args], {
+    cwd,
+    encoding: options.encoding,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
 
 function setupNonSlopeRepo(packageJson: Record<string, unknown>): string {
   const dir = mkdtempSync(join(tmpdir(), 'slope-map-'));
@@ -39,7 +47,7 @@ describe('slope map in a non-SLOPE repo (#351)', () => {
       description: 'Cooper validation app — Next.js + tRPC',
     });
     try {
-      execSync(`node ${SLOPE_BIN} map`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeMap(cwd);
       const md = readFileSync(join(cwd, 'CODEBASE.md'), 'utf8');
       expect(md).toContain('# @cooper/web Codebase Map');
       expect(md).toContain('Cooper validation app — Next.js + tRPC');
@@ -53,7 +61,7 @@ describe('slope map in a non-SLOPE repo (#351)', () => {
   it('omits SLOPE-internal sections (CLI commands, guards, MCP tools, API surface)', () => {
     const cwd = setupNonSlopeRepo({ name: '@cooper/web' });
     try {
-      execSync(`node ${SLOPE_BIN} map`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeMap(cwd);
       const md = readFileSync(join(cwd, 'CODEBASE.md'), 'utf8');
       expect(md).not.toContain('## CLI Commands');
       expect(md).not.toContain('## Guard Definitions');
@@ -83,7 +91,7 @@ describe('slope map in a non-SLOPE repo (#351)', () => {
       writeFileSync(join(cwd, 'apps', 'site', 'main.ts'), 'console.log("hi");');
       writeFileSync(join(cwd, 'apps', 'site', 'main.test.ts'), 'it("works", () => {});');
 
-      execSync(`node ${SLOPE_BIN} map`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeMap(cwd);
       const md = readFileSync(join(cwd, 'CODEBASE.md'), 'utf8');
 
       // Each workspace package gets a section with its package.json name
@@ -103,7 +111,7 @@ describe('slope map in a non-SLOPE repo (#351)', () => {
   it('falls back to "_No packages..." when neither workspaces nor src/ exist', () => {
     const cwd = setupNonSlopeRepo({ name: 'standalone-tool' });
     try {
-      execSync(`node ${SLOPE_BIN} map`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeMap(cwd);
       const md = readFileSync(join(cwd, 'CODEBASE.md'), 'utf8');
       expect(md).toContain('No packages, apps, or top-level src/ directory detected');
     } finally {
@@ -118,7 +126,7 @@ describe('slope map in a non-SLOPE repo (#351)', () => {
 
       let output = '';
       try {
-        execSync(`node ${SLOPE_BIN} map`, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+        runSlopeMap(cwd, [], { encoding: 'utf8' });
       } catch (err) {
         output = `${(err as { stdout?: Buffer | string }).stdout ?? ''}${(err as { stderr?: Buffer | string }).stderr ?? ''}`;
       }
@@ -126,7 +134,7 @@ describe('slope map in a non-SLOPE repo (#351)', () => {
       expect(output).toContain('Refusing to overwrite existing CODEBASE.md with a zero-source map');
       expect(readFileSync(join(cwd, 'CODEBASE.md'), 'utf8')).toContain('Useful existing map');
 
-      execSync(`node ${SLOPE_BIN} map --force`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeMap(cwd, ['--force']);
       const forced = readFileSync(join(cwd, 'CODEBASE.md'), 'utf8');
       expect(forced).toContain('# docs-only-tool Codebase Map');
       expect(forced).toContain('No packages, apps, or top-level src/ directory detected');
@@ -149,7 +157,7 @@ describe('slope map in a non-SLOPE repo (#351)', () => {
       execSync('git config user.name t', { cwd });
       execSync('git commit -q --allow-empty -m initial', { cwd });
 
-      execSync(`node ${SLOPE_BIN} map`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeMap(cwd);
       const md = readFileSync(join(cwd, 'CODEBASE.md'), 'utf8');
       // Directory basename is appended to "Codebase Map"
       expect(md).toMatch(/^# .+ Codebase Map/m);
@@ -166,7 +174,7 @@ describe('slope map in a non-SLOPE repo (#351)', () => {
       writeFileSync(join(cwd, 'CODEBASE.md'),
         '# SLOPE Codebase Map\n\nSprint Lifecycle & Operational Performance Engine\n');
 
-      execSync(`node ${SLOPE_BIN} map`, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+      runSlopeMap(cwd);
       const md = readFileSync(join(cwd, 'CODEBASE.md'), 'utf8');
       expect(md).toContain('# @cooper/web Codebase Map');
       expect(md).not.toContain('# SLOPE Codebase Map');

--- a/tests/core/briefing.test.ts
+++ b/tests/core/briefing.test.ts
@@ -404,6 +404,30 @@ describe('formatBriefing', () => {
     expect(output).toContain('No SLOPE-era scorecards yet');
   });
 
+  it('caps full hazard output and summarizes omitted older hazards', () => {
+    const scorecards = Array.from({ length: 15 }, (_, index) => {
+      const sprint = index + 1;
+      return makeCard({
+        sprint_number: sprint,
+        shots: [makeShot({
+          ticket_key: `S${sprint}-1`,
+          hazards: [{ type: 'rough', description: `hazard ${sprint}` }],
+        })],
+      });
+    });
+
+    const output = formatBriefing({
+      scorecards,
+      commonIssues: makeIssues([]),
+    });
+
+    expect(output).toContain('[S15] rough: hazard 15');
+    expect(output).toContain('[S4] rough: hazard 4');
+    expect(output).not.toContain('[S3] rough: hazard 3');
+    expect(output).toContain('3 older hazards omitted');
+    expect(output).toContain('--keywords=<term>');
+  });
+
   it('shows nutrition alerts for non-healthy categories', () => {
     const output = formatBriefing({
       scorecards: [makeCard({


### PR DESCRIPTION
## Summary
- cap full briefing hazard output recent-first and summarize omitted historical hazards
- add zero-source CODEBASE.md overwrite guard for downstream maps
- keep SLOPE-shaped leftover map recovery working and add --force override
- add S134 scorecard and review artifacts

## Verification
- pnpm build
- pnpm typecheck
- pnpm vitest run tests/core/briefing.test.ts tests/cli/commands/map.test.ts tests/cli/guards/explore.test.ts
- node dist/cli/index.js briefing --sprint=134
- node dist/cli/index.js validate --sprint=134
- node dist/cli/index.js review docs/retros/sprint-134.json

Closes #490