### PR TITLE
S149: repair roadmap signal and compact status view

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ All commands use `npx slope` when installed locally.
 | `npx slope briefing` | Pre-sprint hazard index, nutrition alerts, filtered gotchas |
 | `npx slope plan --complexity=<level>` | Club recommendation + training plan |
 | `npx slope next` | Show next sprint number |
+| `npx slope roadmap status [--sprint=N]` | Compact current roadmap state: active work, blockers, next ready, upcoming |
+| `npx slope roadmap status --full` | Full historical roadmap status |
 | `npx slope roadmap validate` | Validate roadmap dependencies and sprint status |
 
 ### Review & Findings

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -4321,7 +4321,7 @@
       "par": 4,
       "slope": 2,
       "type": "bugfix + product surface",
-      "status": "planned",
+      "status": "complete",
       "depends_on": [
         148
       ],

--- a/docs/backlog/sprint-148-human-surface-simplification.md
+++ b/docs/backlog/sprint-148-human-surface-simplification.md
@@ -224,6 +224,19 @@ Acceptance tests:
 - Default line count stays under a fixed budget.
 - Regression fixtures include S148-like long-history roadmap data.
 
+## S149 Implementation Note
+
+S149 turns the roadmap case study into the active command contract:
+
+- `slope roadmap status` defaults to a compact planning view centered on the
+  current sprint, phase progress, roadmap reality checks, blockers,
+  next-ready work, up to three upcoming sprints, and one recommended action.
+- `slope roadmap status --full` preserves the historical phase-by-phase view
+  for agents, maintainers, and audits that need the complete roadmap.
+- The default command is covered by a long-history regression fixture so
+  completed historical phases and the full critical path stay out of the
+  human-facing status surface.
+
 ## Implementation Backlog
 
 ### S149 - Roadmap Signal Repair and Bounded Planning View

--- a/docs/retros/sprint-149.json
+++ b/docs/retros/sprint-149.json
@@ -1,0 +1,151 @@
+{
+  "sprint_number": 149,
+  "player": "codex",
+  "theme": "Roadmap Signal Repair and Bounded Planning View",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-06-08",
+  "type": "bugfix + product surface",
+  "skills_used": [
+    "slope-sprint-workflow",
+    "github"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "github"
+  ],
+  "skill_gaps_found": [],
+  "shots": [
+    {
+      "ticket_key": "S149-1",
+      "title": "Fix roadmap/status shipped-reference noise from issue-fix and historical imported sprint keys (#539, #541)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Filtered shipped sprint references so issue-style keys such as S147-533 no longer count as shipped roadmap sprint evidence, while real sprint and ticket refs remain valid. Scorecard drift now filters shipped refs through roadmap sprint ids so historical imported keys such as S194 stay out of current status."
+    },
+    {
+      "ticket_key": "S149-2",
+      "title": "Make roadmap status default to current, blockers, next ready, and 1-3 upcoming sprints",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Changed the default roadmap status command to a compact planning view with current sprint, phase progress, reality checks, active tickets, next-ready work, capped upcoming work, and one recommended next action."
+    },
+    {
+      "ticket_key": "S149-3",
+      "title": "Add full/history flags and bounded-output regression tests for roadmap status",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Preserved the historical roadmap output behind --full/--history and added long-history regression coverage that keeps completed phases and the full critical path out of the default view."
+    },
+    {
+      "ticket_key": "S149-4",
+      "title": "Update roadmap help and docs for the compact planning view contract",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Updated CLI help, README planning commands, and the S148 human surface design note so the compact default and --full escape hatch are documented together."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "rough",
+      "impact": "minor",
+      "description": "The sprint started with open validation/status noise from #539 and #541 that made roadmap reality checks stale even after S148 merged."
+    },
+    {
+      "type": "wind",
+      "impact": "minor",
+      "description": "The roadmap status command needed a calmer human default while preserving the full historical audit view for agents and maintainers."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Shipped-reference parsing should distinguish sprint/ticket ids from issue-fix ids before those refs become validation facts.",
+      "outcome": "S149 caps shipped ticket suffixes at normal roadmap ticket ranges and ignores issue-sized suffixes like S147-533."
+    },
+    {
+      "type": "lessons",
+      "description": "Human planning commands need output budgets and an explicit detail escape hatch.",
+      "outcome": "Roadmap status now defaults to a bounded planning view and keeps the full history behind --full/--history."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "`corepack pnpm vitest run tests/core/analyzers/git.test.ts tests/cli/commands/status.test.ts tests/cli/roadmap.test.ts` passed: 63 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`corepack pnpm typecheck`, `corepack pnpm build`, and `corepack pnpm test` passed; full suite result was 232 passed test files, 3655 passed tests, with the existing Postgres suite skipped.",
+      "status": "healthy"
+    },
+    {
+      "category": "validation",
+      "description": "`node dist/cli/index.js roadmap validate` passed with standing ticket-count warnings only, and the S147/#539 false positive no longer appears.",
+      "status": "healthy"
+    },
+    {
+      "category": "cli",
+      "description": "Compiled CLI smokes confirmed compact `roadmap status --sprint=149`, full `roadmap status --sprint=149 --full`, and clean `status --sprint=149` claim reporting.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "`node dist/cli/index.js docs check`, `node dist/cli/index.js map --check`, and `git diff --check` passed; the map is current for sprint 149.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Very satisfying: the roadmap is finally acting more like a cockpit and less like a filing cabinet with a megaphone.",
+    "advice_for_next_player": "S150 can build on the same audience-boundary pattern: small human defaults, explicit full-detail escape hatches, and tests that enforce the output budget.",
+    "what_surprised_you": "The status drift bug was not only a parser issue; status also needed to treat the roadmap as the authoritative current sprint universe.",
+    "excited_about_next": "The command audience metadata sprint now has a working example of how to make a powerful command feel human-sized."
+  },
+  "bunker_locations": [
+    "Issue-fix keys with large suffixes should not count as shipped roadmap tickets.",
+    "Historical imported sprint keys should not appear in closeout drift when those sprint ids are not present in the current roadmap.",
+    "Roadmap status defaults must stay bounded even as the historical roadmap grows."
+  ],
+  "yardage_book_updates": [
+    "src/core/analyzers/git.ts now ignores issue-sized sprint suffixes while preserving real sprint/ticket shipped refs.",
+    "src/cli/commands/status.ts now filters missing-scorecard shipped refs to roadmap sprint ids when roadmap data is available.",
+    "src/cli/commands/roadmap.ts now uses a compact default status view and exposes full history through --full/--history.",
+    "README.md and docs/backlog/sprint-148-human-surface-simplification.md document the compact roadmap status contract."
+  ],
+  "course_management_notes": [
+    "GitHub issue #539 was reopened before implementation because main still reproduced the shipped-reference false positive after S148 merged.",
+    "The PR should close #539 and #541 after CI passes and the branch is merged.",
+    "S150 is now unblocked by S149 in roadmap state, with S151 still dependent on S150."
+  ],
+  "slope_factors": [
+    "roadmap_validation",
+    "status_drift",
+    "cli_surface",
+    "human_output_budget",
+    "scorecard_closeout"
+  ]
+}

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -437,6 +437,7 @@ function printCompactRoadmapStatus(
   const currentLabel = current
     ? `${formatSprintLabel(current.id)} ${current.theme || 'Untitled Sprint'}`
     : `${formatSprintLabel(currentSprint)} (not found in roadmap)`;
+  const currentIsPending = current ? isRoadmapSprintPending(current) : false;
   const currentPhase = phaseForSprint(roadmap, currentSprint);
   const pendingAfterCurrent = sortedRoadmapSprints(roadmap)
     .filter(s => isRoadmapSprintPending(s) && s.id !== currentSprint && compareSprintIds(s.id, currentSprint) > 0);
@@ -493,7 +494,7 @@ function printCompactRoadmapStatus(
   console.log('\nRecommended next action:');
   if (realityLines.some(line => line.includes('[error]'))) {
     console.log('  Resolve the first roadmap reality error before advancing the lane.');
-  } else if (current?.tickets?.length) {
+  } else if (currentIsPending && current?.tickets?.length) {
     const first = current.tickets[0];
     console.log(`  Work ${first.key}: ${first.title}`);
   } else if (nextReady) {

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -39,6 +39,7 @@ function parseArgs(args: string[]): Record<string, string> {
 
 const DEFAULT_ROADMAP_PATH = 'docs/backlog/roadmap.json';
 const TERMINAL_ROADMAP_STATUSES = new Set(['complete', 'superseded']);
+const DEFAULT_UPCOMING_LIMIT = 3;
 
 function getRoadmapStatus(sprint: RoadmapSprint): string | undefined {
   return (sprint as RoadmapSprint & { status?: string }).status;
@@ -46,6 +47,54 @@ function getRoadmapStatus(sprint: RoadmapSprint): string | undefined {
 
 function isTerminalRoadmapSprint(sprint: RoadmapSprint, completedSprints: Set<number>): boolean {
   return completedSprints.has(sprint.id) || TERMINAL_ROADMAP_STATUSES.has(getRoadmapStatus(sprint) ?? '');
+}
+
+function blockedByForSprint(
+  roadmap: RoadmapDefinition,
+  sprint: RoadmapSprint,
+  completedSprints: Set<number>,
+): number[] {
+  return (sprint.depends_on ?? []).filter(dep => {
+    const dependency = roadmap.sprints.find(s => s.id === dep);
+    return dependency ? !isTerminalRoadmapSprint(dependency, completedSprints) : !completedSprints.has(dep);
+  });
+}
+
+function statusLabelForSprint(
+  roadmap: RoadmapDefinition,
+  sprint: RoadmapSprint,
+  currentSprint: number,
+  completedSprints: Set<number>,
+): string {
+  const explicitStatus = getRoadmapStatus(sprint);
+  const isCompleted = completedSprints.has(sprint.id) || explicitStatus === 'complete';
+  const isSuperseded = explicitStatus === 'superseded';
+  const isCurrent = sprint.id === currentSprint;
+  const blockedBy = blockedByForSprint(roadmap, sprint, completedSprints);
+
+  if (isSuperseded) return '\u21B7 superseded';
+  if (isCompleted) return '\u2713 completed';
+  if (isCurrent) return '\u25B6 active';
+  if (blockedBy.length > 0) return `\u2718 blocked by ${blockedBy.map(formatSprintLabel).join(', ')}`;
+  return '\u25CB pending';
+}
+
+function phaseForSprint(roadmap: RoadmapDefinition, sprintId: number): { name: string; sprints: number[] } | undefined {
+  return roadmap.phases.find(phase => phase.sprints?.includes(sprintId));
+}
+
+function formatPhaseProgress(
+  roadmap: RoadmapDefinition,
+  phase: { name: string; sprints: number[] },
+  completedSprints: Set<number>,
+): string {
+  const phaseSprints = roadmap.sprints.filter(s => phase.sprints.includes(s.id));
+  const completed = phaseSprints.filter(s => isTerminalRoadmapSprint(s, completedSprints)).length;
+  return `${phase.name || 'Unnamed Phase'} (${completed}/${phaseSprints.length})`;
+}
+
+function sortedRoadmapSprints(roadmap: RoadmapDefinition): RoadmapSprint[] {
+  return [...roadmap.sprints].sort((a, b) => compareSprintIds(a.id, b.id));
 }
 
 function resolveRoadmapPath(flags: Record<string, string>, cwd: string): string {
@@ -308,6 +357,18 @@ function statusSubcommand(flags: Record<string, string>, cwd: string): void {
   const currentSprint = resolveSprint(flags, cwd, roadmap, scorecards);
   const completedSprints = new Set(scorecards.map(s => s.sprint_number));
 
+  if (flags.full === 'true' || flags.history === 'true') {
+    printFullRoadmapStatus(roadmap, currentSprint, completedSprints);
+  } else {
+    printCompactRoadmapStatus(roadmap, currentSprint, completedSprints, cwd);
+  }
+}
+
+function printFullRoadmapStatus(
+  roadmap: RoadmapDefinition,
+  currentSprint: number,
+  completedSprints: Set<number>,
+): void {
   console.log(`\n# Roadmap Status — ${roadmap.name}`);
   console.log('\u2550'.repeat(40));
   console.log(`\nCurrent sprint: ${formatSprintLabel(currentSprint)}`);
@@ -364,6 +425,84 @@ function statusSubcommand(flags: Record<string, string>, cwd: string): void {
     console.log(context.split('\n').map(l => `  ${l}`).join('\n'));
     console.log('');
   }
+}
+
+function printCompactRoadmapStatus(
+  roadmap: RoadmapDefinition,
+  currentSprint: number,
+  completedSprints: Set<number>,
+  cwd: string,
+): void {
+  const current = roadmap.sprints.find(s => s.id === currentSprint);
+  const currentLabel = current
+    ? `${formatSprintLabel(current.id)} ${current.theme || 'Untitled Sprint'}`
+    : `${formatSprintLabel(currentSprint)} (not found in roadmap)`;
+  const currentPhase = phaseForSprint(roadmap, currentSprint);
+  const pendingAfterCurrent = sortedRoadmapSprints(roadmap)
+    .filter(s => isRoadmapSprintPending(s) && s.id !== currentSprint && compareSprintIds(s.id, currentSprint) > 0);
+  const nextReady = pendingAfterCurrent.find(s => blockedByForSprint(roadmap, s, completedSprints).length === 0);
+  const upcoming = pendingAfterCurrent.slice(0, DEFAULT_UPCOMING_LIMIT);
+  const realityLines = formatRoadmapRealitySection(buildRoadmapReality(cwd, roadmap), undefined, 5).slice(1);
+
+  console.log(`\n# Roadmap Status - ${roadmap.name}`);
+  console.log('\u2550'.repeat(40));
+  console.log(`\nCurrent: ${currentLabel}`);
+  if (currentPhase) console.log(`Phase: ${formatPhaseProgress(roadmap, currentPhase, completedSprints)}`);
+
+  console.log('\nReality checks:');
+  if (realityLines.length === 0) {
+    console.log('  None');
+  } else {
+    for (const line of realityLines) console.log(`  ${line.trim()}`);
+  }
+
+  console.log('\nActive sprint:');
+  if (!current) {
+    console.log(`  ${formatSprintLabel(currentSprint)} is not defined in the roadmap.`);
+  } else {
+    console.log(`  ${formatSprintLabel(current.id)} ${current.theme || 'Untitled Sprint'} - ${statusLabelForSprint(roadmap, current, currentSprint, completedSprints)}`);
+    if ((current.depends_on ?? []).length > 0) {
+      const deps = current.depends_on!.map(dep => {
+        const sprint = roadmap.sprints.find(s => s.id === dep);
+        if (!sprint) return `${formatSprintLabel(dep)} missing`;
+        return `${formatSprintLabel(dep)} ${statusLabelForSprint(roadmap, sprint, currentSprint, completedSprints).replace(/^[^\w]+ /, '')}`;
+      });
+      console.log(`  Dependencies: ${deps.join(', ')}`);
+    }
+    for (const ticket of current.tickets ?? []) {
+      console.log(`  - ${ticket.key}: ${ticket.title}`);
+    }
+  }
+
+  console.log('\nNext ready:');
+  if (nextReady) {
+    console.log(`  ${formatSprintLabel(nextReady.id)} ${nextReady.theme || 'Untitled Sprint'} - ${statusLabelForSprint(roadmap, nextReady, currentSprint, completedSprints)}`);
+  } else {
+    console.log('  None yet');
+  }
+
+  console.log(`\nUpcoming (${upcoming.length}/${Math.min(DEFAULT_UPCOMING_LIMIT, pendingAfterCurrent.length)}):`);
+  if (upcoming.length === 0) {
+    console.log('  None');
+  } else {
+    for (const sprint of upcoming) {
+      console.log(`  ${formatSprintLabel(sprint.id)} ${sprint.theme || 'Untitled Sprint'} - ${statusLabelForSprint(roadmap, sprint, currentSprint, completedSprints)}`);
+    }
+  }
+
+  console.log('\nRecommended next action:');
+  if (realityLines.some(line => line.includes('[error]'))) {
+    console.log('  Resolve the first roadmap reality error before advancing the lane.');
+  } else if (current?.tickets?.length) {
+    const first = current.tickets[0];
+    console.log(`  Work ${first.key}: ${first.title}`);
+  } else if (nextReady) {
+    console.log(`  Start ${formatSprintLabel(nextReady.id)}: ${nextReady.theme || 'Untitled Sprint'}`);
+  } else {
+    console.log('  No roadmap action is currently ready.');
+  }
+
+  console.log('\nFor the full roadmap history, run: slope roadmap status --full\n');
 }
 
 function showSubcommand(flags: Record<string, string>, cwd: string): void {
@@ -596,7 +735,7 @@ slope roadmap — Strategic planning tools
 Usage:
   slope roadmap validate [--path=<file>]     Schema + dependency graph checks
   slope roadmap review [--path=<file>]       Automated architect review
-  slope roadmap status [--path=<file>] [--sprint=N]  Current progress
+  slope roadmap status [--path=<file>] [--sprint=N] [--full]  Compact current progress
   slope roadmap show [--path=<file>]         Render summary (critical path, parallel tracks)
   slope roadmap sync [--path=<file>] [--dry-run]     Sync scorecards into roadmap
   slope roadmap generate [--path=<file>] [--dry-run] Generate from vision + concrete backlog signals
@@ -604,6 +743,7 @@ Usage:
 Options:
   --path=<file>    Path to roadmap JSON (default: docs/backlog/roadmap.json)
   --sprint=N       Override current sprint number (for status)
+  --full           Show full roadmap history for status
   --dry-run        Show what would change without writing (for sync and generate)
 
 Generate requires concrete backlog signals from source TODO/FIXME/HACK comments

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,6 +1,6 @@
-import { checkConflicts, findShippedSprintsOnMain, formatSprintLabel, parseSprintNumber } from '../../core/index.js';
+import { checkConflicts, findShippedSprintsOnMain, formatSprintLabel, parseRoadmap, parseSprintNumber } from '../../core/index.js';
 import type { SprintClaim, SlopeSession } from '../../core/index.js';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { loadConfig } from '../config.js';
 import { inferSprintContext } from '../sprint-inference.js';
@@ -105,20 +105,35 @@ async function showSprintStatus(store: { list: (n: number) => Promise<SprintClai
 
 /** Detect shipped sprints with no scorecard on disk. Used by status to
  *  surface the "post-hole skipped" pattern (#318). */
-function computeScorecardDrift(cwd: string): { missing: number[] } {
+export function computeScorecardDrift(cwd: string): { missing: number[] } {
   try {
     const config = loadConfig(cwd);
     const retroDir = join(cwd, config.scorecardDir);
     const pattern = config.scorecardPattern;
     const shipped = findShippedSprintsOnMain(cwd);
+    const roadmapIds = loadRoadmapSprintIds(cwd, config.roadmapPath);
     const missing: number[] = [];
     for (const id of [...shipped].sort((a, b) => a - b)) {
+      if (roadmapIds && !roadmapIds.has(id)) continue;
       const scorecardPath = join(retroDir, pattern.replaceAll('*', String(id)));
       if (!existsSync(scorecardPath)) missing.push(id);
     }
     return { missing };
   } catch {
     return { missing: [] };
+  }
+}
+
+function loadRoadmapSprintIds(cwd: string, roadmapPath: string): Set<number> | null {
+  try {
+    const path = join(cwd, roadmapPath);
+    if (!existsSync(path)) return null;
+    const parsed = parseRoadmap(JSON.parse(readFileSync(path, 'utf8')));
+    const roadmap = parsed.roadmap;
+    if (!roadmap) return null;
+    return new Set(roadmap.sprints.map(s => s.id));
+  } catch {
+    return null;
   }
 }
 

--- a/src/core/analyzers/git.ts
+++ b/src/core/analyzers/git.ts
@@ -16,6 +16,8 @@ function isSprintRangeEndpoint(line: string, matchStart: number, matchEnd: numbe
   return /S\d+\s*[-\u2013\u2014]\s*$/.test(before) || /^\s*[-\u2013\u2014]\s*S\d+\b/.test(after);
 }
 
+const MAX_SHIPPED_TICKET_SUFFIX = 99;
+
 /** Extract shipped sprint IDs referenced in commit subjects.
  *  Matches `S\d+` not followed by another digit or a dot — so `S75.5` does
  *  NOT count as a reference to S75, and `S70+S71` correctly yields {70, 71}.
@@ -26,11 +28,17 @@ function isSprintRangeEndpoint(line: string, matchStart: number, matchEnd: numbe
  */
 export function extractSprintReferences(commitSubjects: string[]): Set<number> {
   const result = new Set<number>();
-  const re = /\bS(\d+)(?!(?:[\d.]|-0\b))/g;
+  const re = /\bS(\d+)(?:-(\d+))?(?![\d.])/g;
   for (const line of commitSubjects) {
     let m: RegExpExecArray | null;
     while ((m = re.exec(line)) !== null) {
       if (isSprintRangeEndpoint(line, m.index, re.lastIndex)) continue;
+      const ticketSuffix = m[2] == null ? null : parseInt(m[2], 10);
+      if (ticketSuffix === 0) continue;
+      // SLOPE ticket keys are small ordinal suffixes (S149-1, S149-2).
+      // Large suffixes are usually GitHub/product issue keys, e.g. S147-533,
+      // and should not imply that roadmap sprint S147 shipped.
+      if (ticketSuffix != null && ticketSuffix > MAX_SHIPPED_TICKET_SUFFIX) continue;
       result.add(parseInt(m[1], 10));
     }
   }

--- a/tests/cli/commands/status.test.ts
+++ b/tests/cli/commands/status.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { statusCommand } from '../../../src/cli/commands/status.js';
+import { execSync } from 'node:child_process';
+import { computeScorecardDrift, statusCommand } from '../../../src/cli/commands/status.js';
 import { createSprintState, saveSprintState } from '../../../src/cli/sprint-state.js';
 
 let tmpDir: string;
@@ -34,6 +35,18 @@ async function captureLog(fn: () => Promise<void>): Promise<string> {
     vi.restoreAllMocks();
   }
   return logs.join('\n');
+}
+
+function gitInit(dir: string): void {
+  execSync('git init -q', { cwd: dir });
+  execSync('git config user.email test@test', { cwd: dir });
+  execSync('git config user.name test', { cwd: dir });
+}
+
+function gitCommit(dir: string, message: string): void {
+  writeFileSync(join(dir, `commit-${Date.now()}-${Math.random()}.txt`), message);
+  execSync('git add -A', { cwd: dir });
+  execSync('git commit -q -m "' + message.replaceAll('"', '\\"') + '"', { cwd: dir });
 }
 
 describe('slope status', () => {
@@ -73,5 +86,33 @@ describe('slope status', () => {
 
     const output = consoleErrorSpy.mock.calls.map(call => String(call[0])).join('\n');
     expect(output).toContain('Error: --sprint must be a positive sprint id, e.g. 114 or 114.5');
+  });
+
+  it('filters scorecard drift to sprint ids present in the roadmap', () => {
+    gitInit(tmpDir);
+    mkdirSync(join(tmpDir, 'docs', 'backlog'), { recursive: true });
+    writeFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+      name: 'Test Roadmap',
+      phases: [{ name: 'Current', sprints: [7] }],
+      sprints: [
+        {
+          id: 7,
+          theme: 'Current',
+          par: 4,
+          slope: 2,
+          type: 'feature',
+          tickets: [
+            { key: 'S7-1', title: 'T1', club: 'short_iron', complexity: 'standard' },
+            { key: 'S7-2', title: 'T2', club: 'short_iron', complexity: 'standard' },
+            { key: 'S7-3', title: 'T3', club: 'wedge', complexity: 'small' },
+          ],
+        },
+      ],
+    }));
+
+    gitCommit(tmpDir, 'feat(S194-5): historical import-era work');
+    gitCommit(tmpDir, 'feat(S7): current roadmap work');
+
+    expect(computeScorecardDrift(tmpDir).missing).toEqual([7]);
   });
 });

--- a/tests/cli/roadmap.test.ts
+++ b/tests/cli/roadmap.test.ts
@@ -320,6 +320,56 @@ describe('slope roadmap status', () => {
     expect(output).toContain('blocked');
   });
 
+  it('keeps default status bounded and hides completed history', () => {
+    const ticket = (prefix: string, n: number) => ({
+      key: `${prefix}-${n}`,
+      title: `T${n}`,
+      club: 'short_iron' as const,
+      complexity: 'standard' as const,
+    });
+    const sprint = (id: number, status?: string): RoadmapDefinition['sprints'][number] => ({
+      id,
+      theme: `Sprint ${id}`,
+      par: 4,
+      slope: 2,
+      type: 'feature',
+      ...(status ? { status } : {}),
+      ...(id > 1 ? { depends_on: [id - 1] } : {}),
+      tickets: [ticket(`S${id}`, 1), ticket(`S${id}`, 2), ticket(`S${id}`, 3)],
+    });
+    const roadmap = makeRoadmapJson({
+      phases: [
+        { name: 'Old Completed Phase', sprints: [1, 2, 3, 4] },
+        { name: 'Current Phase', sprints: [5, 6, 7, 8, 9] },
+      ],
+      sprints: [
+        sprint(1, 'complete'),
+        sprint(2, 'complete'),
+        sprint(3, 'complete'),
+        sprint(4, 'complete'),
+        sprint(5, 'planned'),
+        sprint(6, 'planned'),
+        sprint(7, 'planned'),
+        sprint(8, 'planned'),
+        sprint(9, 'planned'),
+      ],
+    });
+    writeRoadmap(tmpDir, roadmap);
+    writeConfig(tmpDir);
+
+    roadmapCommand(['status']);
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('Current: S5 Sprint 5');
+    expect(output).toContain('Current Phase');
+    expect(output).not.toContain('Old Completed Phase');
+    expect(output).toContain('S6 Sprint 6');
+    expect(output).toContain('S7 Sprint 7');
+    expect(output).toContain('S8 Sprint 8');
+    expect(output).not.toContain('S9 Sprint 9');
+    expect(output).toContain('slope roadmap status --full');
+  });
+
   it('marks completed sprints from scorecards', () => {
     writeRoadmap(tmpDir, makeRoadmapJson());
     writeConfig(tmpDir, { currentSprint: 8, scorecardDir: 'docs/retros', scorecardPattern: 'sprint-*.json', minSprint: 1 });
@@ -383,11 +433,12 @@ describe('slope roadmap status', () => {
     roadmapCommand(['status']);
 
     const output = consoleOutput.join('\n');
-    expect(output).toContain('Current sprint: S146.1');
+    expect(output).toContain('Current: S146.1 Inserted Release');
     expect(output).toContain('S146.1 Inserted Release');
     expect(output).toContain('\u25B6 active');
     expect(output).toContain('S147 Later');
     expect(output).toContain('blocked by S146.1');
+    expect(output).toContain('For the full roadmap history');
   });
 
   it('treats superseded sprints as terminal progress', () => {
@@ -402,7 +453,7 @@ describe('slope roadmap status', () => {
     writeRoadmap(tmpDir, roadmap);
     writeConfig(tmpDir, { currentSprint: 9 });
 
-    roadmapCommand(['status']);
+    roadmapCommand(['status', '--full']);
 
     const output = consoleOutput.join('\n');
     expect(output).toContain('Phase 1 (2/3)');
@@ -420,7 +471,8 @@ describe('slope roadmap status', () => {
     roadmapCommand(['status']);
 
     const output = consoleOutput.join('\n');
-    expect(output).toContain('Current Context');
+    expect(output).toContain('Current:');
+    expect(output).toContain('Active sprint');
     expect(output).toContain('Phase 1');
   });
 

--- a/tests/cli/roadmap.test.ts
+++ b/tests/cli/roadmap.test.ts
@@ -370,6 +370,26 @@ describe('slope roadmap status', () => {
     expect(output).toContain('slope roadmap status --full');
   });
 
+  it('recommends next ready work when an explicit completed sprint is shown', () => {
+    const roadmap = makeRoadmapJson({
+      sprints: [
+        { ...makeRoadmapJson().sprints[0], status: 'complete' } as RoadmapDefinition['sprints'][number],
+        { ...makeRoadmapJson().sprints[1], status: 'planned' } as RoadmapDefinition['sprints'][number],
+        { ...makeRoadmapJson().sprints[2], status: 'planned' } as RoadmapDefinition['sprints'][number],
+      ],
+    });
+    writeRoadmap(tmpDir, roadmap);
+    writeConfig(tmpDir);
+
+    roadmapCommand(['status', '--sprint=7']);
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('Current: S7 Foundation');
+    expect(output).toContain('S7 Foundation - \u2713 completed');
+    expect(output).toContain('Start S8: Platform');
+    expect(output).not.toContain('Work S7-1');
+  });
+
   it('marks completed sprints from scorecards', () => {
     writeRoadmap(tmpDir, makeRoadmapJson());
     writeConfig(tmpDir, { currentSprint: 8, scorecardDir: 'docs/retros', scorecardPattern: 'sprint-*.json', minSprint: 1 });

--- a/tests/core/analyzers/git.test.ts
+++ b/tests/core/analyzers/git.test.ts
@@ -158,6 +158,10 @@ describe('extractSprintReferences', () => {
     expect(extractSprintReferences(['fix(S101-2): normalize apply_patch paths'])).toEqual(new Set([101]));
   });
 
+  it('does not treat issue-sized ticket suffixes as shipped sprint refs', () => {
+    expect(extractSprintReferences(['fix(S147-533): tolerate roadmap sprints without tickets'])).toEqual(new Set());
+  });
+
   it('does not treat sprint range endpoints as shipped sprint refs', () => {
     expect(extractSprintReferences([
       'docs(roadmap): extend roadmap with Phases 10-12 (S64-S80) (#176)',


### PR DESCRIPTION
## Summary
- Filter shipped sprint detection so issue-fix refs like `S147-533` do not count as shipped roadmap sprint evidence.
- Filter status scorecard drift through roadmap sprint ids to remove historical imported sprint noise.
- Make `slope roadmap status` compact by default, preserving full history behind `--full` / `--history`.
- Record S149 closeout and update docs/help for the compact roadmap status contract.

## Validation
- `corepack pnpm vitest run tests/core/analyzers/git.test.ts tests/cli/commands/status.test.ts tests/cli/roadmap.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test`
- `node dist/cli/index.js validate docs/retros/sprint-149.json`
- `node dist/cli/index.js roadmap validate` (valid; expected branch-local warning that S149 is complete but not yet on main)
- `node dist/cli/index.js docs check`
- `node dist/cli/index.js map --check`
- `git diff --check HEAD`

Closes #539
Closes #541