### PR TITLE
feat(S136): add SLOPE issue scout triage loop

### DIFF
--- a/.github/scripts/send-slope-digest.mjs
+++ b/.github/scripts/send-slope-digest.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+const digestPath = process.argv[2];
+if (!digestPath) {
+  console.error('Usage: send-slope-digest.mjs <digest-path>');
+  process.exit(1);
+}
+
+const apiKey = process.env.RESEND_API_KEY;
+const to = process.env.SLOPE_DIGEST_EMAIL_TO;
+const from = process.env.SLOPE_DIGEST_EMAIL_FROM;
+
+if (!apiKey || !to || !from) {
+  console.error('RESEND_API_KEY, SLOPE_DIGEST_EMAIL_TO, and SLOPE_DIGEST_EMAIL_FROM are required.');
+  process.exit(1);
+}
+
+const text = readFileSync(digestPath, 'utf8');
+const response = await fetch('https://api.resend.com/emails', {
+  method: 'POST',
+  headers: {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    from,
+    to: to.split(',').map(address => address.trim()).filter(Boolean),
+    subject: 'SLOPE issue scout daily approval digest',
+    text,
+  }),
+});
+
+if (!response.ok) {
+  const body = await response.text();
+  console.error(`Resend API failed: ${response.status} ${body}`);
+  process.exit(1);
+}
+
+console.log('SLOPE issue scout digest email sent.');

--- a/.github/workflows/slope-issue-scout.yml
+++ b/.github/workflows/slope-issue-scout.yml
@@ -46,8 +46,7 @@ jobs:
             --source .slope/common-issues.json \
             --source .slope/transcripts \
             --dry-run \
-            --output .slope/issue-scout-candidates.json \
-            --json
+            --output .slope/issue-scout-candidates.json
 
       - name: Render daily approval digest
         run: |
@@ -69,8 +68,7 @@ jobs:
             --source .slope/transcripts \
             --create \
             --output .slope/issue-scout-created.json \
-            --state-path .slope/issue-scout-state.json \
-            --json
+            --state-path .slope/issue-scout-state.json
 
       - name: Email daily digest when configured
         env:

--- a/.github/workflows/slope-issue-scout.yml
+++ b/.github/workflows/slope-issue-scout.yml
@@ -1,0 +1,96 @@
+name: SLOPE Issue Scout
+
+on:
+  schedule:
+    - cron: '17 13 * * *'
+  workflow_dispatch:
+    inputs:
+      create_issues:
+        description: 'Create GitHub issues for non-duplicate candidates'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scout:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Scout SLOPE-driven issue candidates
+        run: |
+          node dist/cli/index.js issue scout \
+            --repo "${{ github.repository }}" \
+            --source docs/issues \
+            --source .slope/common-issues.json \
+            --source .slope/transcripts \
+            --dry-run \
+            --output .slope/issue-scout-candidates.json \
+            --json
+
+      - name: Render daily approval digest
+        run: |
+          node dist/cli/index.js issue triage \
+            --repo "${{ github.repository }}" \
+            --source docs/issues \
+            --source .slope/common-issues.json \
+            --source .slope/transcripts \
+            --daily-digest \
+            --output .slope/issue-scout-digest.md
+
+      - name: Create approved issue candidates
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.create_issues }}
+        run: |
+          node dist/cli/index.js issue scout \
+            --repo "${{ github.repository }}" \
+            --source docs/issues \
+            --source .slope/common-issues.json \
+            --source .slope/transcripts \
+            --create \
+            --output .slope/issue-scout-created.json \
+            --state-path .slope/issue-scout-state.json \
+            --json
+
+      - name: Email daily digest when configured
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          SLOPE_DIGEST_EMAIL_TO: ${{ secrets.SLOPE_DIGEST_EMAIL_TO }}
+          SLOPE_DIGEST_EMAIL_FROM: ${{ secrets.SLOPE_DIGEST_EMAIL_FROM }}
+        run: |
+          if [ -n "$RESEND_API_KEY" ] && [ -n "$SLOPE_DIGEST_EMAIL_TO" ] && [ -n "$SLOPE_DIGEST_EMAIL_FROM" ]; then
+            node .github/scripts/send-slope-digest.mjs .slope/issue-scout-digest.md
+          else
+            echo "Email digest skipped: RESEND_API_KEY, SLOPE_DIGEST_EMAIL_TO, and SLOPE_DIGEST_EMAIL_FROM are required."
+          fi
+
+      - name: Upload scout artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: slope-issue-scout
+          path: |
+            .slope/issue-scout-candidates.json
+            .slope/issue-scout-digest.md
+            .slope/issue-scout-created.json
+            .slope/issue-scout-state.json
+          if-no-files-found: ignore

--- a/docs/guides/issue-scout.md
+++ b/docs/guides/issue-scout.md
@@ -1,0 +1,95 @@
+# SLOPE Issue Scout
+
+`slope issue` detects likely SLOPE product issues from agent work, de-dupes them against GitHub, and prepares a daily approval digest.
+
+## Manual Scout
+
+Run a dry scan against local evidence:
+
+```sh
+slope issue scout \
+  --source .slope/common-issues.json \
+  --source .slope/transcripts \
+  --repo srbryers/slope \
+  --dry-run
+```
+
+For machine-readable output:
+
+```sh
+slope issue scout --repo srbryers/slope --dry-run --json
+```
+
+The dry-run output includes:
+
+- candidate title
+- confidence
+- labels
+- evidence
+- generated issue body
+- fingerprint
+- de-dupe result
+
+## Creating Issues
+
+Create mode is explicit:
+
+```sh
+slope issue scout --repo srbryers/slope --create
+```
+
+The scout opens GitHub issues only for candidates that do not match an existing issue title or scout fingerprint. It records created, commented, or de-duped fingerprints in `.slope/issue-scout.json` by default.
+
+To add fresh evidence to matching issues instead of only recording the duplicate:
+
+```sh
+slope issue scout --repo srbryers/slope --create --comment-duplicates
+```
+
+## Daily Digest
+
+Render the approval digest:
+
+```sh
+slope issue triage \
+  --repo srbryers/slope \
+  --daily-digest \
+  --output .slope/issue-scout-digest.md
+```
+
+The digest includes a `Request Approval To Fix` section. Each new candidate asks for one explicit decision: approve fix, defer, or reject.
+
+## GitHub Action
+
+`.github/workflows/slope-issue-scout.yml` runs daily and on manual dispatch.
+
+Scheduled runs:
+
+- build SLOPE from the checked-out repository
+- scan committed `docs/issues` plus optional `.slope` paths
+- write `.slope/issue-scout-candidates.json`
+- write `.slope/issue-scout-digest.md`
+- upload both as artifacts
+- email the digest when secrets are configured
+
+Manual dispatch can also create issues by enabling `create_issues`.
+
+## Email Secrets
+
+Email is optional. The workflow sends through Resend when all three secrets exist:
+
+- `RESEND_API_KEY`
+- `SLOPE_DIGEST_EMAIL_TO`
+- `SLOPE_DIGEST_EMAIL_FROM`
+
+Without those secrets, the workflow still uploads the digest artifact and logs that email was skipped.
+
+## Safety Model
+
+- Scheduled runs are proposal-only.
+- Issue creation requires manual `workflow_dispatch` with `create_issues=true`.
+- Duplicate titles and scout fingerprints are not opened as new issues.
+- Duplicate commenting is off unless `--comment-duplicates` is passed.
+- The daily digest is an approval request, not an authorization to fix.
+
+After approval, run the normal sprint loop: open a sprint, claim the issue, implement, test, score, review, PR, and merge.

--- a/docs/retros/sprint-136-review.md
+++ b/docs/retros/sprint-136-review.md
@@ -1,0 +1,68 @@
+## Sprint 136 Review: SLOPE Issue Scout and Daily Triage Loop
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 4 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (4/4) |
+| GIR % | 100% (4/4) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 4)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S136-1 | Long Iron | Green | Rough: Initial fallback classifier treated setup docs as issue candidates; built CLI smoke caught it and the fallback now requires problem signals. | Added typed pure functions for SLOPE-driven issue classification, stable fingerprints, GitHub issue de-dupe, issue/comment body rendering, approval digest rendering, and persisted fingerprint state. |
+| S136-2 | Long Iron | Green | Rough: Broad scorecard/review scans created noisy historical candidates; scorecard JSON is now skipped and scheduled scans avoid docs/retros. | Added `slope issue scout` and `slope issue triage` with repeatable sources, JSON/human output, explicit create mode, duplicate handling, and source parsing for common issues, transcripts, JSONL, markdown, text, and logs. |
+| S136-3 | Short Iron | In the Hole | — | Added the daily/manual `SLOPE Issue Scout` workflow, dry-run artifacts, manual issue creation gate, upload artifacts, and optional Resend email helper controlled by repository secrets. |
+| S136-4 | Short Iron | In the Hole | — | Added the issue scout guide plus focused core and CLI tests proving the Fathoms S341-S362 fixture recovers the six historical issue classes without duplicates. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| Wind | minor | S136 was not present in the roadmap tail, so review recommendation had no ticket-count context and the scorecard was written manually. |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Rough | S136-1 | Initial fallback classifier treated setup docs as issue candidates; built CLI smoke caught it and the fallback now requires problem signals. |
+| Rough | S136-2 | Broad scorecard/review scans created noisy historical candidates; scorecard JSON is now skipped and scheduled scans avoid docs/retros. |
+
+**Known hazards for future sprints:**
+- Fallback issue classifiers need problem-signal gates so command examples and setup docs do not become product issue candidates.
+- Historical scorecards and generated review markdown are high-noise sources for issue scouting unless the user explicitly selects them.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Scout sources need a tight evidence contract; scorecards and generated reviews are too noisy unless intentionally selected. | The scheduled workflow scans committed docs/issues plus optional .slope evidence sources, while scorecard JSON is ignored by the source reader. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | Focused issue scout tests, typecheck, build, built CLI smokes, full test suite, and map check passed. |
+| Diet | healthy | Core logic stays pure while GitHub CLI, filesystem, workflow, and email behavior live at the CLI/Action boundary. |
+| Recovery | healthy | Commit and push discipline resumed before closeout after the guard flagged the long feature batch. |
+
+### Course Management Notes
+
+- Validation used pnpm vitest run tests/core/issue-scout.test.ts tests/cli/commands/issue.test.ts, pnpm typecheck, pnpm build, built CLI smokes, pnpm test, and node dist/cli/index.js map --check.
+- Built CLI smoke with --repo srbryers/slope de-duped the six Fathoms-derived classes to #485, #488, #489, #490, #491, and #492.
+- The only new candidate from the scheduled source set is the existing docs/issues post-implementation gate writeup, left for daily approval triage rather than bundled into #493.
+
+### 19th Hole
+
+- **How did it feel?** A useful automation sprint with a good mid-flight correction: the scout was powerful enough to find real issues, then needed sharper source boundaries to avoid turning every retrospective into a candidate.
+- **Advice for next player?** Keep scheduled scans conservative and make create mode manual. Dry-run plus digest artifacts should be the daily default until candidate quality is proven over time.
+- **What surprised you?** The existing local .slope evidence immediately recovered the six Fathoms-derived issues and de-duped them against GitHub titles.
+- **Excited about next?** Use the daily approval digest to decide whether the remaining docs/issues post-implementation gate writeup needs a fresh GitHub issue or is already covered by shipped closeout work.
+

--- a/docs/retros/sprint-136.json
+++ b/docs/retros/sprint-136.json
@@ -1,0 +1,132 @@
+{
+  "sprint_number": 136,
+  "player": "codex",
+  "theme": "SLOPE Issue Scout and Daily Triage Loop",
+  "par": 4,
+  "slope": 4,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-06-03",
+  "type": "feature",
+  "shots": [
+    {
+      "ticket_key": "S136-1",
+      "title": "Add core issue scout classification, de-dupe, body, digest, and fingerprint state helpers (#493)",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Initial fallback classifier treated setup docs as issue candidates; built CLI smoke caught it and the fallback now requires problem signals."
+        }
+      ],
+      "notes": "Added typed pure functions for SLOPE-driven issue classification, stable fingerprints, GitHub issue de-dupe, issue/comment body rendering, approval digest rendering, and persisted fingerprint state."
+    },
+    {
+      "ticket_key": "S136-2",
+      "title": "Add issue scout and triage CLI commands with dry-run, create mode, and evidence ingestion (#493)",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Broad scorecard/review scans created noisy historical candidates; scorecard JSON is now skipped and scheduled scans avoid docs/retros."
+        }
+      ],
+      "notes": "Added `slope issue scout` and `slope issue triage` with repeatable sources, JSON/human output, explicit create mode, duplicate handling, and source parsing for common issues, transcripts, JSONL, markdown, text, and logs."
+    },
+    {
+      "ticket_key": "S136-3",
+      "title": "Add scheduled GitHub Action and optional email digest for daily approval loop (#493)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added the daily/manual `SLOPE Issue Scout` workflow, dry-run artifacts, manual issue creation gate, upload artifacts, and optional Resend email helper controlled by repository secrets."
+    },
+    {
+      "ticket_key": "S136-4",
+      "title": "Document setup and cover scout classification, de-dupe, digest, and CLI behavior (#493)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added the issue scout guide plus focused core and CLI tests proving the Fathoms S341-S362 fixture recovers the six historical issue classes without duplicates."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 2,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "wind",
+      "impact": "minor",
+      "description": "S136 was not present in the roadmap tail, so review recommendation had no ticket-count context and the scorecard was written manually."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Scout sources need a tight evidence contract; scorecards and generated reviews are too noisy unless intentionally selected.",
+      "outcome": "The scheduled workflow scans committed docs/issues plus optional .slope evidence sources, while scorecard JSON is ignored by the source reader."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "Focused issue scout tests, typecheck, build, built CLI smokes, full test suite, and map check passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "diet",
+      "description": "Core logic stays pure while GitHub CLI, filesystem, workflow, and email behavior live at the CLI/Action boundary.",
+      "status": "healthy"
+    },
+    {
+      "category": "recovery",
+      "description": "Commit and push discipline resumed before closeout after the guard flagged the long feature batch.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A useful automation sprint with a good mid-flight correction: the scout was powerful enough to find real issues, then needed sharper source boundaries to avoid turning every retrospective into a candidate.",
+    "advice_for_next_player": "Keep scheduled scans conservative and make create mode manual. Dry-run plus digest artifacts should be the daily default until candidate quality is proven over time.",
+    "what_surprised_you": "The existing local .slope evidence immediately recovered the six Fathoms-derived issues and de-duped them against GitHub titles.",
+    "excited_about_next": "Use the daily approval digest to decide whether the remaining docs/issues post-implementation gate writeup needs a fresh GitHub issue or is already covered by shipped closeout work."
+  },
+  "bunker_locations": [
+    "Fallback issue classifiers need problem-signal gates so command examples and setup docs do not become product issue candidates.",
+    "Historical scorecards and generated review markdown are high-noise sources for issue scouting unless the user explicitly selects them."
+  ],
+  "yardage_book_updates": [
+    "New command: slope issue scout [--source=<path>]... [--repo=<owner/repo>] [--dry-run|--create] [--json]",
+    "New command: slope issue triage [--source=<path>]... [--repo=<owner/repo>] [--daily-digest] [--output=<path>]",
+    "Scheduled workflow: .github/workflows/slope-issue-scout.yml uploads candidate JSON and a daily approval digest; issue creation is manual_dispatch-only.",
+    "Optional email: .github/scripts/send-slope-digest.mjs sends the digest through Resend when RESEND_API_KEY, SLOPE_DIGEST_EMAIL_TO, and SLOPE_DIGEST_EMAIL_FROM are set."
+  ],
+  "course_management_notes": [
+    "Validation used pnpm vitest run tests/core/issue-scout.test.ts tests/cli/commands/issue.test.ts, pnpm typecheck, pnpm build, built CLI smokes, pnpm test, and node dist/cli/index.js map --check.",
+    "Built CLI smoke with --repo srbryers/slope de-duped the six Fathoms-derived classes to #485, #488, #489, #490, #491, and #492.",
+    "The only new candidate from the scheduled source set is the existing docs/issues post-implementation gate writeup, left for daily approval triage rather than bundled into #493."
+  ],
+  "slope_factors": [
+    "github_cli",
+    "scheduled_workflow",
+    "email_digest",
+    "classifier_dedupe"
+  ]
+}

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -170,7 +170,7 @@ async function runScoutCommand(args: string[]): Promise<void> {
     writeJson(resolve(cwd, output), payload);
   }
 
-  if (json || output) {
+  if (json) {
     console.log(JSON.stringify(payload, null, 2));
     return;
   }

--- a/src/cli/commands/issue.ts
+++ b/src/cli/commands/issue.ts
@@ -1,0 +1,648 @@
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, extname, join, relative, resolve } from 'node:path';
+import {
+  buildIssueCandidates,
+  dedupeCandidates,
+  formatIssueBody,
+  formatIssueScoutComment,
+  mergeIssueScoutState,
+  parseIssueScoutState,
+  renderIssueScoutDigest,
+} from '../../core/index.js';
+import type {
+  ExistingIssue,
+  IssueScoutCandidate,
+  IssueScoutEvidence,
+  IssueScoutState,
+  IssueScoutStateRecord,
+} from '../../core/index.js';
+
+interface ParsedIssueArgs {
+  flags: Record<string, string>;
+  repeated: Record<string, string[]>;
+  positionals: string[];
+}
+
+interface ScoutRunOptions {
+  cwd: string;
+  repo?: string;
+  sources: string[];
+  fetchExisting: boolean;
+}
+
+interface ScoutRunResult {
+  repo?: string;
+  sources: string[];
+  evidenceCount: number;
+  candidates: IssueScoutCandidate[];
+}
+
+interface CreateAction {
+  title: string;
+  fingerprint: string;
+  action: 'created' | 'commented' | 'deduped';
+  issueNumber?: number;
+  issueUrl?: string;
+}
+
+const DEFAULT_SOURCES = [
+  '.slope/common-issues.json',
+  '.slope/transcripts',
+  '.slope/review-findings.json',
+  '.slope/guard-metrics.jsonl',
+];
+
+const DEFAULT_STATE_PATH = '.slope/issue-scout.json';
+
+export async function issueCommand(args: string[]): Promise<void> {
+  const subcommand = args[0];
+
+  if (!subcommand || args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  if (subcommand === 'scout') {
+    await runScoutCommand(args.slice(1));
+    return;
+  }
+
+  if (subcommand === 'triage') {
+    await runTriageCommand(args.slice(1));
+    return;
+  }
+
+  throw new Error(`Unknown issue subcommand: ${subcommand}`);
+}
+
+function parseArgs(args: string[]): ParsedIssueArgs {
+  const flags: Record<string, string> = {};
+  const repeated: Record<string, string[]> = {};
+  const positionals: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith('--')) {
+      positionals.push(arg);
+      continue;
+    }
+
+    const eq = arg.indexOf('=');
+    let key: string;
+    let value: string;
+    if (eq >= 0) {
+      key = arg.slice(2, eq);
+      value = arg.slice(eq + 1);
+    } else {
+      key = arg.slice(2);
+      const next = args[i + 1];
+      if (next && !next.startsWith('--')) {
+        value = next;
+        i++;
+      } else {
+        value = 'true';
+      }
+    }
+
+    flags[key] = value;
+    if (!repeated[key]) repeated[key] = [];
+    repeated[key].push(value);
+  }
+
+  return { flags, repeated, positionals };
+}
+
+async function runScoutCommand(args: string[]): Promise<void> {
+  const parsed = parseArgs(args);
+  const cwd = process.cwd();
+  const repo = parsed.flags.repo;
+  const create = parsed.flags.create === 'true';
+  const dryRun = parsed.flags['dry-run'] === 'true' || !create;
+  const json = parsed.flags.json === 'true';
+  const output = parsed.flags.output;
+  const statePath = parsed.flags['state-path'] ?? DEFAULT_STATE_PATH;
+  const commentDuplicates = parsed.flags['comment-duplicates'] === 'true';
+
+  if (create && parsed.flags['dry-run'] === 'true') {
+    throw new Error('Use either --dry-run or --create, not both.');
+  }
+  if (create && !repo) {
+    throw new Error('--create requires --repo=<owner/repo>.');
+  }
+
+  const sources = parsed.repeated.source?.length ? parsed.repeated.source : DEFAULT_SOURCES;
+  const run = await buildScoutRun({
+    cwd,
+    repo,
+    sources,
+    fetchExisting: Boolean(repo),
+  });
+
+  let actions: CreateAction[] = [];
+  if (create) {
+    actions = createOrCommentIssues(run.candidates, {
+      repo: repo!,
+      cwd,
+      statePath: resolve(cwd, statePath),
+      commentDuplicates,
+    });
+  }
+
+  const payload = {
+    mode: create ? 'create' : 'dry-run',
+    repo,
+    sources: run.sources,
+    evidence_count: run.evidenceCount,
+    candidate_count: run.candidates.length,
+    candidates: run.candidates.map(candidate => serializeCandidate(candidate)),
+    actions,
+  };
+
+  if (output) {
+    writeJson(resolve(cwd, output), payload);
+  }
+
+  if (json || output) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  printScoutSummary(run, dryRun, actions);
+}
+
+async function runTriageCommand(args: string[]): Promise<void> {
+  const parsed = parseArgs(args);
+  const cwd = process.cwd();
+  const repo = parsed.flags.repo;
+  const output = parsed.flags.output;
+  const json = parsed.flags.json === 'true';
+  const sources = parsed.repeated.source?.length ? parsed.repeated.source : DEFAULT_SOURCES;
+
+  const run = await buildScoutRun({
+    cwd,
+    repo,
+    sources,
+    fetchExisting: Boolean(repo),
+  });
+
+  const digest = renderIssueScoutDigest(run.candidates, { repo });
+  if (output) {
+    writeText(resolve(cwd, output), digest);
+  }
+
+  if (json) {
+    console.log(JSON.stringify({
+      repo,
+      sources: run.sources,
+      evidence_count: run.evidenceCount,
+      candidate_count: run.candidates.length,
+      digest,
+      candidates: run.candidates.map(candidate => serializeCandidate(candidate)),
+    }, null, 2));
+    return;
+  }
+
+  console.log(digest);
+}
+
+async function buildScoutRun(options: ScoutRunOptions): Promise<ScoutRunResult> {
+  const sourcePaths = options.sources.map(source => resolve(options.cwd, source));
+  const evidence = readIssueScoutSources(options.cwd, sourcePaths);
+  const candidates = buildIssueCandidates(evidence);
+  const existing = options.fetchExisting && options.repo ? fetchExistingIssues(options.repo) : [];
+  const deduped = existing.length > 0 ? dedupeCandidates(candidates, existing) : dedupeCandidates(candidates, []);
+
+  return {
+    repo: options.repo,
+    sources: sourcePaths
+      .filter(path => existsSync(path))
+      .map(path => relative(options.cwd, path)),
+    evidenceCount: evidence.length,
+    candidates: deduped,
+  };
+}
+
+function readIssueScoutSources(cwd: string, sourcePaths: string[]): IssueScoutEvidence[] {
+  const evidence: IssueScoutEvidence[] = [];
+  for (const sourcePath of sourcePaths) {
+    if (!existsSync(sourcePath)) continue;
+    const stat = statSync(sourcePath);
+    if (stat.isDirectory()) {
+      for (const file of walkFiles(sourcePath)) {
+        evidence.push(...readIssueScoutFile(cwd, file));
+      }
+    } else if (stat.isFile()) {
+      evidence.push(...readIssueScoutFile(cwd, sourcePath));
+    }
+  }
+  return evidence;
+}
+
+function walkFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir).sort()) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      files.push(...walkFiles(path));
+    } else if (stat.isFile()) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function readIssueScoutFile(cwd: string, filePath: string): IssueScoutEvidence[] {
+  const ext = extname(filePath).toLowerCase();
+  if (!['.json', '.jsonl', '.md', '.txt', '.log'].includes(ext)) return [];
+
+  const raw = readFileSync(filePath, 'utf8');
+  const sourcePath = relative(cwd, filePath);
+
+  if (ext === '.json') {
+    try {
+      return readJsonEvidence(sourcePath, JSON.parse(raw));
+    } catch {
+      return [makeEvidence(sourcePath, raw)];
+    }
+  }
+
+  if (ext === '.jsonl') {
+    const items: IssueScoutEvidence[] = [];
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      try {
+        items.push(makeEvidence(sourcePath, summarizeObject(JSON.parse(line))));
+      } catch {
+        items.push(makeEvidence(sourcePath, line));
+      }
+    }
+    return items;
+  }
+
+  return splitTextEvidence(sourcePath, raw);
+}
+
+function readJsonEvidence(sourcePath: string, value: unknown): IssueScoutEvidence[] {
+  if (isScorecardJson(value)) return [];
+
+  const records = candidateJsonRecords(value);
+  if (records.length === 0) return [];
+  return records.map(record => {
+    const quote = summarizeObject(record);
+    return makeEvidence(sourcePath, quote, {
+      sprint: extractSprint(quote, record),
+      command: extractCommand(quote),
+      details: summarizeDetails(record),
+    });
+  });
+}
+
+function candidateJsonRecords(value: unknown): Record<string, unknown>[] {
+  if (Array.isArray(value)) {
+    return value.filter(isRecord);
+  }
+  if (!isRecord(value)) return [];
+  if (isScorecardJson(value)) return [];
+
+  const keys = ['recurring_patterns', 'patterns', 'common_issues', 'issues', 'findings', 'events'];
+  for (const key of keys) {
+    const nested = value[key];
+    if (Array.isArray(nested)) return nested.filter(isRecord);
+  }
+
+  return [value];
+}
+
+function summarizeObject(value: unknown): string {
+  if (!isRecord(value)) return String(value);
+
+  const fields = [
+    'title',
+    'name',
+    'summary',
+    'description',
+    'pattern',
+    'issue',
+    'observed',
+    'expected',
+    'evidence',
+    'impact',
+    'workaround',
+    'notes',
+    'command',
+  ];
+
+  const parts: string[] = [];
+  for (const field of fields) {
+    const item = value[field];
+    if (typeof item === 'string') parts.push(item);
+    else if (Array.isArray(item)) parts.push(item.map(entry => typeof entry === 'string' ? entry : JSON.stringify(entry)).join(' '));
+    else if (isRecord(item)) parts.push(JSON.stringify(item));
+  }
+
+  return parts.length > 0 ? parts.join('\n') : JSON.stringify(value);
+}
+
+function summarizeDetails(value: Record<string, unknown>): Record<string, unknown> {
+  const details: Record<string, unknown> = {};
+  for (const key of ['id', 'category', 'severity', 'count', 'frequency', 'first_seen', 'last_seen']) {
+    if (value[key] !== undefined) details[key] = value[key];
+  }
+  return details;
+}
+
+function splitTextEvidence(sourcePath: string, raw: string): IssueScoutEvidence[] {
+  const heading = /^#\s+(.+)$/m.exec(raw)?.[1]?.trim();
+  const chunks = raw
+    .split(/\n\s*\n/)
+    .map(chunk => chunk.trim())
+    .filter(Boolean);
+
+  if (chunks.length === 0) return [];
+  return chunks.map(chunk => makeEvidence(sourcePath, heading && !chunk.includes(heading)
+    ? `${heading}\n${chunk}`
+    : chunk));
+}
+
+function makeEvidence(
+  sourcePath: string,
+  quote: string,
+  overrides: Partial<IssueScoutEvidence> = {},
+): IssueScoutEvidence {
+  const compact = quote
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+  return {
+    source: sourcePath,
+    sourcePath,
+    sprint: overrides.sprint ?? extractSprint(compact),
+    command: overrides.command ?? extractCommand(compact),
+    quote: compact,
+    details: overrides.details,
+  };
+}
+
+function extractSprint(text: string, value?: Record<string, unknown>): number | undefined {
+  const raw = value?.sprint ?? value?.sprint_number ?? value?.sprintNumber;
+  if (typeof raw === 'number') return raw;
+  if (typeof raw === 'string') {
+    const parsed = Number(raw.replace(/^S/i, ''));
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  const match = /\bS(\d+(?:\.\d+)?)\b/i.exec(text);
+  if (!match) return undefined;
+  const sprint = Number(match[1]);
+  return Number.isFinite(sprint) ? sprint : undefined;
+}
+
+function extractCommand(text: string): string | undefined {
+  const backtick = /`(slope\s+[^`]+)`/.exec(text);
+  if (backtick) return backtick[1].trim();
+
+  const inline = /\bslope\s+[a-z][\w-]*(?:\s+[a-z][\w-]*)?(?:\s+--?[a-z][\w-]*(?:=[^\s,.;)]+)?)?/.exec(text);
+  return inline ? inline[0].trim() : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isScorecardJson(value: unknown): boolean {
+  return isRecord(value)
+    && Array.isArray(value.shots)
+    && (value.sprint_number !== undefined || value.sprint !== undefined);
+}
+
+function serializeCandidate(candidate: IssueScoutCandidate): Record<string, unknown> {
+  return {
+    title: candidate.title,
+    kind: candidate.kind,
+    confidence: candidate.confidence,
+    labels: candidate.labels,
+    fingerprint: candidate.fingerprint,
+    summary: candidate.summary,
+    evidence: candidate.evidence,
+    dedupe: candidate.dedupe,
+    body: formatIssueBody(candidate),
+  };
+}
+
+function fetchExistingIssues(repo: string): ExistingIssue[] {
+  const result = runGh([
+    'issue',
+    'list',
+    '--repo',
+    repo,
+    '--state',
+    'all',
+    '--limit',
+    '200',
+    '--json',
+    'number,title,body,state,url,labels',
+  ]);
+
+  const parsed = JSON.parse(result || '[]') as Array<Record<string, unknown>>;
+  return parsed.map(item => ({
+    number: Number(item.number),
+    title: String(item.title ?? ''),
+    body: typeof item.body === 'string' ? item.body : undefined,
+    state: typeof item.state === 'string' ? item.state : undefined,
+    url: typeof item.url === 'string' ? item.url : undefined,
+    labels: Array.isArray(item.labels)
+      ? item.labels.map(label => isRecord(label) ? String(label.name ?? '') : String(label)).filter(Boolean)
+      : [],
+  })).filter(issue => Number.isFinite(issue.number) && issue.title);
+}
+
+function createOrCommentIssues(
+  candidates: IssueScoutCandidate[],
+  opts: { repo: string; cwd: string; statePath: string; commentDuplicates: boolean },
+): CreateAction[] {
+  const state = readIssueScoutState(opts.statePath);
+  const stateByFingerprint = new Map(state.records.map(record => [record.fingerprint, record]));
+  const actions: CreateAction[] = [];
+  const records: IssueScoutStateRecord[] = [];
+
+  for (const candidate of candidates) {
+    const existingRecord = stateByFingerprint.get(candidate.fingerprint);
+    if (existingRecord) {
+      actions.push({
+        title: candidate.title,
+        fingerprint: candidate.fingerprint,
+        action: existingRecord.status,
+        issueNumber: existingRecord.issueNumber,
+        issueUrl: existingRecord.issueUrl,
+      });
+      continue;
+    }
+
+    const matched = candidate.dedupe?.matchedIssue;
+    if (candidate.dedupe?.status === 'duplicate' && matched) {
+      if (opts.commentDuplicates) {
+        runGh([
+          'issue',
+          'comment',
+          String(matched.number),
+          '--repo',
+          opts.repo,
+          '--body',
+          formatIssueScoutComment(candidate),
+        ]);
+      }
+      const action: CreateAction = {
+        title: candidate.title,
+        fingerprint: candidate.fingerprint,
+        action: opts.commentDuplicates ? 'commented' : 'deduped',
+        issueNumber: matched.number,
+        issueUrl: matched.url,
+      };
+      actions.push(action);
+      records.push(recordFromAction(candidate, action));
+      continue;
+    }
+
+    const issueUrl = runGh([
+      'issue',
+      'create',
+      '--repo',
+      opts.repo,
+      '--title',
+      candidate.title,
+      '--body',
+      formatIssueBody(candidate),
+      ...candidate.labels.flatMap(label => ['--label', label]),
+    ]).trim();
+    const issueNumber = issueNumberFromUrl(issueUrl);
+    const action: CreateAction = {
+      title: candidate.title,
+      fingerprint: candidate.fingerprint,
+      action: 'created',
+      issueNumber,
+      issueUrl,
+    };
+    actions.push(action);
+    records.push(recordFromAction(candidate, action));
+  }
+
+  if (records.length > 0) {
+    writeIssueScoutState(opts.statePath, mergeIssueScoutState(state, records));
+  }
+
+  return actions;
+}
+
+function readIssueScoutState(path: string): IssueScoutState {
+  if (!existsSync(path)) return { version: 1, records: [] };
+  return parseIssueScoutState(readFileSync(path, 'utf8'));
+}
+
+function writeIssueScoutState(path: string, state: IssueScoutState): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function recordFromAction(candidate: IssueScoutCandidate, action: CreateAction): IssueScoutStateRecord {
+  return {
+    fingerprint: candidate.fingerprint,
+    title: candidate.title,
+    issueNumber: action.issueNumber,
+    issueUrl: action.issueUrl,
+    status: action.action,
+    updatedAt: new Date().toISOString(),
+    sourcePaths: Array.from(new Set(candidate.evidence.map(item => item.sourcePath).filter(Boolean) as string[])).sort(),
+  };
+}
+
+function issueNumberFromUrl(url: string): number | undefined {
+  const match = /\/issues\/(\d+)/.exec(url);
+  return match ? Number(match[1]) : undefined;
+}
+
+function runGh(args: string[]): string {
+  const result = spawnSync('gh', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.error) throw result.error;
+  if ((result.status ?? 0) !== 0) {
+    throw new Error(`gh ${args.join(' ')} failed: ${(result.stderr ?? '').trim()}`);
+  }
+  return result.stdout ?? '';
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeText(path: string, value: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, value);
+}
+
+function printScoutSummary(run: ScoutRunResult, dryRun: boolean, actions: CreateAction[]): void {
+  console.log('\nSLOPE Issue Scout\n');
+  if (run.repo) console.log(`  Repository: ${run.repo}`);
+  console.log(`  Sources: ${run.sources.length > 0 ? run.sources.join(', ') : 'none found'}`);
+  console.log(`  Evidence items: ${run.evidenceCount}`);
+  console.log(`  Candidates: ${run.candidates.length}`);
+  if (dryRun) console.log('  Mode: dry-run');
+
+  if (run.candidates.length === 0) {
+    console.log('\n  No SLOPE-driven issue candidates found.\n');
+    return;
+  }
+
+  console.log('\n  Candidate issues:');
+  for (const candidate of run.candidates) {
+    const dedupe = candidate.dedupe;
+    const marker = dedupe?.status === 'duplicate' ? 'duplicate' : 'new';
+    const match = dedupe?.matchedIssue ? ` -> #${dedupe.matchedIssue.number}` : '';
+    console.log(`    - [${marker}] ${candidate.title}${match}`);
+    console.log(`      confidence=${candidate.confidence.toFixed(2)} labels=${candidate.labels.join(', ')} fingerprint=${candidate.fingerprint}`);
+    console.log(`      evidence=${candidate.evidence.length} dedupe=${dedupe?.reason ?? 'not checked'}`);
+  }
+
+  if (actions.length > 0) {
+    console.log('\n  Actions:');
+    for (const action of actions) {
+      const target = action.issueNumber ? `#${action.issueNumber}` : action.issueUrl ?? action.fingerprint;
+      console.log(`    - ${action.action}: ${action.title} (${target})`);
+    }
+  }
+  console.log('');
+}
+
+function printUsage(): void {
+  console.log(`
+slope issue - Detect and triage SLOPE-driven product issues from agent work
+
+Usage:
+  slope issue scout [--source=<path>]... [--repo=<owner/repo>] [--dry-run] [--json]
+  slope issue scout --repo=<owner/repo> --create [--comment-duplicates]
+  slope issue triage [--source=<path>]... [--repo=<owner/repo>] [--daily-digest]
+
+Options:
+  --source=<path>          File or directory to scan (repeatable)
+  --repo=<owner/repo>      GitHub repository for dedupe/create
+  --dry-run                Print candidates without opening issues
+  --create                 Open new issues for non-duplicates
+  --comment-duplicates     In create mode, comment on matched issues with new evidence
+  --output=<path>          Write JSON scout output or markdown digest
+  --state-path=<path>      Fingerprint state path (default: .slope/issue-scout.json)
+  --json                   Print machine-readable JSON
+
+Default sources:
+  .slope/common-issues.json, .slope/transcripts, .slope/review-findings.json, .slope/guard-metrics.jsonl
+`);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -75,6 +75,7 @@ import { orgCommand } from './commands/org.js';
 import { memoryCommand } from './commands/memory.js';
 import { phaseCommand } from './commands/phase.js';
 import { skillsCommand } from './commands/skills.js';
+import { issueCommand } from './commands/issue.js';
 import { reportCliError } from './error-reporter.js';
 import { buildSourceCheckoutRuntimeWarning } from './source-runtime.js';
 
@@ -107,6 +108,7 @@ Usage:
   slope card --team                         Show per-player comparison table
   slope validate [path]                     Validate scorecard(s)
   slope skills scan|list|validate           Manage repo-local skill registry
+  slope issue scout|triage                  Detect and triage SLOPE-driven issues
   slope review [path] [--plain]             Format sprint review markdown
   slope briefing                            Pre-round briefing
   slope version                             Show current version
@@ -297,6 +299,9 @@ switch (subcommand) {
   case 'skills':
     skillsCommand(process.argv.slice(3)).catch(reportCliError);
     break;
+  case 'issue':
+    issueCommand(process.argv.slice(3)).catch(reportCliError);
+    break;
   case 'doctor':
     doctorCommand(process.argv.slice(3)).catch(reportCliError);
     break;
@@ -377,6 +382,7 @@ Usage:
   slope metaphor list|set|show              Manage metaphor display themes
   slope plugin list|validate                Manage custom plugins
   slope skills scan|list|validate           Manage repo-local skill registry
+  slope issue scout|triage                  Detect and triage SLOPE-driven issues
   slope initiative create|status|next|advance|review  Multi-sprint initiative orchestration
   slope index [--full|--status|--prune]               Semantic embedding index
   slope context "query" [options]                     Semantic context search

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -374,6 +374,27 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
+    cmd: 'issue', desc: 'Detect and triage SLOPE-driven product issues', category: 'tooling',
+    subcommands: [
+      { name: 'scout', desc: 'Scan common issues/transcripts and propose GitHub issues', flags: [
+        { flag: '--source=<path>', desc: 'File or directory to scan (repeatable)' },
+        { flag: '--repo=<owner/repo>', desc: 'GitHub repository for dedupe/create' },
+        { flag: '--dry-run', desc: 'Print candidates without creating issues' },
+        { flag: '--create', desc: 'Create issues for non-duplicate candidates' },
+        { flag: '--comment-duplicates', desc: 'Comment on matched issues with fresh evidence' },
+        { flag: '--output=<path>', desc: 'Write JSON scout output' },
+        { flag: '--json', desc: 'Print machine-readable JSON' },
+      ]},
+      { name: 'triage', desc: 'Render daily approval digest for issue candidates', flags: [
+        { flag: '--source=<path>', desc: 'File or directory to scan (repeatable)' },
+        { flag: '--repo=<owner/repo>', desc: 'GitHub repository for dedupe context' },
+        { flag: '--daily-digest', desc: 'Render the daily approval digest' },
+        { flag: '--output=<path>', desc: 'Write markdown digest' },
+        { flag: '--json', desc: 'Print digest and candidates as JSON' },
+      ]},
+    ],
+  },
+  {
     cmd: 'metaphor', desc: 'Manage metaphor display themes', category: 'tooling',
     subcommands: [
       { name: 'list', desc: 'Show all available metaphors' },

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -497,6 +497,29 @@ export type {
   FlowStalenessResult,
 } from './flows.js';
 
+// Issue Scout
+export {
+  classifySlopeIssue,
+  buildIssueCandidate,
+  buildIssueCandidates,
+  fingerprintCandidate,
+  dedupeCandidates,
+  formatIssueBody,
+  formatIssueScoutComment,
+  renderIssueScoutDigest,
+  parseIssueScoutState,
+  mergeIssueScoutState,
+} from './issue-scout.js';
+export type {
+  IssueScoutEvidence,
+  IssueScoutClassification,
+  IssueScoutCandidate,
+  IssueScoutDedupeResult,
+  ExistingIssue,
+  IssueScoutState,
+  IssueScoutStateRecord,
+} from './issue-scout.js';
+
 // Inspirations
 export {
   parseInspirations,

--- a/src/core/issue-scout.ts
+++ b/src/core/issue-scout.ts
@@ -1,0 +1,604 @@
+import { createHash } from 'node:crypto';
+
+export interface IssueScoutEvidence {
+  source: string;
+  sourcePath?: string;
+  sprint?: number;
+  command?: string;
+  quote: string;
+  details?: Record<string, unknown>;
+}
+
+export interface IssueScoutClassification {
+  slopeDriven: boolean;
+  kind: string;
+  title: string;
+  labels: string[];
+  confidence: number;
+  summary: string;
+  acceptanceCriteria: string[];
+  reasons: string[];
+}
+
+export interface IssueScoutCandidate {
+  kind: string;
+  title: string;
+  labels: string[];
+  confidence: number;
+  summary: string;
+  acceptanceCriteria: string[];
+  evidence: IssueScoutEvidence[];
+  fingerprint: string;
+  dedupe?: IssueScoutDedupeResult;
+}
+
+export interface ExistingIssue {
+  number: number;
+  title: string;
+  body?: string;
+  state?: string;
+  url?: string;
+  labels?: string[];
+}
+
+export interface IssueScoutDedupeResult {
+  status: 'new' | 'duplicate';
+  reason: string;
+  matchedIssue?: ExistingIssue;
+  similarity?: number;
+}
+
+export interface IssueScoutStateRecord {
+  fingerprint: string;
+  title: string;
+  issueNumber?: number;
+  issueUrl?: string;
+  status: 'created' | 'commented' | 'deduped';
+  updatedAt: string;
+  sourcePaths?: string[];
+}
+
+export interface IssueScoutState {
+  version: 1;
+  records: IssueScoutStateRecord[];
+}
+
+interface PatternDefinition {
+  kind: string;
+  title: string;
+  labels: string[];
+  summary: string;
+  acceptanceCriteria: string[];
+  required: RegExp[];
+  signals: RegExp[];
+}
+
+const FINGERPRINT_MARKER = 'slope-issue-scout:fingerprint:';
+
+const STOP_WORDS = new Set([
+  'the', 'and', 'for', 'with', 'that', 'this', 'from', 'into', 'should',
+  'slope', 'issue', 'issues', 'when', 'then', 'than', 'after', 'before',
+  'during', 'agent', 'agents', 'sprint', 'sprints',
+]);
+
+const SLOPE_PRODUCT_SIGNALS: RegExp[] = [
+  /\bslope\b/i,
+  /\.slope\b/i,
+  /\bscorecard\b/i,
+  /\bbriefing\b/i,
+  /\bauto-card\b/i,
+  /\bclaim\b/i,
+  /\bguard\b/i,
+  /\bpost-push\b/i,
+  /\bcloseout\b/i,
+  /\breview\b/i,
+  /\bvalidate\b/i,
+  /\broadmap\b/i,
+  /\btranscript\b/i,
+  /\bcommon-issues\b/i,
+  /\bNODE_MODULE_VERSION\b/i,
+  /\bbetter-sqlite3\b/i,
+];
+
+const PROBLEM_SIGNALS: RegExp[] = [
+  /\bfailed?\b/i,
+  /\bfailure\b/i,
+  /\berror\b/i,
+  /\bcrash(?:ed)?\b/i,
+  /\bhung\b/i,
+  /\bhang(?:s|ing)?\b/i,
+  /\bmissing\b/i,
+  /\binvalid\b/i,
+  /\bnonzero\b/i,
+  /\bblocked\b/i,
+  /\bworkaround\b/i,
+  /\bmanual(?:ly)?\b/i,
+  /\bwarning\b/i,
+  /\bflood(?:ed|ing)?\b/i,
+  /\bstale\b/i,
+  /\bdrift\b/i,
+  /\bopaque\b/i,
+  /\bwrong\b/i,
+  /\bregression\b/i,
+  /\bbug\b/i,
+];
+
+const PATTERNS: PatternDefinition[] = [
+  {
+    kind: 'ticket-review-result-normalization',
+    title: 'Ticket-style scorecards break review/recommend/amend normalization',
+    labels: ['bug', 'agent-dx', 'workflow'],
+    summary: 'Ticket-style scorecard miss results can be normalized into a misleading review result.',
+    acceptanceCriteria: [
+      'Ticket-style scorecards preserve miss results such as short, long, left, and right in review output.',
+      'Review/recommend/amend paths normalize both classic shot records and ticket-style shot records consistently.',
+      'Regression coverage includes a ticket-style scorecard where a short result must not render as Green.',
+    ],
+    required: [
+      /ticket-style|ticket style/i,
+      /render(?:ed|s)?[^.\n]{0,80}green[^.\n]{0,80}(short|miss)|short[^.\n]{0,80}render(?:ed|s)?[^.\n]{0,80}green/i,
+      /review[^.\n]{0,80}green[^.\n]{0,80}short|review[^.\n]{0,80}short[^.\n]{0,80}green/i,
+    ],
+    signals: [/review/i, /recommend/i, /amend/i, /scorecard/i, /green/i, /\bshort\b/i],
+  },
+  {
+    kind: 'canonical-review-artifact',
+    title: 'Sprint review should materialize or verify the canonical review markdown',
+    labels: ['bug', 'agent-dx', 'workflow'],
+    summary: 'The nominal sprint review command can leave the canonical review markdown missing.',
+    acceptanceCriteria: [
+      'The closeout path either writes docs/retros/sprint-N-review.md or clearly requires an --output path.',
+      'Validation or PR status warns when a scorecard exists without the matching review markdown.',
+      'Tests cover the default review command and canonical artifact verification.',
+    ],
+    required: [/review[^.\n]{0,120}(markdown|md|artifact|stdout|materialize|missing)|sprint-\d+-review\.md/i],
+    signals: [/slope review/i, /closeout/i, /docs\/retros/i, /stdout/i, /canonical/i],
+  },
+  {
+    kind: 'pr-review-prompts-vs-reviewed',
+    title: 'PR review state should not mark prompt generation as reviewed',
+    labels: ['bug', 'agent-dx', 'workflow'],
+    summary: 'PR closeout state can confuse generated review prompts with completed reviewer work.',
+    acceptanceCriteria: [
+      'slope pr status does not report PR review: reviewed from prompt generation alone.',
+      'slope pr review records a review_pending or prompts_generated state unless reviewer output is present.',
+      'Ready for PR closeout requires completed review rounds or explicit waiver metadata.',
+    ],
+    required: [/prompt[^.\n]{0,100}(reviewed|generation)|reviewed[^.\n]{0,100}prompt|PR review:\s*reviewed/i],
+    signals: [/slope pr status/i, /slope pr review/i, /review rounds/i, /closeout/i, /waiver/i],
+  },
+  {
+    kind: 'explore-stale-map-warning-flood',
+    title: 'Explore/stale-map warnings flood output and can hang briefing across long sprint runs',
+    labels: ['bug', 'agent-dx', 'workflow'],
+    summary: 'Repeated explore or stale-map warnings can swamp agent output and make briefing/closeout unreliable.',
+    acceptanceCriteria: [
+      'Explore and stale-map warnings rate-limit identical messages per session or turn.',
+      'slope briefing caps, paginates, or summarizes large historical hazard ledgers after useful output.',
+      'slope map refuses to overwrite a useful CODEBASE.md with zero-source output unless explicitly forced.',
+      'After refresh, the guard stops warning or explains the remaining stale condition with one concrete action.',
+    ],
+    required: [/explore[^.\n]{0,120}(warning|650|flood|loop)|stale-map|briefing[^.\n]{0,120}(hang|hung|time-box|ledger)/i],
+    signals: [/slope briefing/i, /slope map/i, /CODEBASE\.md/i, /rate-?limit/i, /warning/i, /hazard ledger/i],
+  },
+  {
+    kind: 'validate-sprint-scope',
+    title: 'validate --sprint should isolate the requested sprint result',
+    labels: ['bug', 'agent-dx', 'workflow'],
+    summary: 'Sprint-specific validation can behave like a historical validation pass and fail on unrelated scorecards.',
+    acceptanceCriteria: [
+      'slope validate --sprint=N evaluates only the requested scorecard.',
+      'Historical invalid scorecards do not make a valid requested sprint fail.',
+      'The command output makes the validation scope explicit.',
+      'Tests cover a valid requested sprint with invalid historical scorecards and an unknown sprint number.',
+    ],
+    required: [/validate\s+--sprint|--sprint[^.\n]{0,120}(historical|all scorecards|project-wide)/i],
+    signals: [/historical/i, /scorecards/i, /nonzero/i, /valid/i, /invalid/i],
+  },
+  {
+    kind: 'sqlite-native-abi-drift',
+    title: 'sprint status should detect or recover better-sqlite3 native ABI drift',
+    labels: ['bug', 'agent-dx'],
+    summary: 'SQLite-backed sprint status commands can fail with opaque native module ABI errors.',
+    acceptanceCriteria: [
+      'slope sprint status catches stale native binding failures and prints a concrete repair command.',
+      'The recovery message names active Node version and NODE_MODULE_VERSION details when available.',
+      'A health or status path exercises SQLite-backed commands during sprint start and closeout.',
+      'Tests cover stale native module errors for sprint status.',
+    ],
+    required: [/better-sqlite3|NODE_MODULE_VERSION|native ABI|native module/i],
+    signals: [/sprint status/i, /sqlite/i, /node/i, /compiled/i, /rebuild/i],
+  },
+];
+
+function normalizeText(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9#.\-/]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function evidenceText(evidence: IssueScoutEvidence | IssueScoutEvidence[]): string {
+  const items = Array.isArray(evidence) ? evidence : [evidence];
+  return items
+    .map(item => [
+      item.source,
+      item.sourcePath ?? '',
+      item.sprint == null ? '' : `S${item.sprint}`,
+      item.command ?? '',
+      item.quote,
+      item.details ? JSON.stringify(item.details) : '',
+    ].filter(Boolean).join('\n'))
+    .join('\n\n');
+}
+
+function countMatches(text: string, regexes: RegExp[]): number {
+  return regexes.reduce((count, regex) => count + (regex.test(text) ? 1 : 0), 0);
+}
+
+function isLikelySlopeProductIssue(text: string): boolean {
+  return countMatches(text, SLOPE_PRODUCT_SIGNALS) >= 2 && countMatches(text, PROBLEM_SIGNALS) >= 1;
+}
+
+function fallbackTitle(text: string): string {
+  const firstLine = text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .find(line => line && !isMetadataLine(line)) ?? 'SLOPE workflow issue';
+  const cleaned = firstLine
+    .replace(/^[-*#\s]+/, '')
+    .replace(/^issue:\s*/i, '')
+    .replace(/[`*_]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned) return 'SLOPE workflow issue needs triage';
+  return cleaned.length > 90 ? `${cleaned.slice(0, 87).trim()}...` : cleaned;
+}
+
+function isMetadataLine(line: string): boolean {
+  return /^(?:\.?[a-z0-9_-]+\/)+[^ ]+\.(?:md|json|jsonl|txt|log)$/i.test(line)
+    || /^S\d+(?:\.\d+)?$/i.test(line)
+    || /^slope\s+[a-z][\w-]*/.test(line)
+    || /^\{/.test(line);
+}
+
+export function classifySlopeIssue(input: string | IssueScoutEvidence | IssueScoutEvidence[]): IssueScoutClassification {
+  const text = typeof input === 'string' ? input : evidenceText(input);
+
+  let best: { pattern: PatternDefinition; score: number; requiredHits: number; signalHits: number } | null = null;
+  for (const pattern of PATTERNS) {
+    const requiredHits = countMatches(text, pattern.required);
+    if (requiredHits === 0) continue;
+    const signalHits = countMatches(text, pattern.signals);
+    const score = requiredHits * 3 + signalHits;
+    if (!best || score > best.score) {
+      best = { pattern, score, requiredHits, signalHits };
+    }
+  }
+
+  if (best) {
+    const confidence = Math.min(0.95, 0.7 + best.signalHits * 0.04 + best.requiredHits * 0.05);
+    return {
+      slopeDriven: true,
+      kind: best.pattern.kind,
+      title: best.pattern.title,
+      labels: best.pattern.labels,
+      confidence: Number(confidence.toFixed(2)),
+      summary: best.pattern.summary,
+      acceptanceCriteria: best.pattern.acceptanceCriteria,
+      reasons: [`matched ${best.pattern.kind}`, `${best.signalHits} supporting signal(s)`],
+    };
+  }
+
+  if (isLikelySlopeProductIssue(text)) {
+    return {
+      slopeDriven: true,
+      kind: 'slope-workflow-follow-up',
+      title: fallbackTitle(text),
+      labels: ['agent-dx', 'workflow'],
+      confidence: 0.55,
+      summary: 'The evidence appears to describe a SLOPE product or workflow issue that needs human triage.',
+      acceptanceCriteria: [
+        'Reproduce the workflow failure from the captured evidence.',
+        'Decide whether the fix belongs in SLOPE product code, docs, or guard configuration.',
+        'Add focused regression coverage or a documented manual verification path.',
+      ],
+      reasons: ['multiple SLOPE product signals found'],
+    };
+  }
+
+  return {
+    slopeDriven: false,
+    kind: 'not-slope-driven',
+    title: 'Not a SLOPE product issue',
+    labels: [],
+    confidence: 0,
+    summary: 'Evidence does not contain enough SLOPE product signals.',
+    acceptanceCriteria: [],
+    reasons: ['insufficient SLOPE product signals'],
+  };
+}
+
+function stableFingerprint(kind: string, title: string): string {
+  const payload = JSON.stringify({ kind, title: normalizeText(title) });
+  return createHash('sha256').update(payload).digest('hex').slice(0, 16);
+}
+
+export function fingerprintCandidate(candidate: Pick<IssueScoutCandidate, 'kind' | 'title'>): string {
+  return stableFingerprint(candidate.kind, candidate.title);
+}
+
+export function buildIssueCandidate(evidence: IssueScoutEvidence | IssueScoutEvidence[]): IssueScoutCandidate | null {
+  const evidenceItems = Array.isArray(evidence) ? evidence : [evidence];
+  const classification = classifySlopeIssue(evidenceItems);
+  if (!classification.slopeDriven) return null;
+
+  const candidate: IssueScoutCandidate = {
+    kind: classification.kind,
+    title: classification.title,
+    labels: [...classification.labels],
+    confidence: classification.confidence,
+    summary: classification.summary,
+    acceptanceCriteria: [...classification.acceptanceCriteria],
+    evidence: evidenceItems,
+    fingerprint: '',
+  };
+  candidate.fingerprint = fingerprintCandidate(candidate);
+  return candidate;
+}
+
+export function buildIssueCandidates(evidence: IssueScoutEvidence[]): IssueScoutCandidate[] {
+  const byKind = new Map<string, IssueScoutCandidate>();
+
+  for (const item of evidence) {
+    const candidate = buildIssueCandidate(item);
+    if (!candidate) continue;
+
+    const existing = byKind.get(candidate.kind);
+    if (!existing) {
+      byKind.set(candidate.kind, candidate);
+      continue;
+    }
+
+    existing.confidence = Math.max(existing.confidence, candidate.confidence);
+    existing.evidence.push(...candidate.evidence);
+    existing.labels = Array.from(new Set([...existing.labels, ...candidate.labels]));
+  }
+
+  return Array.from(byKind.values()).sort((a, b) =>
+    b.confidence - a.confidence || a.title.localeCompare(b.title)
+  );
+}
+
+function tokens(text: string): Set<string> {
+  return new Set(normalizeText(text)
+    .split(' ')
+    .filter(token => token.length > 2 && !STOP_WORDS.has(token)));
+}
+
+function titleSimilarity(a: string, b: string): number {
+  const aTokens = tokens(a);
+  const bTokens = tokens(b);
+  if (aTokens.size === 0 || bTokens.size === 0) return 0;
+
+  let intersection = 0;
+  for (const token of aTokens) {
+    if (bTokens.has(token)) intersection++;
+  }
+  return intersection / Math.min(aTokens.size, bTokens.size);
+}
+
+function bodyHasFingerprint(issue: ExistingIssue, fingerprint: string): boolean {
+  return (issue.body ?? '').includes(`${FINGERPRINT_MARKER}${fingerprint}`);
+}
+
+export function dedupeCandidates(
+  candidates: IssueScoutCandidate[],
+  existingIssues: ExistingIssue[],
+): IssueScoutCandidate[] {
+  return candidates.map(candidate => {
+    const fingerprintMatch = existingIssues.find(issue => bodyHasFingerprint(issue, candidate.fingerprint));
+    if (fingerprintMatch) {
+      return {
+        ...candidate,
+        dedupe: {
+          status: 'duplicate',
+          reason: 'existing issue body contains the same scout fingerprint',
+          matchedIssue: fingerprintMatch,
+          similarity: 1,
+        },
+      };
+    }
+
+    const exactTitle = existingIssues.find(issue =>
+      normalizeText(issue.title) === normalizeText(candidate.title)
+    );
+    if (exactTitle) {
+      return {
+        ...candidate,
+        dedupe: {
+          status: 'duplicate',
+          reason: 'existing issue title matches candidate title',
+          matchedIssue: exactTitle,
+          similarity: 1,
+        },
+      };
+    }
+
+    let best: { issue: ExistingIssue; similarity: number } | null = null;
+    for (const issue of existingIssues) {
+      const similarity = titleSimilarity(candidate.title, issue.title);
+      if (!best || similarity > best.similarity) best = { issue, similarity };
+    }
+
+    if (best && best.similarity >= 0.74) {
+      return {
+        ...candidate,
+        dedupe: {
+          status: 'duplicate',
+          reason: 'existing issue title is highly similar',
+          matchedIssue: best.issue,
+          similarity: Number(best.similarity.toFixed(2)),
+        },
+      };
+    }
+
+    return {
+      ...candidate,
+      dedupe: {
+        status: 'new',
+        reason: 'no matching issue found',
+      },
+    };
+  });
+}
+
+function cleanOneLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(value: string, max = 420): string {
+  const cleaned = cleanOneLine(value);
+  return cleaned.length > max ? `${cleaned.slice(0, max - 3).trim()}...` : cleaned;
+}
+
+function formatEvidenceLine(evidence: IssueScoutEvidence): string {
+  const parts: string[] = [];
+  if (evidence.sourcePath) parts.push(evidence.sourcePath);
+  if (evidence.sprint != null) parts.push(`S${evidence.sprint}`);
+  if (evidence.command) parts.push(`command: ${evidence.command}`);
+  const prefix = parts.length > 0 ? `${parts.join(' | ')} - ` : '';
+  return `- ${prefix}${truncate(evidence.quote)}`;
+}
+
+export function formatIssueBody(candidate: IssueScoutCandidate): string {
+  const lines: string[] = [
+    '## Summary',
+    '',
+    candidate.summary,
+    '',
+    '## Evidence',
+    '',
+  ];
+
+  for (const item of candidate.evidence.slice(0, 8)) {
+    lines.push(formatEvidenceLine(item));
+  }
+  if (candidate.evidence.length > 8) {
+    lines.push(`- ${candidate.evidence.length - 8} additional evidence item(s) omitted from this issue body.`);
+  }
+
+  lines.push('', '## Acceptance Criteria', '');
+  for (const criterion of candidate.acceptanceCriteria) {
+    lines.push(`- ${criterion}`);
+  }
+
+  lines.push(
+    '',
+    '## Scout Metadata',
+    '',
+    `- confidence: ${candidate.confidence.toFixed(2)}`,
+    `- labels: ${candidate.labels.join(', ')}`,
+    `- ${FINGERPRINT_MARKER}${candidate.fingerprint}`,
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function formatIssueScoutComment(candidate: IssueScoutCandidate): string {
+  const lines = [
+    '## Additional SLOPE Issue Scout Evidence',
+    '',
+    `The scout found more evidence for this issue with confidence ${candidate.confidence.toFixed(2)}.`,
+    '',
+    '## Evidence',
+    '',
+    ...candidate.evidence.slice(0, 8).map(formatEvidenceLine),
+    '',
+    '## Scout Metadata',
+    '',
+    `- ${FINGERPRINT_MARKER}${candidate.fingerprint}`,
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderIssueScoutDigest(
+  candidates: IssueScoutCandidate[],
+  opts: { generatedAt?: string; repo?: string } = {},
+): string {
+  const generatedAt = opts.generatedAt ?? new Date().toISOString();
+  const lines: string[] = [
+    '# SLOPE Issue Scout Daily Digest',
+    '',
+    `Generated: ${generatedAt}`,
+  ];
+  if (opts.repo) lines.push(`Repository: ${opts.repo}`);
+
+  const newCandidates = candidates.filter(c => c.dedupe?.status !== 'duplicate');
+  const duplicates = candidates.filter(c => c.dedupe?.status === 'duplicate');
+
+  lines.push('', '## Request Approval To Fix', '');
+  if (newCandidates.length === 0) {
+    lines.push('No new SLOPE-driven issue candidates need approval today.');
+  } else {
+    for (const candidate of newCandidates) {
+      lines.push(`- ${candidate.title}`);
+      lines.push(`  - confidence: ${candidate.confidence.toFixed(2)}`);
+      lines.push(`  - labels: ${candidate.labels.join(', ')}`);
+      lines.push(`  - fingerprint: ${candidate.fingerprint}`);
+      lines.push('  - requested decision: approve fix, defer, or reject');
+    }
+  }
+
+  if (duplicates.length > 0) {
+    lines.push('', '## Existing Or Duplicate Candidates', '');
+    for (const candidate of duplicates) {
+      const issue = candidate.dedupe?.matchedIssue;
+      const ref = issue ? `#${issue.number}${issue.state ? ` (${issue.state})` : ''}` : 'existing issue';
+      lines.push(`- ${candidate.title} -> ${ref}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function parseIssueScoutState(raw: string): IssueScoutState {
+  try {
+    const parsed = JSON.parse(raw) as Partial<IssueScoutState>;
+    return {
+      version: 1,
+      records: Array.isArray(parsed.records) ? parsed.records.filter(isStateRecord) : [],
+    };
+  } catch {
+    return { version: 1, records: [] };
+  }
+}
+
+function isStateRecord(value: unknown): value is IssueScoutStateRecord {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.fingerprint === 'string'
+    && typeof record.title === 'string'
+    && typeof record.status === 'string'
+    && typeof record.updatedAt === 'string';
+}
+
+export function mergeIssueScoutState(
+  state: IssueScoutState,
+  records: IssueScoutStateRecord[],
+): IssueScoutState {
+  const merged = new Map<string, IssueScoutStateRecord>();
+  for (const record of state.records) merged.set(record.fingerprint, record);
+  for (const record of records) {
+    const existing = merged.get(record.fingerprint);
+    merged.set(record.fingerprint, {
+      ...existing,
+      ...record,
+      sourcePaths: Array.from(new Set([
+        ...(existing?.sourcePaths ?? []),
+        ...(record.sourcePaths ?? []),
+      ])).sort(),
+    });
+  }
+  return {
+    version: 1,
+    records: Array.from(merged.values()).sort((a, b) => a.title.localeCompare(b.title)),
+  };
+}

--- a/src/core/issue-scout.ts
+++ b/src/core/issue-scout.ts
@@ -253,10 +253,16 @@ function fallbackTitle(text: string): string {
 }
 
 function isMetadataLine(line: string): boolean {
-  return /^(?:\.?[a-z0-9_-]+\/)+[^ ]+\.(?:md|json|jsonl|txt|log)$/i.test(line)
-    || /^S\d+(?:\.\d+)?$/i.test(line)
-    || /^slope\s+[a-z][\w-]*/.test(line)
-    || /^\{/.test(line);
+  const lower = line.toLowerCase();
+  const pathLike = !line.includes(' ')
+    && lower.includes('/')
+    && ['.md', '.json', '.jsonl', '.txt', '.log'].some(ext => lower.endsWith(ext));
+  const sprintLike = lower.startsWith('s') && Number.isFinite(Number(lower.slice(1)));
+
+  return pathLike
+    || sprintLike
+    || line.startsWith('slope ')
+    || line.startsWith('{');
 }
 
 export function classifySlopeIssue(input: string | IssueScoutEvidence | IssueScoutEvidence[]): IssueScoutClassification {

--- a/tests/cli/commands/issue.test.ts
+++ b/tests/cli/commands/issue.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { issueCommand } from '../../../src/cli/commands/issue.js';
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `slope-issue-command-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeCommonIssues(cwd: string): string {
+  const slopeDir = join(cwd, '.slope');
+  mkdirSync(slopeDir, { recursive: true });
+  const path = join(slopeDir, 'common-issues.json');
+  writeFileSync(path, JSON.stringify({
+    recurring_patterns: [
+      {
+        title: 'Ticket result normalization',
+        sprint: 342,
+        command: 'slope review docs/retros/sprint-342.json',
+        evidence: 'Ticket-style scorecard result: "short" was rendered as Green in slope review for S342-T5.',
+      },
+      {
+        title: 'Missing review artifact',
+        sprint: 341,
+        command: 'slope review docs/retros/sprint-341.json',
+        evidence: 'slope review docs/retros/sprint-341.json printed to stdout but docs/retros/sprint-341-review.md was missing.',
+      },
+      {
+        title: 'Prompt generation counted as reviewed',
+        sprint: 341,
+        command: 'slope pr status --sprint=341',
+        evidence: 'PR review: reviewed appeared after review prompt generation only; review rounds were not complete.',
+      },
+      {
+        title: 'Warning flood',
+        sprint: 362,
+        command: 'slope briefing --sprint=362',
+        evidence: 'SLOPE explore warning loop flooded output 650x, stale-map warnings persisted, and briefing hung on the hazard ledger.',
+      },
+      {
+        title: 'Validate scope',
+        sprint: 348,
+        command: 'slope validate --sprint=348',
+        evidence: 'slope validate --sprint=348 ran a historical project-wide pass and failed due older invalid scorecards.',
+      },
+      {
+        title: 'Native ABI drift',
+        sprint: 351,
+        command: 'slope sprint status',
+        evidence: 'slope sprint status failed because better-sqlite3 was compiled for a stale NODE_MODULE_VERSION native ABI.',
+      },
+    ],
+  }, null, 2));
+  return path;
+}
+
+async function captureLogs(fn: () => Promise<void>): Promise<string> {
+  const logs: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((message = '') => {
+    logs.push(String(message));
+  });
+  try {
+    await fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return logs.join('\n');
+}
+
+describe('slope issue command', () => {
+  let cwd: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    cwd = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(cwd);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('prints dry-run candidates as JSON with evidence, labels, and dedupe status', async () => {
+    writeCommonIssues(cwd);
+
+    const output = await captureLogs(() =>
+      issueCommand(['scout', '--source=.slope/common-issues.json', '--dry-run', '--json'])
+    );
+    const payload = JSON.parse(output);
+    const titles = payload.candidates.map((candidate: { title: string }) => candidate.title);
+
+    expect(payload.mode).toBe('dry-run');
+    expect(payload.evidence_count).toBe(6);
+    expect(payload.candidate_count).toBe(6);
+    expect(titles).toContain('Ticket-style scorecards break review/recommend/amend normalization');
+    expect(titles).toContain('validate --sprint should isolate the requested sprint result');
+    expect(payload.candidates[0].labels.length).toBeGreaterThan(0);
+    expect(payload.candidates[0].dedupe.status).toBe('new');
+    expect(payload.candidates[0].body).toContain('## Acceptance Criteria');
+  });
+
+  it('writes a daily triage digest with an approval request section', async () => {
+    writeCommonIssues(cwd);
+    const digestPath = join(cwd, '.slope', 'digest.md');
+
+    await captureLogs(() =>
+      issueCommand(['triage', '--source=.slope/common-issues.json', '--daily-digest', '--output=.slope/digest.md'])
+    );
+
+    expect(existsSync(digestPath)).toBe(true);
+    const digest = readFileSync(digestPath, 'utf8');
+    expect(digest).toContain('## Request Approval To Fix');
+    expect(digest).toContain('requested decision: approve fix, defer, or reject');
+  });
+});

--- a/tests/cli/commands/issue.test.ts
+++ b/tests/cli/commands/issue.test.ts
@@ -117,4 +117,20 @@ describe('slope issue command', () => {
     expect(digest).toContain('## Request Approval To Fix');
     expect(digest).toContain('requested decision: approve fix, defer, or reject');
   });
+
+  it('writes scout JSON output without dumping the full payload to stdout', async () => {
+    writeCommonIssues(cwd);
+    const outputPath = join(cwd, '.slope', 'candidates.json');
+
+    const stdout = await captureLogs(() =>
+      issueCommand(['scout', '--source=.slope/common-issues.json', '--dry-run', '--output=.slope/candidates.json'])
+    );
+
+    expect(existsSync(outputPath)).toBe(true);
+    const payload = JSON.parse(readFileSync(outputPath, 'utf8'));
+    expect(payload.candidate_count).toBe(6);
+    expect(stdout).toContain('SLOPE Issue Scout');
+    expect(stdout).toContain('Candidate issues:');
+    expect(stdout).not.toContain('"candidates"');
+  });
 });

--- a/tests/core/issue-scout.test.ts
+++ b/tests/core/issue-scout.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildIssueCandidates,
+  classifySlopeIssue,
+  dedupeCandidates,
+  formatIssueBody,
+  mergeIssueScoutState,
+  parseIssueScoutState,
+  renderIssueScoutDigest,
+} from '../../src/core/issue-scout.js';
+import type { ExistingIssue, IssueScoutEvidence, IssueScoutState } from '../../src/core/issue-scout.js';
+
+function fathomsEvidence(): IssueScoutEvidence[] {
+  return [
+    {
+      source: 'fathoms-s342',
+      sourcePath: '.slope/common-issues.json',
+      sprint: 342,
+      quote: 'Ticket-style scorecard result: "short" was rendered as Green in slope review for S342-T5.',
+      command: 'slope review docs/retros/sprint-342.json',
+    },
+    {
+      source: 'fathoms-s341',
+      sourcePath: '.slope/common-issues.json',
+      sprint: 341,
+      quote: 'slope review docs/retros/sprint-341.json printed to stdout but did not create docs/retros/sprint-341-review.md, leaving the canonical review markdown missing.',
+      command: 'slope review docs/retros/sprint-341.json',
+    },
+    {
+      source: 'fathoms-s341-pr',
+      sourcePath: '.slope/common-issues.json',
+      sprint: 341,
+      quote: 'slope pr status reported PR review: reviewed after slope pr review only generated prompts; review rounds had not completed.',
+      command: 'slope pr status --sprint=341',
+    },
+    {
+      source: 'fathoms-s345-s362',
+      sourcePath: '.slope/common-issues.json',
+      sprint: 362,
+      quote: 'SLOPE explore warning loop flooded output 650x and slope briefing hung after dumping a huge hazard ledger; stale-map warnings around CODEBASE.md did not clear.',
+      command: 'slope briefing --sprint=362',
+    },
+    {
+      source: 'fathoms-s348',
+      sourcePath: '.slope/common-issues.json',
+      sprint: 348,
+      quote: 'slope validate --sprint=348 behaved like a historical project-wide validation pass and failed because older scorecards were invalid.',
+      command: 'slope validate --sprint=348',
+    },
+    {
+      source: 'fathoms-s351',
+      sourcePath: '.slope/common-issues.json',
+      sprint: 351,
+      quote: 'slope sprint status failed with better-sqlite3 native ABI drift: module compiled for NODE_MODULE_VERSION 127 while active Node required 147.',
+      command: 'slope sprint status',
+    },
+  ];
+}
+
+const EXPECTED_TITLES = [
+  'Ticket-style scorecards break review/recommend/amend normalization',
+  'Sprint review should materialize or verify the canonical review markdown',
+  'PR review state should not mark prompt generation as reviewed',
+  'Explore/stale-map warnings flood output and can hang briefing across long sprint runs',
+  'validate --sprint should isolate the requested sprint result',
+  'sprint status should detect or recover better-sqlite3 native ABI drift',
+];
+
+describe('classifySlopeIssue', () => {
+  it('classifies known Fathoms S341-S362 SLOPE issue shapes', () => {
+    const candidates = buildIssueCandidates(fathomsEvidence());
+    expect(candidates.map(candidate => candidate.title).sort()).toEqual(EXPECTED_TITLES.sort());
+    expect(candidates.every(candidate => candidate.confidence >= 0.7)).toBe(true);
+  });
+
+  it('ignores project work that lacks enough SLOPE product signals', () => {
+    const classification = classifySlopeIssue('Unity terrain material needed a render-pass repair in Fathoms.');
+    expect(classification.slopeDriven).toBe(false);
+  });
+
+  it('uses evidence headings instead of source paths for fallback titles', () => {
+    const [candidate] = buildIssueCandidates([{
+      source: 'docs/issues/post-implementation-gate-gap.md',
+      sourcePath: 'docs/issues/post-implementation-gate-gap.md',
+      quote: 'Issue: No Post-Implementation Workflow Gate\nSLOPE guard coverage is missing after implementation and sprints can stop without review or PR.',
+    }]);
+
+    expect(candidate.title).toBe('No Post-Implementation Workflow Gate');
+  });
+});
+
+describe('dedupeCandidates', () => {
+  it('dedupes exact existing GitHub issue titles', () => {
+    const candidates = buildIssueCandidates(fathomsEvidence());
+    const existingIssues: ExistingIssue[] = EXPECTED_TITLES.map((title, index) => ({
+      number: 485 + index,
+      title,
+      state: 'OPEN',
+      url: `https://github.com/srbryers/slope/issues/${485 + index}`,
+    }));
+
+    const deduped = dedupeCandidates(candidates, existingIssues);
+
+    expect(deduped.every(candidate => candidate.dedupe?.status === 'duplicate')).toBe(true);
+    expect(deduped.map(candidate => candidate.dedupe?.matchedIssue?.title).sort()).toEqual(EXPECTED_TITLES.sort());
+  });
+
+  it('dedupes by scout fingerprint in an existing issue body', () => {
+    const [candidate] = buildIssueCandidates([fathomsEvidence()[0]]);
+    const deduped = dedupeCandidates([candidate], [{
+      number: 999,
+      title: 'Different title',
+      body: `metadata\nslope-issue-scout:fingerprint:${candidate.fingerprint}\n`,
+    }]);
+
+    expect(deduped[0].dedupe?.status).toBe('duplicate');
+    expect(deduped[0].dedupe?.matchedIssue?.number).toBe(999);
+  });
+});
+
+describe('issue body and digest formatting', () => {
+  it('includes evidence, acceptance criteria, and fingerprint metadata', () => {
+    const [candidate] = buildIssueCandidates([fathomsEvidence()[0]]);
+    const body = formatIssueBody(candidate);
+
+    expect(body).toContain('## Evidence');
+    expect(body).toContain('## Acceptance Criteria');
+    expect(body).toContain(`slope-issue-scout:fingerprint:${candidate.fingerprint}`);
+  });
+
+  it('renders a daily approval request digest', () => {
+    const candidates = dedupeCandidates(buildIssueCandidates(fathomsEvidence()), []);
+    const digest = renderIssueScoutDigest(candidates, {
+      generatedAt: '2026-06-03T12:00:00.000Z',
+      repo: 'srbryers/slope',
+    });
+
+    expect(digest).toContain('## Request Approval To Fix');
+    expect(digest).toContain('requested decision: approve fix, defer, or reject');
+    expect(digest).toContain('srbryers/slope');
+  });
+});
+
+describe('issue scout state', () => {
+  it('parses corrupt state as empty and merges records by fingerprint', () => {
+    const state = parseIssueScoutState('{not-json') satisfies IssueScoutState;
+    const merged = mergeIssueScoutState(state, [
+      {
+        fingerprint: 'abc',
+        title: 'First',
+        status: 'created',
+        updatedAt: '2026-06-03T12:00:00.000Z',
+        sourcePaths: ['a'],
+      },
+      {
+        fingerprint: 'abc',
+        title: 'First',
+        status: 'commented',
+        updatedAt: '2026-06-03T13:00:00.000Z',
+        sourcePaths: ['b', 'a'],
+      },
+    ]);
+
+    expect(merged.records).toHaveLength(1);
+    expect(merged.records[0]).toMatchObject({ fingerprint: 'abc', status: 'commented' });
+    expect(merged.records[0].sourcePaths).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the SLOPE issue scout requested in #493:

- new pure core issue-scout classifier, fingerprint, de-dupe, issue body, comment body, digest, and state helpers
- new `slope issue scout` and `slope issue triage` CLI commands with dry-run JSON/human output, explicit create mode, duplicate handling, and source ingestion for common issues, transcripts, JSONL, markdown, text, and logs
- scheduled/manual GitHub Action for daily scout artifacts, manual issue creation, and optional Resend email digest
- setup/safety documentation plus S136 scorecard and review artifacts

## Validation

- `pnpm vitest run tests/core/issue-scout.test.ts tests/cli/commands/issue.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (226 files passed, 3583 tests passed, existing Postgres file skipped)
- `node dist/cli/index.js issue scout --source docs/issues --source .slope/common-issues.json --source .slope/transcripts --repo srbryers/slope --dry-run`
- `node dist/cli/index.js issue scout --source docs/issues --source .slope/common-issues.json --source .slope/transcripts --repo srbryers/slope --dry-run --output .slope/issue-scout-smoke.json`
- `node dist/cli/index.js validate --sprint=136`
- `node dist/cli/index.js map --check`

## Scout Smoke Result

The built CLI dry-run recovered the six Fathoms-derived SLOPE issue classes and de-duped them against existing GitHub issues #485, #488, #489, #490, #491, and #492. The only new candidate in the scheduled source set is the existing `docs/issues/post-implementation-gate-gap.md` writeup, left for daily approval triage rather than bundled into this implementation.

## Review Rounds

- Code review: found and fixed log-noise issue where `--output` also dumped full JSON to stdout.
- Architect review: no findings; core/CLI/workflow/e-mail boundaries are separated and scheduled mode is proposal-only.
