### PR TITLE
[codex] Release v1.58.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.58.3",
+  "version": "1.58.4",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.58.3",
+  "version": "1.58.4",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",

--- a/tests/cli/doctor-branch-hygiene.test.ts
+++ b/tests/cli/doctor-branch-hygiene.test.ts
@@ -65,7 +65,7 @@ describe('checkBranchHygiene (GH #322)', () => {
     expect(merged?.status).toBe('warn');
     expect(merged?.message).toMatch(/5 merged-to-main/);
     expect(merged?.message).toContain('git branch -d');
-  });
+  }, 15_000);
 
   it('reports OK for stale-remotes when no remote configured', () => {
     const checks = checkBranchHygiene(cwd);


### PR DESCRIPTION
## Summary

- Bump `@slope-dev/slope` from `1.58.3` to `1.58.4`.
- Bump the bundled Codex plugin manifest to `1.58.4`.
- Stabilize the Windows full-suite release validation path by giving the branch-hygiene stress test enough time under contention.

This release includes the roadmap validator fix merged in #534 and closes the release-validation flake tracked in #536.

Closes #536

## Validation

- `pnpm build`
- `pnpm test -- tests/cli/doctor-branch-hygiene.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `node dist/cli/index.js validate`
- `node dist/cli/index.js map --check`
- `git diff --check`
- package/plugin version parity check