### PR TITLE
[codex] Fix roadmap sprints without tickets arrays

### DIFF
--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -161,9 +161,9 @@ function normalizeRoadmapTicket(ticket: RoadmapTicket): RoadmapTicket {
 function normalizeRoadmap(roadmap: RoadmapDefinition): RoadmapDefinition {
   return {
     ...roadmap,
-    sprints: roadmap.sprints.map(sprint => ({
+    sprints: (roadmap.sprints ?? []).map(sprint => ({
       ...sprint,
-      tickets: sprint.tickets.map(normalizeRoadmapTicket),
+      tickets: (sprint.tickets ?? []).map(normalizeRoadmapTicket),
     })),
   };
 }

--- a/tests/cli/roadmap.test.ts
+++ b/tests/cli/roadmap.test.ts
@@ -171,6 +171,27 @@ describe('slope roadmap validate', () => {
     expect(output).not.toContain('startsWith');
   });
 
+  it('validates a sprint with no tickets array without throwing TypeError', async () => {
+    const roadmap = makeRoadmapJson({
+      sprints: [{
+        id: 7,
+        theme: 'Ticketless',
+        par: 4,
+        slope: 2,
+        type: 'feature',
+      } as unknown as RoadmapDefinition['sprints'][number]],
+      phases: [{ name: 'P1', sprints: [7] }],
+    });
+    writeRoadmap(tmpDir, roadmap);
+    const codes = mockExit();
+
+    await expect(roadmapCommand(['validate'])).rejects.toThrow('process.exit(0)');
+    expect(codes[0]).toBe(0);
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('0 tickets');
+    expect(output).not.toContain('Cannot read properties of undefined');
+  });
+
   it('shows warnings for low ticket count', async () => {
     const roadmap = makeRoadmapJson({
       sprints: [{

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -4,6 +4,7 @@ import {
   computeCriticalPath,
   findParallelOpportunities,
   parseRoadmap,
+  castRoadmapStructure,
   formatRoadmapSummary,
   formatStrategicContext,
   formatSprintLabel,
@@ -408,6 +409,42 @@ describe('parseRoadmap', () => {
     const { roadmap, validation } = parseRoadmap(json);
     expect(roadmap).not.toBeNull();
     expect(validation.valid).toBe(true);
+  });
+
+  it('defaults missing sprint tickets to an empty array when parsing', () => {
+    const json = {
+      name: 'Test',
+      phases: [{ name: 'P1', sprints: [7] }],
+      sprints: [{
+        id: 7,
+        theme: 'Ticketless',
+        par: 4,
+        slope: 2,
+        type: 'feature',
+      }],
+    };
+
+    const { roadmap, validation } = parseRoadmap(json);
+
+    expect(roadmap?.sprints[0].tickets).toEqual([]);
+    expect(validation.valid).toBe(true);
+    expect(validation.warnings.some(w => w.message.includes('0 tickets'))).toBe(true);
+  });
+
+  it('defaults missing sprint tickets to an empty array when structurally casting', () => {
+    const roadmap = castRoadmapStructure({
+      name: 'Test',
+      phases: [{ name: 'P1', sprints: [7] }],
+      sprints: [{
+        id: 7,
+        theme: 'Ticketless',
+        par: 4,
+        slope: 2,
+        type: 'feature',
+      }],
+    });
+
+    expect(roadmap?.sprints[0].tickets).toEqual([]);
   });
 
   it('rejects non-object input', () => {


### PR DESCRIPTION
## Summary

Fixes roadmap normalization so historical or summary-only sprints without a `tickets` array are treated as zero-ticket sprints instead of crashing during roadmap parsing/casting.

Closes #533.

## Root Cause

`normalizeRoadmap()` assumed every sprint had `tickets` and called `sprint.tickets.map(...)`. When `parseRoadmap()` or `castRoadmapStructure()` handled a roadmap with a ticketless sprint, every roadmap CLI path that depended on those functions could throw `Cannot read properties of undefined (reading 'map')` before validation could report useful output.

## Changes

- Default missing `roadmap.sprints` and `sprint.tickets` to empty arrays during roadmap normalization.
- Add core regression coverage for `parseRoadmap()` and `castRoadmapStructure()` with ticketless sprints.
- Add CLI validation coverage confirming `slope roadmap validate` reports `0 tickets` instead of throwing.

## Validation

- `pnpm build`
- `pnpm test -- tests/core/roadmap.test.ts tests/cli/roadmap.test.ts`
- `node dist/cli/index.js roadmap validate --path=%TEMP%/slope-roadmap-missing-tickets-repro.json`
- `pnpm test` (first run hit an unrelated branch-hygiene timeout; isolated rerun passed; second full run passed)
- `node dist/cli/index.js validate`
- `node dist/cli/index.js map --check`
- `git diff --check`