### PR TITLE
Fix workflow-step-gate execution scoping

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -1,6 +1,6 @@
 {
   "name": "SLOPE Development Roadmap",
-  "description": "Forward-looking roadmap from S61+. Phases 1-9 (S1-S47) are complete. S48-S60 were hardening, guard enforcement, and process sprints. This roadmap covers adoption, observability, guard maturity, multi-project, loop evolution, and issue-driven recovery. S61-S64 reflect what actually shipped (themes diverged from original plan). Note: the actual S69 diverged from the planned Referee sprint \u2014 a carryover patch kit ran instead. The Referee work was rescheduled as S78. S75.5 (The Bug Clearing) added 2026-05-02 to clear accumulated CLI bugs from external repos. S132-S136 were backfilled from shipped scorecards on 2026-06-05; S137 adds post-merge retro tooling and durable memory, S137.5 addresses Windows suite portability for #509, S138-S144 triage open GitHub issues #499/#501/#502/#503/#505/#507/#510/#511/#512/#513/#514/#515/#516/#517/#518 into focused recovery sprints, S145 closed validation-signal regressions #519/#520, S146 cleaned stale roadmap state plus decimal sprint shipped-artifact warnings (#522), S146.1 cut the v1.58.1 patch release while repairing release-bump staging (#524/#528), active inserted sprint status (#525), and guard test isolation (#526), and S146.2 closes the decimal post-merge retro gap (#529).",
+  "description": "Forward-looking roadmap from S61+. Phases 1-9 (S1-S47) are complete. S48-S60 were hardening, guard enforcement, and process sprints. This roadmap covers adoption, observability, guard maturity, multi-project, loop evolution, and issue-driven recovery. S61-S64 reflect what actually shipped (themes diverged from original plan). Note: the actual S69 diverged from the planned Referee sprint \u2014 a carryover patch kit ran instead. The Referee work was rescheduled as S78. S75.5 (The Bug Clearing) added 2026-05-02 to clear accumulated CLI bugs from external repos. S132-S136 were backfilled from shipped scorecards on 2026-06-05; S137 adds post-merge retro tooling and durable memory, S137.5 addresses Windows suite portability for #509, S138-S144 triage open GitHub issues #499/#501/#502/#503/#505/#507/#510/#511/#512/#513/#514/#515/#516/#517/#518 into focused recovery sprints, S145 closed validation-signal regressions #519/#520, S146 cleaned stale roadmap state plus decimal sprint shipped-artifact warnings (#522), S146.1 cut the v1.58.1 patch release while repairing release-bump staging (#524/#528), active inserted sprint status (#525), and guard test isolation (#526), S146.2 closes the decimal post-merge retro gap (#529), and S146.3 scopes workflow-step-gate to the relevant execution (#531).",
   "phases": [
     {
       "name": "Phase 10 \u2014 Adoption & Onboarding",
@@ -327,10 +327,11 @@
       "sprints": [
         146,
         146.1,
-        146.2
+        146.2,
+        146.3
       ],
-      "status": "complete",
-      "note": "Clean stale roadmap state after the recovery train, fix decimal sprint shipped-artifact detection (#522), cut the v1.58.1 patch release, repair release-bump staging/status/test-isolation issues (#524/#525/#526/#528), and close the decimal post-merge retro gap (#529)."
+      "status": "active",
+      "note": "Clean stale roadmap state after the recovery train, fix decimal sprint shipped-artifact detection (#522), cut the v1.58.1 patch release, repair release-bump staging/status/test-isolation issues (#524/#525/#526/#528), close the decimal post-merge retro gap (#529), and scope workflow-step-gate to the relevant execution (#531)."
     },
     {
       "name": "Phase 46 \u2014 Handoff Continuity",
@@ -4179,6 +4180,36 @@
       ]
     },
     {
+      "id": 146.3,
+      "theme": "Workflow Step Gate Execution Scoping",
+      "par": 3,
+      "slope": 1,
+      "type": "bugfix + patch release",
+      "status": "active",
+      "depends_on": [
+        146.2
+      ],
+      "note": "Close #531 by making workflow-step-gate choose the execution relevant to the current session or sprint, then publish the 1.58.3 patch.",
+      "tickets": [
+        {
+          "key": "S146.3-1",
+          "title": "Scope workflow-step-gate to session/current sprint and fail open on ambiguous executions (#531)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 531
+        },
+        {
+          "key": "S146.3-2",
+          "title": "Bump package and bundled plugin manifest to 1.58.3 for the workflow gate fix",
+          "club": "wedge",
+          "complexity": "small",
+          "depends_on": [
+            "S146.3-1"
+          ]
+        }
+      ]
+    },
+    {
       "id": 147,
       "theme": "Handoff and Cross-Session Continuity",
       "par": 4,
@@ -4186,7 +4217,7 @@
       "type": "feature",
       "status": "planned",
       "depends_on": [
-        146.2
+        146.3
       ],
       "note": "Make handoffs first-class and low-friction: briefing should surface the latest durable handoff, agent next-md should merge durable human state with auto-derived state, and hazards should have a one-line path into common issues.",
       "tickets": [

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -330,7 +330,7 @@
         146.2,
         146.3
       ],
-      "status": "active",
+      "status": "complete",
       "note": "Clean stale roadmap state after the recovery train, fix decimal sprint shipped-artifact detection (#522), cut the v1.58.1 patch release, repair release-bump staging/status/test-isolation issues (#524/#525/#526/#528), close the decimal post-merge retro gap (#529), and scope workflow-step-gate to the relevant execution (#531)."
     },
     {
@@ -4185,7 +4185,9 @@
       "par": 3,
       "slope": 1,
       "type": "bugfix + patch release",
-      "status": "active",
+      "status": "complete",
+      "score": 3,
+      "score_label": "par",
       "depends_on": [
         146.2
       ],

--- a/docs/retros/sprint-146.3-review.md
+++ b/docs/retros/sprint-146.3-review.md
@@ -1,0 +1,63 @@
+## Sprint 146.3 Review: Workflow Step Gate Execution Scoping
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 1 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (2/2) |
+| GIR % | 100% (2/2) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 2)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S146.3-1 | Short Iron | In the Hole | — | Replaced active[0] workflow selection with deterministic scoping: match the hook session first, then branch/current sprint, then preserve single-active-execution behavior, and fail open with context when multiple executions cannot be disambiguated. |
+| S146.3-2 | Wedge | In the Hole | — | Ran scripts/version-bump.mjs 1.58.3 so package.json and templates/codex/plugins/slope/.codex-plugin/plugin.json moved together, then verified the built CLI reports @slope-dev/slope v1.58.3. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| Pin Position | minor | Issue #531 appeared after the patch-release loop because long-lived workflow executions from older sprints could still coexist with the active sprint execution. |
+
+### Hazards Discovered
+
+**Known hazards for future sprints:**
+- Workflow guards that inspect running executions must not choose active[0] when multiple sessions or sprints can be running.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Workflow guards that inspect durable running executions must scope by session or sprint before applying blocking policy. | workflow-step-gate now blocks only a relevant non-agent_work execution and allows edits when multiple running executions are ambiguous. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | `corepack pnpm vitest run tests/cli/guards/workflow-step-gate.test.ts` passed: 12 tests. |
+| testing | healthy | `corepack pnpm typecheck`, `corepack pnpm test`, and `corepack pnpm build` passed; full suite reported 232 test files passed, 1 skipped, 3645 tests passed, and 25 skipped. |
+| docs | healthy | `node dist/cli/index.js roadmap validate`, `map --check`, `docs generate`, and `docs check` passed after the 1.58.3 build. |
+| release | healthy | `node dist/cli/index.js version` reports @slope-dev/slope v1.58.3; after merge, create GitHub Release `v1.58.3` and verify npm latest updates through the GitHub Release workflow. |
+
+### Course Management Notes
+
+- GitHub issue #531 is closed by the S146.3 PR.
+- Roadmap commit: af214a3.
+- Implementation commit: bf24e22.
+- Selector-priority follow-up commit: 74a1288.
+- Version bump commit: 7cf7b5b.
+- After merge, create GitHub Release `v1.58.3` and verify npm latest updates.
+
+### 19th Hole
+
+- **How did it feel?** A precise follow-up: the bug was small, but it sat right on SLOPE's own ability to enforce discipline without blocking the wrong work.
+- **Advice for next player?** Whenever a guard reads a global running-execution list, add a multi-execution regression before trusting ordering.
+- **What surprised you?** The existing resync logic already handled some stale branch cases, but active sprint-state and session scoping still needed to be explicit.
+- **Excited about next?** The release loop can now continue without unrelated workflow history turning into a global edit lock.

--- a/docs/retros/sprint-146.3.json
+++ b/docs/retros/sprint-146.3.json
@@ -1,0 +1,118 @@
+{
+  "sprint_number": 146.3,
+  "player": "codex",
+  "theme": "Workflow Step Gate Execution Scoping",
+  "par": 3,
+  "slope": 1,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-06-07",
+  "type": "bugfix + patch release",
+  "skills_used": [
+    "slope-sprint-workflow",
+    "github"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow"
+  ],
+  "skill_gaps_found": [],
+  "shots": [
+    {
+      "ticket_key": "S146.3-1",
+      "title": "Scope workflow-step-gate to session/current sprint and fail open on ambiguous executions (#531)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Replaced active[0] workflow selection with deterministic scoping: match the hook session first, then branch/current sprint, then preserve single-active-execution behavior, and fail open with context when multiple executions cannot be disambiguated."
+    },
+    {
+      "ticket_key": "S146.3-2",
+      "title": "Bump package and bundled plugin manifest to 1.58.3 for the workflow gate fix",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Ran scripts/version-bump.mjs 1.58.3 so package.json and templates/codex/plugins/slope/.codex-plugin/plugin.json moved together, then verified the built CLI reports @slope-dev/slope v1.58.3."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 2,
+    "fairways_total": 2,
+    "greens_in_regulation": 2,
+    "greens_total": 2,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "pin_position",
+      "impact": "minor",
+      "description": "Issue #531 appeared after the patch-release loop because long-lived workflow executions from older sprints could still coexist with the active sprint execution."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Workflow guards that inspect durable running executions must scope by session or sprint before applying blocking policy.",
+      "outcome": "workflow-step-gate now blocks only a relevant non-agent_work execution and allows edits when multiple running executions are ambiguous."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "`corepack pnpm vitest run tests/cli/guards/workflow-step-gate.test.ts` passed: 12 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`corepack pnpm typecheck`, `corepack pnpm test`, and `corepack pnpm build` passed; full suite reported 232 test files passed, 1 skipped, 3645 tests passed, and 25 skipped.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "`node dist/cli/index.js roadmap validate`, `map --check`, `docs generate`, and `docs check` passed after the 1.58.3 build.",
+      "status": "healthy"
+    },
+    {
+      "category": "release",
+      "description": "`node dist/cli/index.js version` reports @slope-dev/slope v1.58.3; after merge, create GitHub Release `v1.58.3` and verify npm latest updates through the GitHub Release workflow.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A precise follow-up: the bug was small, but it sat right on SLOPE's own ability to enforce discipline without blocking the wrong work.",
+    "advice_for_next_player": "Whenever a guard reads a global running-execution list, add a multi-execution regression before trusting ordering.",
+    "what_surprised_you": "The existing resync logic already handled some stale branch cases, but active sprint-state and session scoping still needed to be explicit.",
+    "excited_about_next": "The release loop can now continue without unrelated workflow history turning into a global edit lock."
+  },
+  "bunker_locations": [
+    "Workflow guards that inspect running executions must not choose active[0] when multiple sessions or sprints can be running."
+  ],
+  "yardage_book_updates": [
+    "src/cli/guards/workflow-step-gate.ts now selects a running workflow execution by session, branch/current sprint, or single-active fallback.",
+    "tests/cli/guards/workflow-step-gate.test.ts covers current-sprint selection, session selection, and ambiguous multi-execution fail-open behavior.",
+    "package.json and templates/codex/plugins/slope/.codex-plugin/plugin.json are bumped to 1.58.3."
+  ],
+  "course_management_notes": [
+    "GitHub issue #531 is closed by the S146.3 PR.",
+    "Roadmap commit: af214a3.",
+    "Implementation commit: bf24e22.",
+    "Selector-priority follow-up commit: 74a1288.",
+    "Version bump commit: 7cf7b5b.",
+    "After merge, create GitHub Release `v1.58.3` and verify npm latest updates."
+  ],
+  "slope_factors": [
+    "workflow_guard",
+    "multiple_running_executions",
+    "session_scope",
+    "patch_release"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.58.2",
+  "version": "1.58.3",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/guards/workflow-step-gate.ts
+++ b/src/cli/guards/workflow-step-gate.ts
@@ -73,15 +73,23 @@ function selectWorkflowExecution(
   cwd: string,
   config: SlopeConfig,
 ): WorkflowExecution | null {
+  const sprintLabels = sprintLabelsForContext(cwd, config);
   const sessionId = input.session_id?.trim();
+  if (sessionId && sprintLabels.length > 0) {
+    const bySessionAndSprint = active.find(exec =>
+      exec.session_id === sessionId && sprintLabels.some(label => sprintIdsMatch(exec.sprint_id, label)),
+    );
+    if (bySessionAndSprint) return bySessionAndSprint;
+  }
+
+  for (const label of sprintLabels) {
+    const bySprint = active.find(exec => sprintIdsMatch(exec.sprint_id, label));
+    if (bySprint) return bySprint;
+  }
+
   if (sessionId) {
     const bySession = active.find(exec => exec.session_id === sessionId);
     if (bySession) return bySession;
-  }
-
-  for (const label of sprintLabelsForContext(cwd, config)) {
-    const bySprint = active.find(exec => sprintIdsMatch(exec.sprint_id, label));
-    if (bySprint) return bySprint;
   }
 
   return active.length === 1 ? active[0] : null;

--- a/src/cli/guards/workflow-step-gate.ts
+++ b/src/cli/guards/workflow-step-gate.ts
@@ -1,10 +1,11 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import type { HookInput, GuardResult } from '../../core/index.js';
-import { loadWorkflow } from '../../core/index.js';
+import type { HookInput, GuardResult, SlopeConfig, WorkflowExecution } from '../../core/index.js';
+import { formatSprintLabel, loadWorkflow, parseSprintNumber } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { SqliteSlopeStore } from '../../store/index.js';
-import { reconcileWorkflowExecutions } from '../workflow-resync.js';
+import { inferSprintContext } from '../sprint-inference.js';
+import { inferSprintFromBranch, reconcileWorkflowExecutions } from '../workflow-resync.js';
 
 /**
  * Workflow-step-gate guard: fires PreToolUse on Edit/Write.
@@ -26,7 +27,14 @@ export async function workflowStepGateGuard(input: HookInput, cwd: string): Prom
     const active = await store.listExecutions({ status: 'running' });
     if (active.length === 0) return resyncContext(resync);
 
-    const exec = active[0];
+    const exec = selectWorkflowExecution(active, input, cwd, config);
+    if (!exec) {
+      return withAdditionalContext(
+        resyncContext(resync),
+        'SLOPE workflow-step-gate: multiple running workflow executions; no session, branch, or sprint match, so edits are allowed.',
+      );
+    }
+
     if (!exec.current_phase || !exec.current_step) return resyncContext(resync);
 
     // Load the workflow definition to find the step's type
@@ -59,6 +67,53 @@ export async function workflowStepGateGuard(input: HookInput, cwd: string): Prom
   }
 }
 
+function selectWorkflowExecution(
+  active: WorkflowExecution[],
+  input: HookInput,
+  cwd: string,
+  config: SlopeConfig,
+): WorkflowExecution | null {
+  const sessionId = input.session_id?.trim();
+  if (sessionId) {
+    const bySession = active.find(exec => exec.session_id === sessionId);
+    if (bySession) return bySession;
+  }
+
+  for (const label of sprintLabelsForContext(cwd, config)) {
+    const bySprint = active.find(exec => sprintIdsMatch(exec.sprint_id, label));
+    if (bySprint) return bySprint;
+  }
+
+  return active.length === 1 ? active[0] : null;
+}
+
+function sprintLabelsForContext(cwd: string, config: SlopeConfig): string[] {
+  const labels = new Set<string>();
+  const branchSprint = inferSprintFromBranch(cwd);
+  if (branchSprint !== null) labels.add(formatSprintLabel(branchSprint));
+
+  try {
+    const inferred = inferSprintContext(cwd, config);
+    if (inferred.source !== 'initial') labels.add(inferred.label);
+  } catch {
+    // Sprint inference is advisory for this guard; ambiguity should fail open.
+  }
+
+  return [...labels];
+}
+
+function sprintIdsMatch(left: string | undefined, right: string): boolean {
+  const normalizedLeft = normalizeSprintLabel(left);
+  const normalizedRight = normalizeSprintLabel(right);
+  return normalizedLeft !== null && normalizedRight !== null && normalizedLeft === normalizedRight;
+}
+
+function normalizeSprintLabel(value: string | undefined): string | null {
+  if (!value) return null;
+  const parsed = parseSprintNumber(value);
+  return parsed === null ? value.trim().toUpperCase() : formatSprintLabel(parsed).toUpperCase();
+}
+
 function resyncContext(result: Awaited<ReturnType<typeof reconcileWorkflowExecutions>>): GuardResult {
   const lines: string[] = [];
   if (result.paused.length > 0) lines.push(`SLOPE workflow-step-gate: paused ${result.paused.length} stale workflow execution(s).`);
@@ -68,4 +123,11 @@ function resyncContext(result: Awaited<ReturnType<typeof reconcileWorkflowExecut
     ));
   }
   return lines.length > 0 ? { context: lines.join('\n') } : {};
+}
+
+function withAdditionalContext(result: GuardResult, context: string): GuardResult {
+  return {
+    ...result,
+    context: [result.context, context].filter(Boolean).join('\n'),
+  };
 }

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.58.2",
+  "version": "1.58.3",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",

--- a/tests/cli/guards/workflow-step-gate.test.ts
+++ b/tests/cli/guards/workflow-step-gate.test.ts
@@ -6,10 +6,11 @@ import { execFileSync } from 'node:child_process';
 import { workflowStepGateGuard } from '../../../src/cli/guards/workflow-step-gate.js';
 import { SqliteSlopeStore } from '../../../src/store/index.js';
 import type { HookInput } from '../../../src/core/index.js';
+import { createSprintState, saveSprintState } from '../../../src/cli/sprint-state.js';
 
 let TMP: string;
 
-function makeInput(): HookInput {
+function makeInput(overrides: Partial<HookInput> = {}): HookInput {
   return {
     session_id: 'test-session',
     cwd: TMP,
@@ -17,6 +18,7 @@ function makeInput(): HookInput {
     tool_name: 'Edit',
     tool_input: { file_path: '/foo/bar.ts' },
     tool_response: {},
+    ...overrides,
   };
 }
 
@@ -48,9 +50,23 @@ function writeWorkflow(name: string, stepType: string): void {
   ].join('\n'));
 }
 
-async function createRunningExecution(store: SqliteSlopeStore, workflow: string, phase: string, step: string): Promise<void> {
-  const exec = await store.startExecution({ workflow_name: workflow, sprint_id: 'S77' });
+async function createRunningExecution(
+  store: SqliteSlopeStore,
+  workflow: string,
+  phase: string,
+  step: string,
+  options: { sprintId?: string; sessionId?: string } = {},
+): Promise<void> {
+  const exec = await store.startExecution({
+    workflow_name: workflow,
+    sprint_id: options.sprintId ?? 'S77',
+    session_id: options.sessionId,
+  });
   await store.updateExecutionState(exec.id, phase, step);
+}
+
+function waitForTimestampTick(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 5));
 }
 
 function initGitForSprint(sprint: number): void {
@@ -102,6 +118,58 @@ describe('workflowStepGateGuard', () => {
 
     const result = await workflowStepGateGuard(makeInput(), TMP);
     expect(result).toEqual({});
+  });
+
+  it('uses current sprint execution instead of unrelated active[0] (#531)', async () => {
+    writeConfig();
+    saveSprintState(TMP, createSprintState(531, 'implementing'));
+    writeWorkflow('current-wf', 'agent_work');
+    writeWorkflow('unrelated-wf', 'command');
+    const store = new SqliteSlopeStore(join(TMP, '.slope/slope.db'));
+    await createRunningExecution(store, 'current-wf', 'phase1', 'step1', { sprintId: 'S531' });
+    await waitForTimestampTick();
+    await createRunningExecution(store, 'unrelated-wf', 'phase1', 'step1', { sprintId: 'S85' });
+    store.close();
+
+    const result = await workflowStepGateGuard(makeInput(), TMP);
+    expect(result.decision).toBeUndefined();
+    expect(result.blockReason).toBeUndefined();
+  });
+
+  it('uses matching session execution instead of unrelated active[0] (#531)', async () => {
+    writeConfig();
+    writeWorkflow('session-wf', 'agent_work');
+    writeWorkflow('unrelated-wf', 'command');
+    const store = new SqliteSlopeStore(join(TMP, '.slope/slope.db'));
+    await createRunningExecution(store, 'session-wf', 'phase1', 'step1', {
+      sprintId: 'S77',
+      sessionId: 'test-session',
+    });
+    await waitForTimestampTick();
+    await createRunningExecution(store, 'unrelated-wf', 'phase1', 'step1', {
+      sprintId: 'S85',
+      sessionId: 'other-session',
+    });
+    store.close();
+
+    const result = await workflowStepGateGuard(makeInput(), TMP);
+    expect(result.decision).toBeUndefined();
+    expect(result.blockReason).toBeUndefined();
+  });
+
+  it('fails open when multiple executions cannot be disambiguated (#531)', async () => {
+    writeConfig();
+    writeWorkflow('command-wf', 'command');
+    writeWorkflow('validation-wf', 'validation');
+    const store = new SqliteSlopeStore(join(TMP, '.slope/slope.db'));
+    await createRunningExecution(store, 'command-wf', 'phase1', 'step1', { sprintId: 'S77' });
+    await waitForTimestampTick();
+    await createRunningExecution(store, 'validation-wf', 'phase1', 'step1', { sprintId: 'S85' });
+    store.close();
+
+    const result = await workflowStepGateGuard(makeInput(), TMP);
+    expect(result.decision).toBeUndefined();
+    expect(result.context).toContain('multiple running workflow executions');
   });
 
   it('blocks file edit on command step', async () => {

--- a/tests/cli/guards/workflow-step-gate.test.ts
+++ b/tests/cli/guards/workflow-step-gate.test.ts
@@ -157,6 +157,25 @@ describe('workflowStepGateGuard', () => {
     expect(result.blockReason).toBeUndefined();
   });
 
+  it('prefers current sprint over a stale execution from the same session (#531)', async () => {
+    writeConfig();
+    saveSprintState(TMP, createSprintState(531, 'implementing'));
+    writeWorkflow('current-wf', 'agent_work');
+    writeWorkflow('stale-session-wf', 'command');
+    const store = new SqliteSlopeStore(join(TMP, '.slope/slope.db'));
+    await createRunningExecution(store, 'current-wf', 'phase1', 'step1', { sprintId: 'S531' });
+    await waitForTimestampTick();
+    await createRunningExecution(store, 'stale-session-wf', 'phase1', 'step1', {
+      sprintId: 'S85',
+      sessionId: 'test-session',
+    });
+    store.close();
+
+    const result = await workflowStepGateGuard(makeInput(), TMP);
+    expect(result.decision).toBeUndefined();
+    expect(result.blockReason).toBeUndefined();
+  });
+
   it('fails open when multiple executions cannot be disambiguated (#531)', async () => {
     writeConfig();
     writeWorkflow('command-wf', 'command');


### PR DESCRIPTION
## Summary
- Scope workflow-step-gate running execution selection by session plus current sprint, current sprint, session, or single-active fallback instead of trusting active[0].
- Fail open with guard context when multiple running executions cannot be disambiguated.
- Add S146.3 roadmap, scorecard, review artifacts, and bump package/plugin metadata to v1.58.3.

Closes #531

## Validation
- `corepack pnpm vitest run tests/cli/guards/workflow-step-gate.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test`
- `node dist/cli/index.js validate docs/retros/sprint-146.3.json`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js docs generate && node dist/cli/index.js docs check`
- `node dist/cli/index.js version`