### PR TITLE
[codex] Release v1.58.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.58.4",
+  "version": "1.58.5",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.58.4",
+  "version": "1.58.5",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
## Summary

- Bump `@slope-dev/slope` from `1.58.4` to `1.58.5`.
- Bump the bundled Codex plugin manifest to `1.58.5`.
- Release the roadmap validator fixes merged in #535.

## Included Fixes

- Preserve canonical sparse long-roadmap sprint IDs such as `S205` when ticket prefixes prove they are not legacy encoded half-sprints.
- Treat `superseded` as a terminal non-complete status for shipped-commit roadmap validation.
- Keep roadmap numbering gaps as warnings for long-lived roadmaps.

## Validation

- `pnpm build`
- `pnpm test -- tests/core/roadmap.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `node dist/cli/index.js validate`
- `node dist/cli/index.js map --check`
- `git diff --check`
- package/plugin version parity check