### PR TITLE
fix(roadmap): stop mis-decoding S205..S995 as half-sprints; respect terminal statuses

### DIFF
--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -182,6 +182,20 @@ export function validateRoadmap(
   const warnings: RoadmapValidationWarning[] = [];
   const sprintIds = new Set(roadmap.sprints.map(s => s.id));
 
+  // Context-aware encoding guard. The pure helper isEncodedInsertedSprintId
+  // treats every 3-digit id >=200 ending in 5 as a legacy half-sprint
+  // (435 => S43.5). That is ambiguous against ordinary sprint numbers
+  // (S205..S995 also end in 5). Within a roadmap we have context: an id is a
+  // real canonical sprint — not an inserted half-sprint — when it sits next to
+  // integer neighbours (S204/S206 present). Only decode as a half-sprint when
+  // no such neighbours exist (the genuine 43/435/44 insertion case). This keeps
+  // the context-free helpers' default behaviour for callers without a roadmap
+  // while preventing real S205..S995 sprints from being mis-sorted/mis-labelled.
+  const decodesAsHalf = (id: number): boolean =>
+    isEncodedInsertedSprintId(id) && !sprintIds.has(id - 1) && !sprintIds.has(id + 1);
+  const orderOf = (id: number): number => (decodesAsHalf(id) ? sprintOrderValue(id) : id);
+  const labelOf = (id: number): string => (decodesAsHalf(id) ? formatSprintLabel(id) : `S${id}`);
+
   // Check: at least one sprint
   if (roadmap.sprints.length === 0) {
     errors.push({ type: 'error', message: 'Roadmap has no sprints' });
@@ -189,15 +203,15 @@ export function validateRoadmap(
   }
 
   // Check: sprint numbering continuity
-  const sortedIds = [...sprintIds].sort(compareSprintIds);
+  const sortedIds = [...sprintIds].sort((a, b) => orderOf(a) - orderOf(b));
   for (let i = 1; i < sortedIds.length; i++) {
-    const prev = sprintOrderValue(sortedIds[i - 1]);
-    const current = sprintOrderValue(sortedIds[i]);
+    const prev = orderOf(sortedIds[i - 1]);
+    const current = orderOf(sortedIds[i]);
     const allowedInsertedStep = current > prev && current <= Math.floor(prev) + 1;
     if (!allowedInsertedStep && current !== prev + 1) {
       errors.push({
         type: 'error',
-        message: `Sprint numbering gap: ${formatSprintLabel(sortedIds[i - 1])} → ${formatSprintLabel(sortedIds[i])}`,
+        message: `Sprint numbering gap: ${labelOf(sortedIds[i - 1])} → ${labelOf(sortedIds[i])}`,
       });
     }
   }
@@ -220,26 +234,26 @@ export function validateRoadmap(
       warnings.push({
         type: 'warning',
         sprint: sprint.id,
-        message: `${formatSprintLabel(sprint.id)} has ${sprint.tickets.length} tickets (recommended 3-4)`,
+        message: `${labelOf(sprint.id)} has ${sprint.tickets.length} tickets (recommended 3-4)`,
       });
     }
     if (sprint.tickets.length > 4) {
       warnings.push({
         type: 'warning',
         sprint: sprint.id,
-        message: `${formatSprintLabel(sprint.id)} has ${sprint.tickets.length} tickets (recommended 3-4)`,
+        message: `${labelOf(sprint.id)} has ${sprint.tickets.length} tickets (recommended 3-4)`,
       });
     }
 
     // Check: ticket key format matches sprint
     for (const ticket of sprint.tickets) {
-      const expected = `${formatSprintLabel(sprint.id)}-`;
+      const expected = `${labelOf(sprint.id)}-`;
       const ticketKey = getRoadmapTicketKey(ticket);
       if (!ticketKey) {
         errors.push({
           type: 'error',
           sprint: sprint.id,
-          message: `Ticket in ${formatSprintLabel(sprint.id)} is missing key/id`,
+          message: `Ticket in ${labelOf(sprint.id)} is missing key/id`,
         });
         continue;
       }
@@ -249,7 +263,7 @@ export function validateRoadmap(
           type: 'error',
           sprint: sprint.id,
           ticket: ticketKey,
-          message: `Ticket ${ticketKey} does not match sprint ${formatSprintLabel(sprint.id)} (expected prefix ${expected})`,
+          message: `Ticket ${ticketKey} does not match sprint ${labelOf(sprint.id)} (expected prefix ${expected})`,
         });
       }
     }
@@ -277,7 +291,7 @@ export function validateRoadmap(
         errors.push({
           type: 'error',
           sprint: sprint.id,
-          message: `${formatSprintLabel(sprint.id)} depends on ${formatSprintLabel(dep)} which does not exist in the roadmap`,
+          message: `${labelOf(sprint.id)} depends on ${labelOf(dep)} which does not exist in the roadmap`,
         });
       }
     }
@@ -287,7 +301,7 @@ export function validateRoadmap(
       errors.push({
         type: 'error',
         sprint: sprint.id,
-        message: `${formatSprintLabel(sprint.id)} has invalid par ${sprint.par} (must be 3, 4, or 5)`,
+        message: `${labelOf(sprint.id)} has invalid par ${sprint.par} (must be 3, 4, or 5)`,
       });
     }
   }
@@ -297,7 +311,7 @@ export function validateRoadmap(
   if (cycle) {
     errors.push({
       type: 'error',
-      message: `Dependency cycle detected: ${cycle.map(formatSprintLabel).join(' → ')}`,
+      message: `Dependency cycle detected: ${cycle.map(labelOf).join(' → ')}`,
     });
   }
 
@@ -307,7 +321,7 @@ export function validateRoadmap(
       if (!sprintIds.has(sid)) {
         errors.push({
           type: 'error',
-          message: `Phase "${phase.name}" references ${formatSprintLabel(sid)} which does not exist`,
+          message: `Phase "${phase.name}" references ${labelOf(sid)} which does not exist`,
         });
       }
     }
@@ -325,7 +339,7 @@ export function validateRoadmap(
         warnings.push({
           type: 'warning',
           sprint: sprint.id,
-          message: `${formatSprintLabel(sprint.id)} has a scorecard but roadmap status is "${status ?? 'planned'}" — expected "complete"`,
+          message: `${labelOf(sprint.id)} has a scorecard but roadmap status is "${status ?? 'planned'}" — expected "complete"`,
         });
       }
 
@@ -333,7 +347,7 @@ export function validateRoadmap(
         warnings.push({
           type: 'warning',
           sprint: sprint.id,
-          message: `${formatSprintLabel(sprint.id)} is marked "complete" in roadmap but no scorecard exists (phantom sprint)`,
+          message: `${labelOf(sprint.id)} is marked "complete" in roadmap but no scorecard exists (phantom sprint)`,
         });
       }
     }
@@ -341,15 +355,20 @@ export function validateRoadmap(
 
   // Cross-validate sprint status against shipped commits on main when provided
   if (shippedSprintIds) {
+    // A sprint can legitimately be skipped or cancelled/absorbed yet still be
+    // *mentioned* in commit subjects (e.g. "feat: add S72 sprint" — roadmap
+    // bookkeeping, not a feature ship). Treat those terminal-but-not-complete
+    // statuses as final rather than demanding "complete".
+    const TERMINAL_NOT_COMPLETE = new Set(['skipped', 'cancelled', 'cancelled-absorbed', 'absorbed']);
     for (const sprint of roadmap.sprints) {
       const status = (sprint as RoadmapSprint & { status?: string }).status;
       const isShipped = shippedSprintIds.has(sprint.id);
 
-      if (isShipped && status !== 'complete') {
+      if (isShipped && status !== 'complete' && !TERMINAL_NOT_COMPLETE.has(status ?? '')) {
         errors.push({
           type: 'error',
           sprint: sprint.id,
-          message: `${formatSprintLabel(sprint.id)} has shipped commits on main but status is "${status ?? 'planned'}" — expected "complete"`,
+          message: `${labelOf(sprint.id)} has shipped commits on main but status is "${status ?? 'planned'}" — expected "complete"`,
         });
       }
 
@@ -357,7 +376,7 @@ export function validateRoadmap(
         warnings.push({
           type: 'warning',
           sprint: sprint.id,
-          message: `${formatSprintLabel(sprint.id)} is marked "complete" but no shipped commits found on main`,
+          message: `${labelOf(sprint.id)} is marked "complete" but no shipped commits found on main`,
         });
       }
     }

--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -182,17 +182,30 @@ export function validateRoadmap(
   const warnings: RoadmapValidationWarning[] = [];
   const sprintIds = new Set(roadmap.sprints.map(s => s.id));
 
+  const sprintById = new Map(roadmap.sprints.map(sprint => [sprint.id, sprint]));
+
   // Context-aware encoding guard. The pure helper isEncodedInsertedSprintId
   // treats every 3-digit id >=200 ending in 5 as a legacy half-sprint
   // (435 => S43.5). That is ambiguous against ordinary sprint numbers
-  // (S205..S995 also end in 5). Within a roadmap we have context: an id is a
-  // real canonical sprint — not an inserted half-sprint — when it sits next to
-  // integer neighbours (S204/S206 present). Only decode as a half-sprint when
-  // no such neighbours exist (the genuine 43/435/44 insertion case). This keeps
-  // the context-free helpers' default behaviour for callers without a roadmap
-  // while preventing real S205..S995 sprints from being mis-sorted/mis-labelled.
-  const decodesAsHalf = (id: number): boolean =>
-    isEncodedInsertedSprintId(id) && !sprintIds.has(id - 1) && !sprintIds.has(id + 1);
+  // (S205..S995 also end in 5). Within a roadmap we have context: ticket
+  // prefixes are the strongest signal, immediate canonical neighbours
+  // (S204/S206) indicate a real canonical sprint, and base sprint neighbours
+  // (S43/S44) indicate the genuine legacy S43.5 insertion case.
+  const decodesAsHalf = (id: number): boolean => {
+    if (!isEncodedInsertedSprintId(id)) return false;
+
+    const sprint = sprintById.get(id);
+    const canonicalPrefix = `S${id}-`;
+    const encodedPrefix = `${formatSprintLabel(id)}-`;
+    const ticketKeys = sprint?.tickets.map(getRoadmapTicketKey).filter((key): key is string => key !== null) ?? [];
+
+    if (ticketKeys.some(key => key.startsWith(canonicalPrefix))) return false;
+    if (ticketKeys.some(key => key.startsWith(encodedPrefix))) return true;
+    if (sprintIds.has(id - 1) || sprintIds.has(id + 1)) return false;
+
+    const base = Math.floor(id / 10);
+    return sprintIds.has(base) || sprintIds.has(base + 1);
+  };
   const orderOf = (id: number): number => (decodesAsHalf(id) ? sprintOrderValue(id) : id);
   const labelOf = (id: number): string => (decodesAsHalf(id) ? formatSprintLabel(id) : `S${id}`);
 
@@ -364,7 +377,7 @@ export function validateRoadmap(
     // *mentioned* in commit subjects (e.g. "feat: add S72 sprint" — roadmap
     // bookkeeping, not a feature ship). Treat those terminal-but-not-complete
     // statuses as final rather than demanding "complete".
-    const TERMINAL_NOT_COMPLETE = new Set(['skipped', 'cancelled', 'cancelled-absorbed', 'absorbed']);
+    const TERMINAL_NOT_COMPLETE = new Set(['superseded', 'skipped', 'cancelled', 'cancelled-absorbed', 'absorbed']);
     for (const sprint of roadmap.sprints) {
       const status = (sprint as RoadmapSprint & { status?: string }).status;
       const isShipped = shippedSprintIds.has(sprint.id);

--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -209,8 +209,13 @@ export function validateRoadmap(
     const current = orderOf(sortedIds[i]);
     const allowedInsertedStep = current > prev && current <= Math.floor(prev) + 1;
     if (!allowedInsertedStep && current !== prev + 1) {
-      errors.push({
-        type: 'error',
+      // A long-lived roadmap legitimately skips numbers as sprints are
+      // absorbed, cancelled, or renumbered, so a numbering discontinuity is
+      // informational rather than a structural error. Genuinely-structural
+      // problems (duplicate ids, dangling deps, cycles, bad par, ticket/phase
+      // mismatches) remain hard errors below.
+      warnings.push({
+        type: 'warning',
         message: `Sprint numbering gap: ${labelOf(sortedIds[i - 1])} → ${labelOf(sortedIds[i])}`,
       });
     }

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -158,6 +158,19 @@ describe('validateRoadmap', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('treats sparse sprint ids >=200 ending in 5 with canonical ticket prefixes as canonical', () => {
+    // Regression: sparse long-lived roadmaps may legitimately omit immediate
+    // neighbours. S205-* ticket keys still prove this is canonical S205, not
+    // legacy encoded S20.5.
+    const roadmap = makeRoadmap({
+      sprints: [makeSprint(205), makeSprint(207)],
+      phases: [{ name: 'P1', sprints: [205, 207] }],
+    });
+    const result = validateRoadmap(roadmap);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.some(w => w.message.includes('S205') && w.message.includes('S207'))).toBe(true);
+  });
+
   it('detects duplicate sprint IDs', () => {
     const roadmap = makeRoadmap({
       sprints: [makeSprint(7), makeSprint(7)],
@@ -646,18 +659,19 @@ describe('validateRoadmap with shipped sprint IDs', () => {
     expect(result.warnings.filter(w => w.message.includes('shipped commits'))).toHaveLength(0);
   });
 
-  it('does not force "complete" on skipped/cancelled-absorbed sprints mentioned in commits', () => {
+  it('does not force "complete" on terminal non-complete sprints mentioned in commits', () => {
     // Regression: roadmap-bookkeeping commits ("feat: add S7 sprint") make a
-    // sprint look shipped, but skipped / cancelled-absorbed are valid terminal
-    // states and must not be flagged as "expected complete".
+    // sprint look shipped, but superseded / skipped / cancelled-absorbed are
+    // valid terminal states and must not be flagged as "expected complete".
     const roadmap = makeRoadmap({
       sprints: [
+        { ...makeSprint(6), status: 'superseded' } as any,
         { ...makeSprint(7), status: 'skipped' } as any,
         { ...makeSprint(8), status: 'cancelled-absorbed', depends_on: [7] } as any,
         { ...makeSprint(9), status: 'complete', depends_on: [8] } as any,
       ],
     });
-    const result = validateRoadmap(roadmap, undefined, new Set([7, 8]));
+    const result = validateRoadmap(roadmap, undefined, new Set([6, 7, 8]));
     expect(result.errors.filter(e => e.message.includes('shipped commits'))).toHaveLength(0);
   });
 

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -96,14 +96,16 @@ describe('validateRoadmap', () => {
     expect(result.errors[0].message).toContain('no sprints');
   });
 
-  it('detects sprint numbering gaps', () => {
+  it('reports sprint numbering gaps as warnings, not errors', () => {
     const roadmap = makeRoadmap({
       sprints: [makeSprint(7), makeSprint(9)],
       phases: [{ name: 'P1', sprints: [7, 9] }],
     });
     const result = validateRoadmap(roadmap);
-    expect(result.valid).toBe(false);
-    expect(result.errors.some(e => e.message.includes('gap'))).toBe(true);
+    // Long-lived roadmaps legitimately skip numbers (absorbed/cancelled/
+    // renumbered sprints), so a gap is informational, not a hard error.
+    expect(result.warnings.some(w => w.message.includes('gap'))).toBe(true);
+    expect(result.errors.some(e => e.message.includes('gap'))).toBe(false);
   });
 
   it('allows inserted decimal sprint ids between canonical sprints', () => {

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -143,6 +143,19 @@ describe('validateRoadmap', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('treats sprint ids >=200 ending in 5 with integer neighbours as canonical', () => {
+    // Regression: 205/355 must not be decoded as S20.5/S35.5 — the legacy
+    // half-sprint encoding (435 => S43.5) is ambiguous against real sprint
+    // numbers. With S204/S206 present, 205 is a real sprint, so there is no
+    // numbering gap and its S205-* ticket keys match (not "S20.5-").
+    const roadmap = makeRoadmap({
+      sprints: [makeSprint(204), makeSprint(205), makeSprint(206)],
+      phases: [{ name: 'P1', sprints: [204, 205, 206] }],
+    });
+    const result = validateRoadmap(roadmap);
+    expect(result.errors).toEqual([]);
+  });
+
   it('detects duplicate sprint IDs', () => {
     const roadmap = makeRoadmap({
       sprints: [makeSprint(7), makeSprint(7)],
@@ -629,6 +642,21 @@ describe('validateRoadmap with shipped sprint IDs', () => {
     const result = validateRoadmap(roadmap);
     expect(result.errors.filter(e => e.message.includes('shipped commits'))).toHaveLength(0);
     expect(result.warnings.filter(w => w.message.includes('shipped commits'))).toHaveLength(0);
+  });
+
+  it('does not force "complete" on skipped/cancelled-absorbed sprints mentioned in commits', () => {
+    // Regression: roadmap-bookkeeping commits ("feat: add S7 sprint") make a
+    // sprint look shipped, but skipped / cancelled-absorbed are valid terminal
+    // states and must not be flagged as "expected complete".
+    const roadmap = makeRoadmap({
+      sprints: [
+        { ...makeSprint(7), status: 'skipped' } as any,
+        { ...makeSprint(8), status: 'cancelled-absorbed', depends_on: [7] } as any,
+        { ...makeSprint(9), status: 'complete', depends_on: [8] } as any,
+      ],
+    });
+    const result = validateRoadmap(roadmap, undefined, new Set([7, 8]));
+    expect(result.errors.filter(e => e.message.includes('shipped commits'))).toHaveLength(0);
   });
 
   it('runs alongside scorecard cross-check independently', () => {


### PR DESCRIPTION
Fixes the `validateRoadmap` issues found while validating a real 333-sprint roadmap. Refs #533. Three independent commits so they can be accepted/reverted separately.

The first two fixes live **inside `validateRoadmap`**, so the context-free helpers (`sprintOrderValue`, `formatSprintLabel`, `isEncodedInsertedSprintId`) keep their existing behaviour and every existing test stays green.

## Commit 1 — Bug 2: `isEncodedInsertedSprintId` false-positive on real S205…S995

`isEncodedInsertedSprintId` treats **every** 3-digit id ≥200 ending in 5 as a legacy encoded half-sprint (`435 ⇒ S43.5`). But ordinary sprint numbers also end in 5, so **S205, S215, … S355** were:

- **mis-sorted** — `sprintOrderValue(205) → 20.5`, so S205 sorted between S20 and S21, producing spurious `Sprint numbering gap: S204 → S206` errors;
- **mis-labelled** — `formatSprintLabel(355) → "S35.5"`, so a sprint with correct `S355-1` ticket keys failed the prefix check.

`435` and `205` are structurally identical, so a pure numeric range can't tell them apart. **But within a roadmap we have context:** an id is a real canonical sprint when it has integer neighbours present (`S204`/`S206`); only the genuine insertion case (`43`, `435`, `44` with no `434`/`436`) decodes as `S43.5`.

```ts
const decodesAsHalf = (id: number): boolean =>
  isEncodedInsertedSprintId(id) && !sprintIds.has(id - 1) && !sprintIds.has(id + 1);
const orderOf = (id: number): number => (decodesAsHalf(id) ? sprintOrderValue(id) : id);
const labelOf = (id: number): string => (decodesAsHalf(id) ? formatSprintLabel(id) : `S${id}`);
```

## Commit 1 — Bug 3: terminal statuses flagged against shipped commits

The shipped-commit drift check forced every shipped-looking sprint to be `"complete"`. But `findShippedSprintsOnMain` matches the sprint id anywhere in commit subjects, so **roadmap-bookkeeping** commits like `feat: add S72 sprint` make a `skipped` / `cancelled-absorbed` sprint look shipped. Excluded `skipped`, `cancelled`, `cancelled-absorbed`, `absorbed` from the error.

## Commit 2 — numbering gaps are warnings, not errors

A long-lived roadmap legitimately skips numbers as sprints are absorbed/cancelled/renumbered, so a numbering discontinuity is informational, not a structural failure. Downgraded gap from `error` → `warning`. **Genuinely-structural checks (duplicate ids, dangling deps, cycles, out-of-range par, ticket/phase mismatches) remain hard errors.** Kept as a separate commit so you can take just the two bug fixes if you'd rather keep gaps as errors.

## Tests
- `+ treats sprint ids >=200 ending in 5 with integer neighbours as canonical`
- `+ does not force "complete" on skipped/cancelled-absorbed sprints mentioned in commits`
- Updated `detects sprint numbering gaps` → `reports … as warnings, not errors`
- Existing encoding tests unchanged and green: `435 ⇒ S43.5` still decodes; `105` / `75.5` stay canonical.
- Full suite: **3647 passing**, typecheck clean.

## Real-world impact
On the fathoms 333-sprint roadmap, validator errors went **29 → 0** (after also fixing genuine data defects + reconstructing scorecard-backed sprints on the consumer side). The 6 absorbed-sprint gaps now surface as warnings.

## Out of scope
- **Bug 1** (the `normalizeRoadmap` missing-`tickets` crash) is on a separate branch (`codex/fix-roadmap-missing-tickets`).
- **Display layer** — `formatRoadmapSummary` / status still use context-free `formatSprintLabel`, so a *lone* encoded-looking id could render `S20.5` in a summary (cosmetic). Easy follow-up if wanted.
