### PR TITLE
S150: add command audiences and bounded help

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,18 @@ execute({ code: 'return computeHandicapCard(loadScorecards())' })
 
 All commands use `npx slope` when installed locally.
 
+Default help is intentionally small:
+
+| Command | Description |
+|---------|-------------|
+| `npx slope help` | Human command surface for daily work, setup, and direction |
+| `npx slope help <command>` | Detailed usage for one command |
+| `npx slope help --all` | Full command registry with audience labels |
+
+Commands are classified as `human`, `agent`, `advanced`, or `internal`.
+Humans should usually start with the default help surface; skills and agents
+orchestrate the rest of the CLI as execution primitives.
+
 ### Setup
 
 | Command | Description |

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -4368,7 +4368,7 @@
       "par": 4,
       "slope": 2,
       "type": "cli product surface",
-      "status": "planned",
+      "status": "complete",
       "depends_on": [
         149
       ],

--- a/docs/backlog/sprint-148-human-surface-simplification.md
+++ b/docs/backlog/sprint-148-human-surface-simplification.md
@@ -237,6 +237,20 @@ S149 turns the roadmap case study into the active command contract:
   completed historical phases and the full critical path stay out of the
   human-facing status surface.
 
+## S150 Implementation Note
+
+S150 turns the audience taxonomy into executable CLI metadata and help behavior:
+
+- Every top-level registry command now has an `audience` of `human`, `agent`,
+  `advanced`, or `internal`.
+- `slope help`, `slope --help`, and bare `slope` default to a bounded human
+  command surface instead of the full implementation registry.
+- `slope help --all` is the explicit escape hatch for the full registry and
+  prints audience labels so humans can see which commands are primarily for
+  skills, agents, maintainers, or internal plumbing.
+- Regression tests keep audience metadata complete and keep default help from
+  reintroducing agent/internal commands into the human surface.
+
 ## Implementation Backlog
 
 ### S149 - Roadmap Signal Repair and Bounded Planning View

--- a/docs/retros/sprint-150.json
+++ b/docs/retros/sprint-150.json
@@ -1,0 +1,144 @@
+{
+  "sprint_number": 150,
+  "player": "codex",
+  "theme": "Command Audience Metadata and Default Help",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-06-08",
+  "type": "cli product surface",
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow"
+  ],
+  "skill_gaps_found": [],
+  "shots": [
+    {
+      "ticket_key": "S150-1",
+      "title": "Add audience metadata to every CLI command registry entry",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added `audience` metadata to every top-level CLI registry command and covered it with registry tests for valid values plus the intentional bounded human command set."
+    },
+    {
+      "ticket_key": "S150-2",
+      "title": "Make default help show the compact human cockpit",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "`slope help`, `slope --help`, and bare `slope` now render a compact human command surface focused on daily work, setup, and direction instead of dumping every implementation command."
+    },
+    {
+      "ticket_key": "S150-3",
+      "title": "Add an explicit full-command escape hatch for the complete registry",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "`slope help --all` now prints the full command registry with audience labels, and `slope help <command>` shows the command audience in detail output."
+    },
+    {
+      "ticket_key": "S150-4",
+      "title": "Add registry/help tests that keep default help bounded",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added help and registry regressions that keep audience metadata complete, default help under budget, and agent/internal commands out of the human surface."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "pin_position",
+      "impact": "minor",
+      "description": "S150 intentionally changed the user-facing default help surface, so compiled CLI smokes were required in addition to unit tests."
+    },
+    {
+      "type": "wind",
+      "impact": "minor",
+      "description": "The docs manifest is generated into ignored `.slope/docs.json`; `docs generate` was still required locally before `docs check` could pass against the new command registry checksum."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Help output needs a registry-owned audience model, not a separate hand-maintained allowlist.",
+      "outcome": "The command registry now stores audience metadata and tests enforce the bounded human command set."
+    },
+    {
+      "type": "lessons",
+      "description": "A full-detail escape hatch makes it safer to shrink default output without removing power-user capability.",
+      "outcome": "`slope help --all` preserves the complete command reference with audience labels."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "`corepack pnpm vitest run tests/cli/registry.test.ts tests/cli/commands/help.test.ts` passed: 12 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`corepack pnpm typecheck`, `corepack pnpm build`, and `corepack pnpm test` passed; full suite result was 233 passed test files, 3662 passed tests, with the existing Postgres suite skipped.",
+      "status": "healthy"
+    },
+    {
+      "category": "cli",
+      "description": "Compiled CLI smokes confirmed compact `help`, compact `--help`, compact bare `slope`, full `help --all`, and concise unknown-command guidance.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "`node dist/cli/index.js docs generate --pretty`, `node dist/cli/index.js docs check`, and `node dist/cli/index.js map --check` passed.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Clean and clarifying. The CLI still has all its machinery, but the front door finally behaves like it knows a human is standing there.",
+    "advice_for_next_player": "S151 can now build `now` and `start` on top of audience metadata rather than reopening the whole command-list debate.",
+    "what_surprised_you": "The no-argument CLI path still carried an enormous legacy help template, so default help needed both `help.ts` and `index.ts` to converge.",
+    "excited_about_next": "The human cockpit implementation can now be a layer over explicit registry intent instead of a pile of special cases."
+  },
+  "bunker_locations": [
+    "Default help surfaces must not silently drift back toward full internal command dumps.",
+    "Command audience metadata should remain the source of truth for human, agent, advanced, and internal command exposure.",
+    "The older planned S147 lane remains a roadmap disposition question before the default roadmap navigator can be treated as purely next-phase."
+  ],
+  "yardage_book_updates": [
+    "src/cli/registry.ts now records `audience` on every top-level command.",
+    "src/cli/commands/help.ts now renders compact default help, command detail audiences, and full registry output behind `--all`.",
+    "src/cli/index.ts now routes global help, bare CLI, and unknown-command guidance through the bounded human surface.",
+    "README.md and docs/backlog/sprint-148-human-surface-simplification.md document the S150 help contract."
+  ],
+  "course_management_notes": [
+    "No open GitHub issues were present at S150 start.",
+    "S150 unblocks S151, the skill-first human cockpit implementation sprint.",
+    "S147 remains a separate older planned handoff-continuity lane and should be explicitly run, rescheduled, or superseded."
+  ],
+  "slope_factors": [
+    "cli_surface",
+    "command_registry",
+    "human_output_budget",
+    "documentation_manifest",
+    "help_contract"
+  ]
+}

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -1,25 +1,31 @@
 import { CLI_COMMAND_REGISTRY, CLI_INTERNAL_MODULES } from '../registry.js';
-import type { CliCommandMeta } from '../registry.js';
+import type { CliCommandAudience, CliCommandMeta } from '../registry.js';
 
 /**
- * slope help [command] — Show detailed per-command usage from the registry.
+ * slope help [command] - Show human help, full registry, or command details.
  */
 export async function helpCommand(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
     console.log(`
-slope help — Command reference
+slope help - Command reference
 
 Usage:
-  slope help              Show all commands grouped by category
+  slope help              Show the bounded human command surface
   slope help <command>    Show detailed usage for a command
+  slope help --all        Show all commands grouped by category
 `);
     return;
   }
 
-  const commandName = args[0];
+  if (args.includes('--all')) {
+    printAllCommandHelp();
+    return;
+  }
+
+  const commandName = args.find(arg => !arg.startsWith('-'));
 
   if (!commandName) {
-    printCategoryList();
+    printDefaultHelp();
     return;
   }
 
@@ -32,7 +38,45 @@ Usage:
   printCommandDetail(meta);
 }
 
-function printCategoryList(): void {
+const HUMAN_HELP_ORDER = [
+  'briefing',
+  'review',
+  'doctor',
+  'card',
+  'status',
+  'roadmap',
+  'vision',
+  'quickstart',
+  'init',
+] as const;
+
+const AUDIENCE_LABELS: Record<CliCommandAudience, string> = {
+  human: 'human',
+  agent: 'agent',
+  advanced: 'advanced',
+  internal: 'internal',
+};
+
+export function printDefaultHelp(): void {
+  const byName = new Map(CLI_COMMAND_REGISTRY.map(cmd => [cmd.cmd, cmd]));
+  console.log('\nSLOPE - Human Command Surface\n');
+  console.log('Daily work:');
+  for (const name of HUMAN_HELP_ORDER.slice(0, 6)) {
+    const cmd = byName.get(name);
+    if (cmd) printCommandRow(cmd, 4);
+  }
+
+  console.log('\nSetup and direction:');
+  for (const name of HUMAN_HELP_ORDER.slice(6)) {
+    const cmd = byName.get(name);
+    if (cmd) printCommandRow(cmd, 4);
+  }
+
+  console.log('\nAgents and skills use the rest of the CLI as execution primitives.');
+  console.log('Run `slope help <command>` for details, or `slope help --all` for the full registry.\n');
+}
+
+export function printAllCommandHelp(): void {
   const categories: Record<string, CliCommandMeta[]> = {};
   for (const cmd of CLI_COMMAND_REGISTRY) {
     if ((CLI_INTERNAL_MODULES as readonly string[]).includes(cmd.cmd)) continue;
@@ -41,7 +85,7 @@ function printCategoryList(): void {
     categories[cat].push(cmd);
   }
 
-  console.log('\nSLOPE CLI — Command Reference\n');
+  console.log('\nSLOPE CLI - Full Command Reference\n');
 
   const categoryOrder = ['lifecycle', 'scoring', 'analysis', 'planning', 'tooling'] as const;
   const categoryLabels: Record<string, string> = {
@@ -58,19 +102,19 @@ function printCategoryList(): void {
 
     console.log(`  ${categoryLabels[cat]}:`);
     for (const cmd of cmds) {
-      const name = cmd.cmd === 'index-cmd' ? 'index' : cmd.cmd;
-      console.log(`    ${name.padEnd(18)} ${cmd.desc}`);
+      printCommandRow(cmd, 4, true);
     }
     console.log('');
   }
 
-  console.log('Run `slope help <command>` for detailed usage.\n');
+  console.log('Run `slope help` for the bounded human surface, or `slope help <command>` for detailed usage.\n');
 }
 
 function printCommandDetail(meta: CliCommandMeta): void {
   const displayName = meta.cmd === 'index-cmd' ? 'index' : meta.cmd;
-  console.log(`\nslope ${displayName} — ${meta.desc}\n`);
+  console.log(`\nslope ${displayName} - ${meta.desc}\n`);
   console.log(`  Category: ${meta.category}\n`);
+  console.log(`  Audience: ${AUDIENCE_LABELS[meta.audience]}\n`);
 
   if (meta.subcommands && meta.subcommands.length > 0) {
     console.log('  Subcommands:\n');
@@ -95,6 +139,13 @@ function printCommandDetail(meta: CliCommandMeta): void {
   }
 }
 
+function printCommandRow(cmd: CliCommandMeta, indent: number, includeAudience = false): void {
+  const name = cmd.cmd === 'index-cmd' ? 'index' : cmd.cmd;
+  const prefix = ' '.repeat(indent);
+  const audience = includeAudience ? ` [${AUDIENCE_LABELS[cmd.audience]}]` : '';
+  console.log(`${prefix}${name.padEnd(14)} ${cmd.desc}${audience}`);
+}
+
 function suggestClosest(input: string): void {
   const names = CLI_COMMAND_REGISTRY
     .filter(c => !(CLI_INTERNAL_MODULES as readonly string[]).includes(c.cmd))
@@ -107,6 +158,6 @@ function suggestClosest(input: string): void {
   if (matches.length > 0) {
     console.error(`Did you mean: ${matches.join(', ')}?`);
   }
-  console.error(`\nRun \`slope help\` to see all commands.`);
+  console.error(`\nRun \`slope help\` for the human surface or \`slope help --all\` for all commands.`);
   process.exit(1);
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -69,7 +69,7 @@ import { sprintCommand } from './commands/sprint.js';
 import { resumeCommand } from './commands/resume.js';
 import { doctorCommand } from './commands/doctor.js';
 import { versionCommand } from './commands/version.js';
-import { helpCommand } from './commands/help.js';
+import { helpCommand, printDefaultHelp } from './commands/help.js';
 import { quickstartCommand } from './commands/quickstart.js';
 import { worktreeCommand } from './commands/worktree.js';
 import { orgCommand } from './commands/org.js';
@@ -97,27 +97,7 @@ if (sourceRuntimeWarning) {
 
 // Handle --help and -h flags globally
 if (subcommand === '--help' || subcommand === '-h') {
-  console.log(`
-SLOPE CLI — Sprint Lifecycle & Operational Performance Engine
-
-Usage:
-  slope init [--claude-code|--cursor|--codex|--opencode|--generic|--all]  Initialize .slope/ directory
-  slope init --team                         Enable multi-developer team mode
-  slope init --with-example                 Also seed docs/retros/sprint-1.json with an example
-  slope card                                Show handicap card
-  slope card --player=<name>                Show handicap for a specific player
-  slope card --team                         Show per-player comparison table
-  slope validate [path]                     Validate scorecard(s)
-  slope skills scan|list|validate           Manage repo-local skill registry
-  slope issue scout|triage                  Detect and triage SLOPE-driven issues
-  slope review [path] [--plain]             Format sprint review markdown
-  slope briefing                            Pre-round briefing
-  slope version                             Show current version
-  slope doctor                              Check repo health
-  slope resume [--from=path] [--force]      Portable sprint resume from tracked artifacts
-
-For full command list, run: slope
-`);
+  printDefaultHelp();
   process.exit(0);
 }
 
@@ -329,108 +309,11 @@ switch (subcommand) {
     memoryCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   default:
-    console.log(`
-SLOPE CLI — Sprint Lifecycle & Operational Performance Engine
-
-Usage:
-  slope init [--claude-code|--cursor|--codex|--opencode|--generic|--all]  Initialize .slope/ directory
-  slope init --team                         Enable multi-developer team mode
-  slope init --with-example                 Also seed docs/retros/sprint-1.json with an example
-  slope card                                Show handicap card
-  slope card --player=<name>                Show handicap for a specific player
-  slope card --team                         Show per-player comparison table
-  slope validate [path]                     Validate scorecard(s)
-  slope validate [path] --skills            Validate scorecard skill references
-  slope review [path] [--plain]             Format sprint review markdown
-  slope review start [--rounds=N|--tier=T]  Start plan review lifecycle
-  slope review round                        Record a completed review round
-  slope review status                       Show current review state
-  slope review reset                        Clear review state
-  slope review recommend                    Recommend review types for current sprint
-  slope review findings add|list|clear      Manage implementation review findings
-  slope review amend [--sprint=N]           Amend scorecard with review findings
-  slope pr review [--pr=N] [--sprint=N]     Run post-PR review workflow
-  slope pr status [--sprint=N]              Check PR closeout readiness
-  slope briefing [--sprint=N] [options]      Pre-round briefing
-  slope plan --complexity=<level>           Pre-shot advisor (club + training + hazards)
-  slope classify --scope=... ...            Classify a shot from execution trace
-  slope claim --target=<t> [--force]        Claim a ticket or area for the sprint
-  slope release --id=<id>                   Release a claim by ID
-  slope release --target=<t> [--player=<p>] Release a claim by target
-  slope status [--sprint=N]                 Show sprint course status + conflicts
-  slope tournament --id=<id> --sprints=N..M Build tournament review from sprints
-  slope auto-card --sprint=<N> [options]    Generate scorecard from git + CI signals
-  slope hook add|remove|list|show            Manage lifecycle hooks
-  slope hook add --level=full               Install all guidance hooks
-  slope guard <name>                        Run a guard handler (reads stdin)
-  slope guard list|enable|disable           Manage guard activation
-  slope session start|end|heartbeat|prune|list Manage live sessions
-  slope next                                Show next sprint number (auto-detect)
-  slope extract --file=<path> [options]       Extract events into SLOPE store
-  slope distill [--auto] [--dry-run]         Promote event patterns to common issues
-  slope standup [--session=<id>] [--json]     Generate standup report from session
-  slope standup --ingest=<path> [--role=<id>] Ingest another agent's standup
-  slope report --html [--output=<path>]      Generate HTML performance report
-  slope dashboard [--port=N] [--no-open]    Live local performance dashboard
-  slope dashboard --player=<name>          Filter dashboard to a single player
-  slope roadmap validate|review|status|show  Strategic planning tools
-  slope map [--check] [--output=<path>]     Generate/update codebase map
-  slope flows init|list|check               Manage user flow definitions
-  slope inspirations add|list|link          Track external OSS inspiration sources
-  slope analyze [--json] [--analyzers=...]  Scan repo and generate profile
-  slope vision [--json]                     Display project vision document
-  slope store status [--json]                Store diagnostics (type, schema, stats)
-  slope store migrate status                Show schema version and migration status
-  slope store backup [--output=<path>]      Back up the store
-  slope store restore --from=<path>         Restore from a backup
-  slope transcript list|show|stats          View session transcript data
-  slope metaphor list|set|show              Manage metaphor display themes
-  slope plugin list|validate                Manage custom plugins
-  slope skills scan|list|validate           Manage repo-local skill registry
-  slope issue scout|triage                  Detect and triage SLOPE-driven issues
-  slope initiative create|status|next|advance|review  Multi-sprint initiative orchestration
-  slope index [--full|--status|--prune]               Semantic embedding index
-  slope context "query" [options]                     Semantic context search
-  slope prep <ticket-id> [--json] [--top=5]          Generate execution plan for a ticket
-  slope enrich [backlog-path] [--output=<path>]      Batch-enrich backlog with file context
-  slope stats export [--pretty]                      Export stats JSON for slope-web
-  slope docs generate|changelog|check                Documentation manifest and changelog
-  slope sprint start|gate|status|reset               Manage sprint lifecycle state
-  slope worktree start|status|cleanup [options]      Manage persistent worktrees
-  slope loop status|config|run|continuous|...        Autonomous sprint execution loop
-  slope doctor [--fix] [--dry-run]                   Check repo health and fix issues
-  slope version                                      Show current version
-  slope version bump [<version>] [--dry-run]         Bump version, create PR, merge
-
-Examples:
-  slope init                                Create .slope/ with config + example scorecard
-  slope init --cursor                       Also install Cursor IDE rules
-  slope init --cursor                       Also add SLOPE MCP server to .cursor/mcp.json
-  slope init --claude-code                  Also install Claude Code rules + hooks
-  slope init --codex                        Also install Codex CLI hooks + AGENTS.md guidance
-  slope init --opencode                     Also install OpenCode AGENTS.md + MCP config
-  slope init --team                          Enable multi-developer mode
-  slope card                                Show handicap across all scorecards
-  slope card --player=alice                 Show handicap for alice only
-  slope card --team                         Compare all players side-by-side
-  slope validate docs/retros/sprint-1.json  Validate a specific scorecard
-  slope validate                            Validate all scorecards
-  slope review                              Review the latest scorecard
-  slope review --plain                      Non-technical sprint review
-  slope briefing                            Full briefing (top 10 recent gotchas)
-  slope briefing --categories=testing       Filter by category
-  slope briefing --keywords=migration       Filter by keyword
-  slope plan --complexity=medium            Club recommendation for medium ticket
-  slope plan --complexity=large --areas=db  Include hazard warnings for db area
-  slope classify --scope="a.ts" --modified="a.ts" --tests=pass --reverts=0
-  slope briefing --sprint=2                 Briefing for sprint 2
-  slope claim --target=S2-1 --sprint=2      Claim ticket S2-1 for sprint 2
-  slope claim --target=packages/cli --scope=area  Claim an area
-  slope claim --target=S2-1 --force         Claim even if overlap conflict exists
-  slope status --sprint=2                   Show all claims for sprint 2
-  slope release --target=S2-1               Release your claim on S2-1
-  slope dashboard                           Start live dashboard on port 3000
-  slope dashboard --port=8080 --no-open     Custom port, no browser auto-open
-`);
-    process.exit(subcommand ? 1 : 0);
+    if (!subcommand) {
+      printDefaultHelp();
+      process.exit(0);
+    }
+    console.error(`Unknown command: "${subcommand}"`);
+    console.error('Run `slope help` for the human surface or `slope help --all` for all commands.');
+    process.exit(1);
 }

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -16,6 +16,8 @@ export interface CliSubcommand {
   flags?: CliFlag[];
 }
 
+export type CliCommandAudience = 'human' | 'agent' | 'advanced' | 'internal';
+
 export interface CliCommandMeta {
   /** Command name as invoked: e.g. "init", "auto-card" */
   cmd: string;
@@ -23,6 +25,8 @@ export interface CliCommandMeta {
   desc: string;
   /** Functional category */
   category: 'lifecycle' | 'scoring' | 'analysis' | 'tooling' | 'planning';
+  /** Primary audience for the top-level command surface */
+  audience: CliCommandAudience;
   /** Subcommands, if any */
   subcommands?: CliSubcommand[];
   /** Top-level flags (when no subcommands, or shared across subcommands) */
@@ -35,32 +39,32 @@ export const CLI_INTERNAL_MODULES = ['phase', 'review-state', 'review-run', 'spr
 export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
   // ── Lifecycle ──────────────────────────────────────────────────
   {
-    cmd: 'init', desc: 'Initialize .slope/ directory', category: 'lifecycle',
+    cmd: 'init', desc: 'Initialize .slope/ directory', category: 'lifecycle', audience: 'human',
     flags: [
       { flag: '--metaphor=<id>', desc: 'Set metaphor theme (golf, gaming, dnd, etc.)' },
       { flag: '--interactive', desc: 'Rich interactive setup wizard' },
     ],
   },
   {
-    cmd: 'interview', desc: 'Run project interview (human or agent JSON mode)', category: 'lifecycle',
+    cmd: 'interview', desc: 'Run project interview (human or agent JSON mode)', category: 'lifecycle', audience: 'advanced',
     flags: [
       { flag: '--agent', desc: 'JSON I/O mode for agent harnesses' },
       { flag: '--force', desc: 'Re-interview even if project already initialized' },
     ],
   },
   {
-    cmd: 'help', desc: 'Show detailed per-command usage', category: 'lifecycle',
+    cmd: 'help', desc: 'Show detailed per-command usage', category: 'lifecycle', audience: 'human',
     flags: [{ flag: '<command>', desc: 'Command name to show details for' }],
   },
   {
-    cmd: 'quickstart', desc: 'Interactive tutorial for new users', category: 'lifecycle',
+    cmd: 'quickstart', desc: 'Interactive tutorial for new users', category: 'lifecycle', audience: 'human',
   },
   {
-    cmd: 'doctor', desc: 'Check repo health and auto-fix issues', category: 'lifecycle',
+    cmd: 'doctor', desc: 'Check repo health and auto-fix issues', category: 'lifecycle', audience: 'human',
     flags: [{ flag: '--fix', desc: 'Auto-fix detected issues' }],
   },
   {
-    cmd: 'version', desc: 'Show version or bump with automated PR workflow', category: 'lifecycle',
+    cmd: 'version', desc: 'Show version or bump with automated PR workflow', category: 'lifecycle', audience: 'advanced',
     subcommands: [
       { name: 'bump', desc: 'Bump version with automated PR workflow', flags: [
         { flag: '<version>', desc: 'Explicit version (e.g. 1.28.0)' },
@@ -72,7 +76,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'session', desc: 'Manage live sessions', category: 'lifecycle',
+    cmd: 'session', desc: 'Manage live sessions', category: 'lifecycle', audience: 'agent',
     subcommands: [
       { name: 'start', desc: 'Start a new session', flags: [
         { flag: '--role=<role>', desc: 'Session role (primary, secondary, observer)' },
@@ -93,7 +97,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'claim', desc: 'Claim a ticket or area for the sprint', category: 'lifecycle',
+    cmd: 'claim', desc: 'Claim a ticket or area for the sprint', category: 'lifecycle', audience: 'agent',
     flags: [
       { flag: '--target=<path>', desc: 'File or directory to claim' },
       { flag: '--ticket=<key>', desc: 'Ticket key (e.g. S48-1)' },
@@ -101,19 +105,19 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'release', desc: 'Release a claim by ID or target', category: 'lifecycle',
+    cmd: 'release', desc: 'Release a claim by ID or target', category: 'lifecycle', audience: 'agent',
     flags: [
       { flag: '--id=<id>', desc: 'Claim ID to release' },
       { flag: '--target=<path>', desc: 'Release claim by target path' },
     ],
   },
   {
-    cmd: 'status', desc: 'Show sprint course status and conflicts', category: 'lifecycle',
+    cmd: 'status', desc: 'Show sprint course status and conflicts', category: 'lifecycle', audience: 'human',
     flags: [{ flag: '--json', desc: 'Output as JSON' }],
   },
-  { cmd: 'next', desc: 'Show next sprint number (auto-detect)', category: 'lifecycle' },
+  { cmd: 'next', desc: 'Show next sprint number (auto-detect)', category: 'lifecycle', audience: 'advanced' },
   {
-    cmd: 'resume', desc: 'Portable sprint resume from tracked artifacts', category: 'lifecycle',
+    cmd: 'resume', desc: 'Portable sprint resume from tracked artifacts', category: 'lifecycle', audience: 'agent',
     flags: [
       { flag: '--from=<path>', desc: 'Resume pointer path (default: docs/backlog/.sprint-active.json)' },
       { flag: '--sprint=<N>', desc: 'Explicit sprint number when no pointer exists' },
@@ -123,7 +127,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'sprint', desc: 'Manage sprint lifecycle state and gates', category: 'lifecycle',
+    cmd: 'sprint', desc: 'Manage sprint lifecycle state and gates', category: 'lifecycle', audience: 'agent',
     subcommands: [
       { name: 'start', desc: 'Start a new sprint', flags: [
         { flag: '--number=<N>', desc: 'Sprint number (required)' },
@@ -150,7 +154,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
 
   // ── Scoring ────────────────────────────────────────────────────
   {
-    cmd: 'card', desc: 'Display handicap card', category: 'scoring',
+    cmd: 'card', desc: 'Display handicap card', category: 'scoring', audience: 'human',
     flags: [
       { flag: '--metaphor=<id>', desc: 'Display theme override' },
       { flag: '--player=<name>', desc: 'Filter to a specific player' },
@@ -159,14 +163,14 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'validate', desc: 'Validate scorecard(s)', category: 'scoring',
+    cmd: 'validate', desc: 'Validate scorecard(s)', category: 'scoring', audience: 'agent',
     flags: [
       { flag: '<path>', desc: 'Scorecard JSON file to validate' },
       { flag: '--skills', desc: 'Check scorecard skill references against .slope/skills.json' },
     ],
   },
   {
-    cmd: 'review', desc: 'Format sprint review or manage review state', category: 'scoring',
+    cmd: 'review', desc: 'Format sprint review or manage review state', category: 'scoring', audience: 'human',
     subcommands: [
       { name: 'start', desc: 'Start a plan review', flags: [
         { flag: '--tier=<tier>', desc: 'Review tier (skip, light, standard, deep)' },
@@ -194,7 +198,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'auto-card', desc: 'Generate scorecard from git + CI signals', category: 'scoring',
+    cmd: 'auto-card', desc: 'Generate scorecard from git + CI signals', category: 'scoring', audience: 'agent',
     flags: [
       { flag: '--sprint=<N>', desc: 'Sprint number (required)' },
       { flag: '--since=<date>', desc: 'Start date for git log' },
@@ -208,7 +212,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'classify', desc: 'Classify a shot from execution trace', category: 'scoring',
+    cmd: 'classify', desc: 'Classify a shot from execution trace', category: 'scoring', audience: 'agent',
     flags: [
       { flag: '--scope=<files>', desc: 'Comma-separated file scope' },
       { flag: '--modified=<files>', desc: 'Comma-separated modified files' },
@@ -218,7 +222,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'tournament', desc: 'Build tournament review from sprints', category: 'scoring',
+    cmd: 'tournament', desc: 'Build tournament review from sprints', category: 'scoring', audience: 'advanced',
     flags: [
       { flag: '--id=<id>', desc: 'Tournament identifier' },
       { flag: '--name=<name>', desc: 'Tournament display name' },
@@ -229,7 +233,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
 
   // ── Analysis ───────────────────────────────────────────────────
   {
-    cmd: 'briefing', desc: 'Pre-round briefing with hazards and nutrition', category: 'analysis',
+    cmd: 'briefing', desc: 'Pre-round briefing with hazards and nutrition', category: 'analysis', audience: 'human',
     flags: [
       { flag: '--categories=<list>', desc: 'Filter by issue categories (comma-separated)' },
       { flag: '--keywords=<list>', desc: 'Filter by keywords (comma-separated)' },
@@ -242,7 +246,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'plan', desc: 'Pre-shot advisor (club + training + hazards)', category: 'analysis',
+    cmd: 'plan', desc: 'Pre-shot advisor (club + training + hazards)', category: 'analysis', audience: 'agent',
     flags: [
       { flag: '--complexity=<level>', desc: 'Complexity (trivial, small, medium, large)' },
       { flag: '--slope-factors=<list>', desc: 'Comma-separated slope factors' },
@@ -251,14 +255,14 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'report', desc: 'Generate HTML performance report', category: 'analysis',
+    cmd: 'report', desc: 'Generate HTML performance report', category: 'analysis', audience: 'advanced',
     flags: [
       { flag: '--html', desc: 'Generate HTML report' },
       { flag: '--output=<path>', desc: 'Output file path' },
     ],
   },
   {
-    cmd: 'dashboard', desc: 'Live local performance dashboard', category: 'analysis',
+    cmd: 'dashboard', desc: 'Live local performance dashboard', category: 'analysis', audience: 'advanced',
     flags: [
       { flag: '--port=<N>', desc: 'HTTP port (default: 3000)' },
       { flag: '--no-open', desc: 'Don\'t auto-open browser' },
@@ -268,7 +272,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'standup', desc: 'Generate or ingest standup report', category: 'analysis',
+    cmd: 'standup', desc: 'Generate or ingest standup report', category: 'analysis', audience: 'agent',
     flags: [
       { flag: '--session=<id>', desc: 'Session ID for standup generation' },
       { flag: '--role=<id>', desc: 'Agent role filter' },
@@ -279,7 +283,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'analyze', desc: 'Scan repo and generate profile', category: 'analysis',
+    cmd: 'analyze', desc: 'Scan repo and generate profile', category: 'analysis', audience: 'advanced',
     flags: [
       { flag: '--analyzers=<list>', desc: 'Run specific analyzers (comma-separated: stack, git, etc.)' },
       { flag: '--json', desc: 'Output full profile as JSON' },
@@ -288,7 +292,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
 
   // ── Tooling ────────────────────────────────────────────────────
   {
-    cmd: 'hook', desc: 'Manage lifecycle hooks', category: 'tooling',
+    cmd: 'hook', desc: 'Manage lifecycle hooks', category: 'tooling', audience: 'internal',
     subcommands: [
       { name: 'add', desc: 'Install guard hooks', flags: [
         { flag: '--level=<level>', desc: 'Hook level (full, scoring)' },
@@ -301,7 +305,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'guard', desc: 'Run guard handler or manage guard activation', category: 'tooling',
+    cmd: 'guard', desc: 'Run guard handler or manage guard activation', category: 'tooling', audience: 'internal',
     subcommands: [
       { name: '<name>', desc: 'Run a guard (reads hook JSON from stdin)' },
       { name: 'list', desc: 'Show all available guards' },
@@ -319,7 +323,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'extract', desc: 'Extract events into SLOPE store', category: 'tooling',
+    cmd: 'extract', desc: 'Extract events into SLOPE store', category: 'tooling', audience: 'internal',
     flags: [
       { flag: '--file=<path>', desc: 'Event file to extract' },
       { flag: '--session-id=<id>', desc: 'Session ID to tag events' },
@@ -327,7 +331,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'distill', desc: 'Promote event patterns to common issues', category: 'tooling',
+    cmd: 'distill', desc: 'Promote event patterns to common issues', category: 'tooling', audience: 'agent',
     flags: [
       { flag: '--auto', desc: 'Auto-promote patterns above threshold' },
       { flag: '--dry-run', desc: 'Preview without writing' },
@@ -336,14 +340,14 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'map', desc: 'Generate/update codebase map', category: 'tooling',
+    cmd: 'map', desc: 'Generate/update codebase map', category: 'tooling', audience: 'agent',
     flags: [
       { flag: '--check', desc: 'Check staleness (exit 1 if stale)' },
       { flag: '--output=<path>', desc: 'Custom output path (default: CODEBASE.md)' },
     ],
   },
   {
-    cmd: 'workflow', desc: 'Manage workflow definitions', category: 'tooling',
+    cmd: 'workflow', desc: 'Manage workflow definitions', category: 'tooling', audience: 'internal',
     subcommands: [
       { name: 'validate', desc: 'Parse and validate a workflow definition' },
       { name: 'list', desc: 'List all available workflows (project + built-in)' },
@@ -351,7 +355,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'flows', desc: 'Manage user flow definitions', category: 'tooling',
+    cmd: 'flows', desc: 'Manage user flow definitions', category: 'tooling', audience: 'advanced',
     subcommands: [
       { name: 'init', desc: 'Create .slope/flows.json with example template' },
       { name: 'list', desc: 'List all flows with staleness indicators' },
@@ -359,7 +363,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'inspirations', desc: 'Track external OSS inspiration sources', category: 'tooling',
+    cmd: 'inspirations', desc: 'Track external OSS inspiration sources', category: 'tooling', audience: 'advanced',
     subcommands: [
       { name: 'add', desc: 'Add an inspiration source', flags: [
         { flag: '--url=<url>', desc: 'Source URL (required)' },
@@ -377,7 +381,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'skills', desc: 'Manage repo-local Agent Skills registry', category: 'tooling',
+    cmd: 'skills', desc: 'Manage repo-local Agent Skills registry', category: 'tooling', audience: 'advanced',
     subcommands: [
       { name: 'scan', desc: 'Scan configured skill roots into .slope/skills.json', flags: [
         { flag: '--root=<path>', desc: 'Skill root to scan (repeatable or comma-separated)' },
@@ -393,7 +397,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'issue', desc: 'Detect and triage SLOPE-driven product issues', category: 'tooling',
+    cmd: 'issue', desc: 'Detect and triage SLOPE-driven product issues', category: 'tooling', audience: 'agent',
     subcommands: [
       { name: 'scout', desc: 'Scan common issues/transcripts and propose GitHub issues', flags: [
         { flag: '--source=<path>', desc: 'File or directory to scan (repeatable)' },
@@ -414,7 +418,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'metaphor', desc: 'Manage metaphor display themes', category: 'tooling',
+    cmd: 'metaphor', desc: 'Manage metaphor display themes', category: 'tooling', audience: 'advanced',
     subcommands: [
       { name: 'list', desc: 'Show all available metaphors' },
       { name: 'set', desc: 'Set the active metaphor', flags: [
@@ -426,7 +430,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'plugin', desc: 'Manage custom plugins', category: 'tooling',
+    cmd: 'plugin', desc: 'Manage custom plugins', category: 'tooling', audience: 'advanced',
     subcommands: [
       { name: 'list', desc: 'Show all plugins (built-in + custom)' },
       { name: 'validate', desc: 'Validate a plugin file', flags: [
@@ -435,7 +439,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'store', desc: 'Store diagnostics and management', category: 'tooling',
+    cmd: 'store', desc: 'Store diagnostics and management', category: 'tooling', audience: 'internal',
     subcommands: [
       { name: 'status', desc: 'Show store type, schema version, and stats', flags: [
         { flag: '--json', desc: 'Output as JSON' },
@@ -446,7 +450,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'escalate', desc: 'Escalate issues based on severity triggers', category: 'tooling',
+    cmd: 'escalate', desc: 'Escalate issues based on severity triggers', category: 'tooling', audience: 'agent',
     flags: [
       { flag: '--reason=<text>', desc: 'Manual escalation reason' },
       { flag: '--session-id=<id>', desc: 'Session ID context' },
@@ -455,7 +459,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'transcript', desc: 'View session transcript data', category: 'tooling',
+    cmd: 'transcript', desc: 'View session transcript data', category: 'tooling', audience: 'internal',
     subcommands: [
       { name: 'list', desc: 'List available transcripts' },
       { name: 'show', desc: 'Show turn-by-turn summary', flags: [
@@ -469,7 +473,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
 
   // ── Planning ───────────────────────────────────────────────────
   {
-    cmd: 'roadmap', desc: 'Strategic planning and roadmap tools', category: 'planning',
+    cmd: 'roadmap', desc: 'Strategic planning and roadmap tools', category: 'planning', audience: 'human',
     subcommands: [
       { name: 'validate', desc: 'Schema + dependency graph checks', flags: [
         { flag: '--path=<file>', desc: 'Roadmap file path' },
@@ -494,7 +498,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'retro', desc: 'Retrospective scorecard utilities', category: 'planning',
+    cmd: 'retro', desc: 'Retrospective scorecard utilities', category: 'planning', audience: 'agent',
     subcommands: [
       { name: 'backfill', desc: 'Generate scorecard from git history (#318)', flags: [
         { flag: '--sprint=<N>', desc: 'Sprint number (or use --all-missing)' },
@@ -515,7 +519,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'vision', desc: 'Display project vision document', category: 'planning',
+    cmd: 'vision', desc: 'Display project vision document', category: 'planning', audience: 'human',
     subcommands: [
       { name: 'create', desc: 'Create a new vision document', flags: [
         { flag: '--purpose=<text>', desc: 'Project purpose' },
@@ -529,7 +533,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     flags: [{ flag: '--json', desc: 'Output as JSON' }],
   },
   {
-    cmd: 'initiative', desc: 'Multi-sprint initiative orchestration', category: 'planning',
+    cmd: 'initiative', desc: 'Multi-sprint initiative orchestration', category: 'planning', audience: 'advanced',
     subcommands: [
       { name: 'create', desc: 'Create a new initiative' },
       { name: 'status', desc: 'Show current initiative state' },
@@ -547,7 +551,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
 
   // ── Loop ─────────────────────────────────────────────
   {
-    cmd: 'loop', desc: 'Autonomous sprint execution loop', category: 'tooling',
+    cmd: 'loop', desc: 'Autonomous sprint execution loop', category: 'tooling', audience: 'advanced',
     subcommands: [
       { name: 'run', desc: 'Single sprint execution', flags: [
         { flag: '--sprint=<ID>', desc: 'Sprint ID to execute' },
@@ -594,7 +598,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
   },
 
   {
-    cmd: 'worktree', desc: 'Manage git worktrees', category: 'tooling',
+    cmd: 'worktree', desc: 'Manage git worktrees', category: 'tooling', audience: 'agent',
     subcommands: [
       { name: 'status', desc: 'Show sibling worktree dirty/ahead/migration state', flags: [
         { flag: '--base=<ref>', desc: 'Base ref for ahead/behind and changed-file detection' },
@@ -610,7 +614,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
 
   // ── Indexing ──────────────────────────────────────────────────────
   {
-    cmd: 'index-cmd', desc: 'Semantic embedding index management', category: 'tooling',
+    cmd: 'index-cmd', desc: 'Semantic embedding index management', category: 'tooling', audience: 'internal',
     flags: [
       { flag: '--full', desc: 'Full reindex (drop + rebuild)' },
       { flag: '--status', desc: 'Show index stats' },
@@ -619,7 +623,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'context', desc: 'Semantic context search for agents', category: 'tooling',
+    cmd: 'context', desc: 'Semantic context search for agents', category: 'tooling', audience: 'agent',
     flags: [
       { flag: '<query>', desc: 'Free-text semantic search query' },
       { flag: '--ticket=<key>', desc: 'Use ticket title as query' },
@@ -629,7 +633,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'prep', desc: 'Generate execution plan for a ticket', category: 'tooling',
+    cmd: 'prep', desc: 'Generate execution plan for a ticket', category: 'tooling', audience: 'agent',
     flags: [
       { flag: '<ticket-id>', desc: 'Ticket ID to prepare' },
       { flag: '--json', desc: 'Output as JSON' },
@@ -638,7 +642,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'enrich', desc: 'Batch-enrich backlog with file context', category: 'tooling',
+    cmd: 'enrich', desc: 'Batch-enrich backlog with file context', category: 'tooling', audience: 'agent',
     flags: [
       { flag: '<backlog-path>', desc: 'Path to backlog file' },
       { flag: '--output=<path>', desc: 'Output path for enriched backlog' },
@@ -647,7 +651,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'stats', desc: 'Export stats JSON for slope-web live dashboard', category: 'tooling',
+    cmd: 'stats', desc: 'Export stats JSON for slope-web live dashboard', category: 'tooling', audience: 'internal',
     subcommands: [
       { name: 'export', desc: 'Compute SlopeStats JSON from local scorecards + registries', flags: [
         { flag: '--pretty', desc: 'Pretty-print JSON output' },
@@ -656,7 +660,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'docs', desc: 'Generate documentation manifest and changelog', category: 'tooling',
+    cmd: 'docs', desc: 'Generate documentation manifest and changelog', category: 'tooling', audience: 'agent',
     subcommands: [
       { name: 'generate', desc: 'Build manifest JSON from registries + git history', flags: [
         { flag: '--output=<path>', desc: 'Write manifest to path (default: .slope/docs.json)' },
@@ -680,7 +684,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'org', desc: 'Multi-repo aggregation and org-level metrics', category: 'analysis',
+    cmd: 'org', desc: 'Multi-repo aggregation and org-level metrics', category: 'analysis', audience: 'advanced',
     subcommands: [
       { name: 'init', desc: 'Create .slope/org.json template' },
       { name: 'status', desc: 'Show all repos with handicaps and sprint counts', flags: [
@@ -692,7 +696,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'memory', desc: 'Cross-session memory management', category: 'analysis',
+    cmd: 'memory', desc: 'Cross-session memory management', category: 'analysis', audience: 'advanced',
     subcommands: [
       { name: 'add', desc: 'Add a memory', flags: [
         { flag: '--category=<cat>', desc: 'Category: workflow, style, project, hazard, other' },
@@ -713,7 +717,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'agent', desc: 'Machine-readable operational primitives for AI agents', category: 'tooling',
+    cmd: 'agent', desc: 'Machine-readable operational primitives for AI agents', category: 'tooling', audience: 'agent',
     subcommands: [
       { name: 'status', desc: 'Show current state (human or JSON)', flags: [
         { flag: '--json', desc: 'Emit AgentStatus JSON' },
@@ -724,7 +728,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'ticket', desc: 'Per-ticket lifecycle commands', category: 'lifecycle',
+    cmd: 'ticket', desc: 'Per-ticket lifecycle commands', category: 'lifecycle', audience: 'agent',
     subcommands: [
       { name: 'done', desc: 'Mark ticket complete; release claim', flags: [
         { flag: '<key>', desc: 'Ticket key (e.g. S1-1)' },
@@ -734,14 +738,14 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'commit-ready', desc: 'Pre-commit checklist for agents', category: 'tooling',
+    cmd: 'commit-ready', desc: 'Pre-commit checklist for agents', category: 'tooling', audience: 'agent',
     flags: [
       { flag: '--json', desc: 'Emit CommitReadyResult JSON' },
       { flag: '--strict', desc: 'Exit non-zero when blockers exist' },
     ],
   },
   {
-    cmd: 'gate', desc: 'Initiative review gate aliases (agent-friendly)', category: 'tooling',
+    cmd: 'gate', desc: 'Initiative review gate aliases (agent-friendly)', category: 'tooling', audience: 'agent',
     subcommands: [
       { name: 'status', desc: 'Pending plan/pr gates per sprint', flags: [
         { flag: '--json', desc: 'Emit pending list as JSON' },
@@ -759,7 +763,7 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     ],
   },
   {
-    cmd: 'pr', desc: 'Pull request helpers (auto-close, finalize, closeout)', category: 'tooling',
+    cmd: 'pr', desc: 'Pull request helpers (auto-close, finalize, closeout)', category: 'tooling', audience: 'agent',
     subcommands: [
       { name: 'finalize', desc: 'Inject Closes #N for issue refs in commit messages (#321)', flags: [
         { flag: '--pr=<N>', desc: 'PR number (default: resolved from current branch)' },

--- a/tests/cli/commands/help.test.ts
+++ b/tests/cli/commands/help.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { helpCommand, printDefaultHelp } from '../../../src/cli/commands/help.js';
+
+let consoleOutput: string[];
+let consoleErrors: string[];
+
+beforeEach(() => {
+  consoleOutput = [];
+  consoleErrors = [];
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    consoleOutput.push(args.map(String).join(' '));
+  });
+  vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    consoleErrors.push(args.map(String).join(' '));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('slope help', () => {
+  it('prints a bounded human surface by default', async () => {
+    await helpCommand([]);
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('SLOPE - Human Command Surface');
+    expect(output).toContain('briefing');
+    expect(output).toContain('review');
+    expect(output).toContain('doctor');
+    expect(output).toContain('roadmap');
+    expect(output).toContain('slope help --all');
+    expect(output).not.toContain('claim');
+    expect(output).not.toContain('guard');
+    expect(output).not.toContain('auto-card');
+    expect(output.split('\n').length).toBeLessThanOrEqual(25);
+  });
+
+  it('uses the same bounded surface for global help rendering', () => {
+    printDefaultHelp();
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('SLOPE - Human Command Surface');
+    expect(output).not.toContain('Full Command Reference');
+  });
+
+  it('shows the full registry with audience labels behind --all', async () => {
+    await helpCommand(['--all']);
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('SLOPE CLI - Full Command Reference');
+    expect(output).toContain('claim');
+    expect(output).toContain('[agent]');
+    expect(output).toContain('guard');
+    expect(output).toContain('[internal]');
+    expect(output).toContain('Run `slope help` for the bounded human surface');
+  });
+
+  it('shows command detail with audience metadata', async () => {
+    await helpCommand(['claim']);
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('slope claim');
+    expect(output).toContain('Category: lifecycle');
+    expect(output).toContain('Audience: agent');
+    expect(output).toContain('--target=<path>');
+  });
+
+  it('teaches the --all escape hatch in help usage', async () => {
+    await helpCommand(['--help']);
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('slope help --all');
+    expect(output).toContain('bounded human command surface');
+  });
+});

--- a/tests/cli/registry.test.ts
+++ b/tests/cli/registry.test.ts
@@ -20,6 +20,33 @@ describe('CLI_COMMAND_REGISTRY', () => {
     }
   });
 
+  it('every entry has valid audience metadata', () => {
+    const validAudiences = ['human', 'agent', 'advanced', 'internal'];
+    for (const entry of CLI_COMMAND_REGISTRY) {
+      expect(validAudiences).toContain(entry.audience);
+    }
+  });
+
+  it('keeps the human command surface intentional and bounded', () => {
+    const humanCommands = CLI_COMMAND_REGISTRY
+      .filter(entry => entry.audience === 'human')
+      .map(entry => entry.cmd)
+      .sort();
+
+    expect(humanCommands).toEqual([
+      'briefing',
+      'card',
+      'doctor',
+      'help',
+      'init',
+      'quickstart',
+      'review',
+      'roadmap',
+      'status',
+      'vision',
+    ]);
+  });
+
   it('every entry has non-empty cmd and desc', () => {
     for (const entry of CLI_COMMAND_REGISTRY) {
       expect(entry.cmd.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Add audience metadata (`human`, `agent`, `advanced`, `internal`) across the CLI command registry.
- Bound the default human help surface for `slope`, `slope --help`, and `slope help`; keep the full registry available via `slope help --all`.
- Show command audiences in detailed/full help, update docs, and record S150 closeout.

## Validation
- `corepack pnpm vitest run tests/cli/registry.test.ts tests/cli/commands/help.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test`
- `node dist/cli/index.js help`
- `node dist/cli/index.js help --all`
- `node dist/cli/index.js --help`
- `node dist/cli/index.js unknown-command`
- `node dist/cli/index.js`
- `node dist/cli/index.js validate docs/retros/sprint-150.json`
- `node dist/cli/index.js docs check`
- `node dist/cli/index.js roadmap validate` (expected branch-local warning: S150 complete but not yet on main)
- `node dist/cli/index.js map --check`
- `git diff --check HEAD`