### PR TITLE
S151: add skill-first human cockpit commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Default help is intentionally small:
 
 | Command | Description |
 |---------|-------------|
+| `npx slope now` | Compact current-state cockpit: current sprint, state, claims, next action |
+| `npx slope start [--ticket=KEY]` | Start or begin work without exposing sprint/claim plumbing |
 | `npx slope help` | Human command surface for daily work, setup, and direction |
 | `npx slope help <command>` | Detailed usage for one command |
 | `npx slope help --all` | Full command registry with audience labels |
@@ -297,6 +299,8 @@ orchestrate the rest of the CLI as execution primitives.
 
 | Command | Description |
 |---------|-------------|
+| `npx slope now` | Compact current-state cockpit |
+| `npx slope start [--ticket=KEY]` | Start sprint state or begin a ticket with briefing, claim, prep, and next gates |
 | `npx slope briefing` | Pre-sprint hazard index, nutrition alerts, filtered gotchas |
 | `npx slope plan --complexity=<level>` | Club recommendation + training plan |
 | `npx slope next` | Show next sprint number |

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -347,7 +347,8 @@
         148,
         149,
         150,
-        151
+        151,
+        151.1
       ],
       "status": "planned",
       "note": "Plan and implement the higher-level SLOPE operating surface so humans see a small, memorable cockpit while agents and skills orchestrate the deeper CLI/MCP execution framework."
@@ -4453,6 +4454,35 @@
           "depends_on": [
             "S151-2",
             "S151-3"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 151.1,
+      "theme": "Windows Git Analyzer Timeout Hardening",
+      "par": 3,
+      "slope": 2,
+      "type": "test hardening",
+      "status": "planned",
+      "depends_on": [
+        151
+      ],
+      "note": "Close #544 by making the git analyzer daily-cadence regression deterministic under Windows/local CPU contention before the next release-validation loop depends on the full suite.",
+      "tickets": [
+        {
+          "key": "S151.1-1",
+          "title": "Remove wall-clock sensitivity from the git analyzer daily-cadence fixture (#544)",
+          "club": "short_iron",
+          "complexity": "standard"
+        },
+        {
+          "key": "S151.1-2",
+          "title": "Validate focused git analyzer and full-suite behavior for #544",
+          "club": "wedge",
+          "complexity": "small",
+          "depends_on": [
+            "S151.1-1"
           ]
         }
       ]

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -4415,7 +4415,7 @@
       "par": 4,
       "slope": 3,
       "type": "workflow + cli surface",
-      "status": "planned",
+      "status": "complete",
       "depends_on": [
         150
       ],

--- a/docs/backlog/sprint-148-human-surface-simplification.md
+++ b/docs/backlog/sprint-148-human-surface-simplification.md
@@ -292,6 +292,17 @@ Tickets:
   sprint execution explicitly hide CLI plumbing from humans.
 - `S151-4`: Add end-to-end tests or transcript fixtures for the cockpit flows.
 
+S151 Implementation Note:
+
+- `slope now` is the compact current-state cockpit: current sprint, phase,
+  sprint state, claims, next action, and the `slope start --ticket=...` move.
+- `slope start` is the human start-of-work entry. Without a ticket it starts or
+  refreshes sprint state and prints a compact briefing; with a ticket it routes
+  to the bundled sprint begin flow for claim, briefing, prep, and gates.
+- Repo skill guidance now maps human asks like release, PR review, issue
+  triage, sprint execution, and retro capture to outcome-oriented workflows
+  while leaving raw CLI plumbing as agent primitives.
+
 ## Non-Goals Reaffirmed
 
 - Do not remove existing commands in this phase.

--- a/docs/backlog/sprint-148-human-surface-simplification.md
+++ b/docs/backlog/sprint-148-human-surface-simplification.md
@@ -303,6 +303,18 @@ S151 Implementation Note:
   triage, sprint execution, and retro capture to outcome-oriented workflows
   while leaving raw CLI plumbing as agent primitives.
 
+### S151.1 - Windows Git Analyzer Timeout Hardening
+
+Purpose: repair the validation issue raised as #544 during S151 closeout, where
+the git analyzer daily-cadence fixture exceeded hard-coded Windows timeouts
+under local CPU contention.
+
+Tickets:
+
+- `S151.1-1`: Remove wall-clock sensitivity from the git analyzer
+  daily-cadence fixture.
+- `S151.1-2`: Validate focused git analyzer and full-suite behavior for #544.
+
 ## Non-Goals Reaffirmed
 
 - Do not remove existing commands in this phase.

--- a/docs/retros/sprint-151.json
+++ b/docs/retros/sprint-151.json
@@ -1,0 +1,156 @@
+{
+  "sprint_number": 151,
+  "player": "codex",
+  "theme": "Skill-First Human Cockpit Implementation",
+  "par": 4,
+  "slope": 3,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-06-08",
+  "type": "workflow + cli surface",
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow"
+  ],
+  "skill_gaps_found": [],
+  "shots": [
+    {
+      "ticket_key": "S151-1",
+      "title": "Implement a compact slope now current-state cockpit",
+      "club": "long_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added `slope now` as a compact human cockpit that reports current sprint, roadmap phase, sprint state, active claims, next ticket, and the next `slope start --ticket=...` move. JSON output is available for agents."
+    },
+    {
+      "ticket_key": "S151-2",
+      "title": "Implement a start or sprint-begin entry that coordinates briefing, sprint state, and claim guidance",
+      "club": "long_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added top-level `slope start`; without a ticket it starts or refreshes sprint state and prints compact briefing, while `--ticket=KEY` delegates to the existing bundled sprint begin flow for claim, briefing, prep, and gates."
+    },
+    {
+      "ticket_key": "S151-3",
+      "title": "Update skills so release, PR review, issue triage, retro, and sprint execution hide CLI plumbing",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The first pass edited ignored local `.agents/` skill files; durable project guidance had to move into tracked README, backlog notes, and generated agent templates."
+        }
+      ],
+      "notes": "Updated README, the Phase 47 backlog note, generated CLAUDE/AGENTS/Cursor templates, and template tests so human asks map to outcome-oriented workflows while agents keep using raw CLI primitives internally."
+    },
+    {
+      "ticket_key": "S151-4",
+      "title": "Add end-to-end tests or transcript fixtures for cockpit workflows",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Added command-level tests for `slope now`, `slope start`, help/registry guardrails, and generated template guidance. A focused test caught the accidental removal of `slope briefing` from generic checklist guidance before commit."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0.5,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "rough",
+      "impact": "minor",
+      "description": "S151 changed command registry metadata, so docs manifest generation was required before `docs check` could pass."
+    },
+    {
+      "type": "wind",
+      "impact": "minor",
+      "description": "CODEBASE.md is ignored in this repository; `slope map` refreshed local map state and `map --check` passed with the new command/file counts."
+    },
+    {
+      "type": "rough",
+      "impact": "minor",
+      "description": "Roadmap closeout initially changed the Phase 47 status instead of the S151 sprint status; `roadmap validate` caught it before commit."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "A human cockpit command should summarize what to do next, not reveal the whole lifecycle state machine.",
+      "outcome": "`slope now` and `slope start` sit on top of roadmap, sprint-state, briefing, claim, and prep primitives."
+    },
+    {
+      "type": "lessons",
+      "description": "Local `.agents/` skills are ignored; durable generated guidance belongs in tracked template source.",
+      "outcome": "The template generator now emits cockpit-first project guidance for CLAUDE.md, AGENTS.md, Cursor/Windsurf rules, and generic checklists."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "`corepack pnpm vitest run tests/cli/template-generator.test.ts tests/cli/commands/now.test.ts tests/cli/commands/start.test.ts tests/cli/commands/help.test.ts tests/cli/registry.test.ts` passed: 36 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`corepack pnpm typecheck` and `corepack pnpm build` passed before closeout.",
+      "status": "healthy"
+    },
+    {
+      "category": "cli",
+      "description": "Compiled CLI smokes passed for `slope now`, `slope now --json`, `slope start --help`, and bounded `slope help`.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "`node dist/cli/index.js docs generate --pretty`, `docs check`, `roadmap validate`, and `map --check` passed with expected historical roadmap warnings.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A clean surface pass with one useful trap: the human cockpit is tiny, but making it durable means touching the generated guidance, not just the local skill copy.",
+    "advice_for_next_player": "Keep `slope now` as the front door. If the next phase adds more human workflows, build them as aliases over proven primitives instead of exposing more command inventory.",
+    "what_surprised_you": "The repo's live `.agents/` skill files are intentionally ignored, so template source is the real shipped skill-guidance surface.",
+    "excited_about_next": "The Phase 47 human surface lane is now almost done; the next work can decide whether to ship tracked official skills or keep skills as generated/local artifacts."
+  },
+  "bunker_locations": [
+    "Human-facing commands should not leak claim/session/gate plumbing unless the user explicitly asks for it.",
+    "Generated agent templates must be updated when human workflow guidance changes; ignored local skill edits are not enough.",
+    "Generic workflow guidance should keep `slope briefing` available as deeper context even when `slope now` and `slope start` become the front door.",
+    "Roadmap JSON edits need exact sprint-level context because phase and sprint entries both carry `status` fields."
+  ],
+  "yardage_book_updates": [
+    "src/cli/commands/now.ts now implements the compact current-state cockpit.",
+    "src/cli/commands/start.ts now implements the human start-of-work entry and delegates ticket starts to sprint begin.",
+    "src/cli/template-generator.ts now emits cockpit-first guidance for generated project contexts.",
+    "README.md and docs/backlog/sprint-148-human-surface-simplification.md document the S151 contract."
+  ],
+  "course_management_notes": [
+    "S151 completes the planned skill-first human cockpit sprint.",
+    "The command registry now contains 61 commands, with `now` and `start` added to the bounded human surface.",
+    "No new GitHub issue was raised; the ignored `.agents/` discovery was resolved within S151 by updating tracked template source."
+  ],
+  "slope_factors": [
+    "cli_surface",
+    "workflow_alias",
+    "generated_agent_guidance",
+    "human_output_budget",
+    "documentation_manifest"
+  ]
+}

--- a/docs/retros/sprint-151.json
+++ b/docs/retros/sprint-151.json
@@ -121,6 +121,11 @@
       "category": "docs",
       "description": "`node dist/cli/index.js docs generate --pretty`, `docs check`, `roadmap validate`, and `map --check` passed with expected historical roadmap warnings.",
       "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "Full local `corepack pnpm test` did not complete under Windows CPU contention; focused investigation isolated existing git analyzer timeout issue #544 and triaged it to S151.1.",
+      "status": "warning"
     }
   ],
   "nineteenth_hole": {
@@ -144,7 +149,8 @@
   "course_management_notes": [
     "S151 completes the planned skill-first human cockpit sprint.",
     "The command registry now contains 61 commands, with `now` and `start` added to the bounded human surface.",
-    "No new GitHub issue was raised; the ignored `.agents/` discovery was resolved within S151 by updating tracked template source."
+    "Raised #544 from full-suite validation timeout in `tests/core/analyzers/git.test.ts` and triaged it into S151.1.",
+    "The ignored `.agents/` discovery was resolved within S151 by updating tracked template source."
   ],
   "slope_factors": [
     "cli_surface",

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -39,6 +39,8 @@ Usage:
 }
 
 const HUMAN_HELP_ORDER = [
+  'now',
+  'start',
   'briefing',
   'review',
   'doctor',
@@ -61,13 +63,13 @@ export function printDefaultHelp(): void {
   const byName = new Map(CLI_COMMAND_REGISTRY.map(cmd => [cmd.cmd, cmd]));
   console.log('\nSLOPE - Human Command Surface\n');
   console.log('Daily work:');
-  for (const name of HUMAN_HELP_ORDER.slice(0, 6)) {
+  for (const name of HUMAN_HELP_ORDER.slice(0, 8)) {
     const cmd = byName.get(name);
     if (cmd) printCommandRow(cmd, 4);
   }
 
   console.log('\nSetup and direction:');
-  for (const name of HUMAN_HELP_ORDER.slice(6)) {
+  for (const name of HUMAN_HELP_ORDER.slice(8)) {
     const cmd = byName.get(name);
     if (cmd) printCommandRow(cmd, 4);
   }

--- a/src/cli/commands/now.ts
+++ b/src/cli/commands/now.ts
@@ -1,0 +1,184 @@
+import { formatSprintLabel, formatSprintNumber, isRoadmapSprintPending, loadScorecards, parseSprintNumber } from '../../core/index.js';
+import type { RoadmapDefinition, RoadmapSprint, RoadmapTicket, SprintClaim } from '../../core/index.js';
+import { loadConfig } from '../config.js';
+import { inferSprintContext, loadRoadmapForInference } from '../sprint-inference.js';
+import { loadSprintState, pendingGates } from '../sprint-state.js';
+import { resolveStore } from '../store.js';
+
+interface NowSnapshot {
+  sprint: number;
+  sprintLabel: string;
+  source: string;
+  roadmap?: {
+    name: string;
+    theme?: string;
+    phase?: string;
+    phaseProgress?: string;
+    status: string;
+  };
+  sprintState?: {
+    phase: string;
+    pendingGates: string[];
+  };
+  claims: {
+    total: number;
+    ticketClaims: number;
+  };
+  nextAction: string;
+  nextTicket?: RoadmapTicket;
+}
+
+function parseArgs(args: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const arg of args) {
+    const match = arg.match(/^--(\w[\w-]*)(?:=(.+))?$/);
+    if (match) result[match[1]] = match[2] ?? 'true';
+  }
+  return result;
+}
+
+function sprintStatus(sprint: RoadmapSprint | undefined, completed: Set<number>, currentSprint: number): string {
+  if (!sprint) return 'not in roadmap';
+  const explicit = (sprint as RoadmapSprint & { status?: string }).status;
+  if (explicit === 'superseded') return 'superseded';
+  if (explicit === 'complete' || completed.has(sprint.id)) return 'complete';
+  if (sprint.id === currentSprint) return 'active';
+  if (isRoadmapSprintPending(sprint)) return 'pending';
+  return explicit ?? 'unknown';
+}
+
+function isTerminal(sprint: RoadmapSprint, completed: Set<number>): boolean {
+  const explicit = (sprint as RoadmapSprint & { status?: string }).status;
+  return explicit === 'complete' || explicit === 'superseded' || completed.has(sprint.id);
+}
+
+function formatPhaseProgress(roadmap: RoadmapDefinition, sprint: number, completed: Set<number>): { name: string; progress: string } | undefined {
+  const phase = roadmap.phases.find(p => p.sprints.includes(sprint));
+  if (!phase) return undefined;
+  const phaseSprints = roadmap.sprints.filter(s => phase.sprints.includes(s.id));
+  const completedCount = phaseSprints.filter(s => isTerminal(s, completed)).length;
+  return {
+    name: phase.name,
+    progress: `${completedCount}/${phaseSprints.length}`,
+  };
+}
+
+function findNextTicket(sprint: RoadmapSprint | undefined, claims: SprintClaim[]): RoadmapTicket | undefined {
+  if (!sprint) return undefined;
+  const claimedTargets = new Set(claims.map(c => c.target));
+  return sprint.tickets.find(ticket => !claimedTargets.has(ticket.key)) ?? sprint.tickets[0];
+}
+
+function buildNextAction(snapshot: Omit<NowSnapshot, 'nextAction'>): string {
+  if (!snapshot.roadmap) {
+    return 'Run slope init or slope roadmap status to establish project direction.';
+  }
+  if (snapshot.nextTicket) {
+    return `Start ${snapshot.nextTicket.key}: ${snapshot.nextTicket.title}`;
+  }
+  if (snapshot.sprintState && snapshot.sprintState.pendingGates.length > 0) {
+    return `Clear pending gates: ${snapshot.sprintState.pendingGates.join(', ')}`;
+  }
+  return `Review ${snapshot.sprintLabel} and prepare closeout.`;
+}
+
+async function buildNowSnapshot(cwd: string, flags: Record<string, string>): Promise<NowSnapshot> {
+  const config = loadConfig(cwd);
+  const inferred = inferSprintContext(cwd, config);
+  const parsedSprint = flags.sprint ? parseSprintNumber(flags.sprint) : inferred.sprint;
+  if (parsedSprint == null) {
+    throw new Error(`Invalid sprint number: ${flags.sprint}`);
+  }
+  const sprint = parsedSprint;
+  const sprintLabel = formatSprintLabel(sprint);
+  const roadmap = loadRoadmapForInference(cwd, config) ?? undefined;
+  const scorecards = loadScorecards(config, cwd);
+  const completed = new Set(scorecards.map(card => card.sprint_number));
+  const current = roadmap?.sprints.find(s => s.id === sprint);
+  const phase = roadmap ? formatPhaseProgress(roadmap, sprint, completed) : undefined;
+  const state = loadSprintState(cwd);
+
+  const store = await resolveStore(cwd);
+  let claims: SprintClaim[];
+  try {
+    claims = await store.list(sprint);
+  } finally {
+    store.close();
+  }
+
+  const partial: Omit<NowSnapshot, 'nextAction'> = {
+    sprint,
+    sprintLabel,
+    source: flags.sprint ? 'flag' : inferred.source,
+    roadmap: roadmap ? {
+      name: roadmap.name,
+      theme: current?.theme,
+      phase: phase?.name,
+      phaseProgress: phase?.progress,
+      status: sprintStatus(current, completed, sprint),
+    } : undefined,
+    sprintState: state?.sprint === sprint ? {
+      phase: state.phase,
+      pendingGates: pendingGates(state),
+    } : undefined,
+    claims: {
+      total: claims.length,
+      ticketClaims: claims.filter(c => c.scope === 'ticket').length,
+    },
+    nextTicket: findNextTicket(current, claims),
+  };
+
+  return {
+    ...partial,
+    nextAction: buildNextAction(partial),
+  };
+}
+
+function printNowSnapshot(snapshot: NowSnapshot): void {
+  console.log('\nSLOPE Now');
+  console.log('='.repeat(32));
+  const theme = snapshot.roadmap?.theme ? ` - ${snapshot.roadmap.theme}` : '';
+  console.log(`Current: ${snapshot.sprintLabel}${theme}`);
+  if (snapshot.roadmap?.phase) {
+    const progress = snapshot.roadmap.phaseProgress ? ` (${snapshot.roadmap.phaseProgress})` : '';
+    console.log(`Phase: ${snapshot.roadmap.phase}${progress}`);
+  }
+  console.log(`Roadmap: ${snapshot.roadmap?.status ?? 'not found'} (${snapshot.source})`);
+  console.log(`Sprint state: ${snapshot.sprintState?.phase ?? 'not started'}`);
+  console.log(`Claims: ${snapshot.claims.total} active, ${snapshot.claims.ticketClaims} ticket`);
+  console.log(`Next: ${snapshot.nextAction}`);
+  if (snapshot.nextTicket) {
+    console.log(`Start: slope start --ticket=${snapshot.nextTicket.key}`);
+  }
+  console.log(`More: slope roadmap status --sprint=${formatSprintNumber(snapshot.sprint)}\n`);
+}
+
+function printUsage(): void {
+  console.log(`
+slope now - Compact current-state cockpit
+
+Usage:
+  slope now [--sprint=N] [--json]
+
+Shows the current sprint, phase, sprint state, claim count, and next human action.
+`);
+}
+
+export async function nowCommand(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const flags = parseArgs(args);
+  const snapshot = await buildNowSnapshot(process.cwd(), flags);
+  if (flags.json === 'true') {
+    console.log(JSON.stringify(snapshot, null, 2));
+    return;
+  }
+  printNowSnapshot(snapshot);
+}
+
+export const testInternals = {
+  buildNowSnapshot,
+};

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -1,0 +1,62 @@
+import { formatSprintNumber, parseSprintNumber } from '../../core/index.js';
+import { briefingCommand } from './briefing.js';
+import { sprintCommand } from './sprint.js';
+import { loadConfig } from '../config.js';
+import { inferSprintContext } from '../sprint-inference.js';
+
+function parseArgs(args: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const arg of args) {
+    const match = arg.match(/^--(\w[\w-]*)(?:=(.+))?$/);
+    if (match) result[match[1]] = match[2] ?? 'true';
+  }
+  return result;
+}
+
+function resolveSprint(flags: Record<string, string>): number {
+  if (flags.sprint) {
+    const parsed = parseSprintNumber(flags.sprint);
+    if (parsed == null) {
+      console.error(`Invalid sprint number: ${flags.sprint}`);
+      process.exit(1);
+    }
+    return parsed;
+  }
+  return inferSprintContext(process.cwd(), loadConfig(process.cwd())).sprint;
+}
+
+function printUsage(): void {
+  console.log(`
+slope start - Human start-of-work cockpit
+
+Usage:
+  slope start [--sprint=N]
+  slope start --ticket=KEY [--sprint=N]
+
+Without --ticket, starts or refreshes sprint state and prints a compact briefing.
+With --ticket, runs the bundled begin flow: sprint state, claim, briefing, prep, and next gates.
+`);
+}
+
+export async function startCommand(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const flags = parseArgs(args);
+  const sprint = resolveSprint(flags);
+  const sprintText = formatSprintNumber(sprint);
+  const ticket = flags.ticket;
+
+  if (ticket) {
+    await sprintCommand(['begin', `--sprint=${sprintText}`, `--ticket=${ticket}`]);
+    return;
+  }
+
+  await sprintCommand(['start', `--number=${sprintText}`, '--phase=implementing']);
+  console.log('\nBriefing');
+  console.log('='.repeat(32));
+  await briefingCommand([`--sprint=${sprintText}`, '--compact']);
+  console.log(`Next: run slope start --ticket=<key> to claim work, or slope now to inspect the cockpit.\n`);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -71,6 +71,8 @@ import { doctorCommand } from './commands/doctor.js';
 import { versionCommand } from './commands/version.js';
 import { helpCommand, printDefaultHelp } from './commands/help.js';
 import { quickstartCommand } from './commands/quickstart.js';
+import { nowCommand } from './commands/now.js';
+import { startCommand } from './commands/start.js';
 import { worktreeCommand } from './commands/worktree.js';
 import { orgCommand } from './commands/org.js';
 import { memoryCommand } from './commands/memory.js';
@@ -298,6 +300,12 @@ switch (subcommand) {
     break;
   case 'quickstart':
     quickstartCommand(process.argv.slice(3)).catch(reportCliError);
+    break;
+  case 'now':
+    nowCommand(process.argv.slice(3)).catch(reportCliError);
+    break;
+  case 'start':
+    startCommand(process.argv.slice(3)).catch(reportCliError);
     break;
   case 'worktree':
     worktreeCommand(process.argv.slice(3)).catch(reportCliError);

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -57,6 +57,20 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
     flags: [{ flag: '<command>', desc: 'Command name to show details for' }],
   },
   {
+    cmd: 'now', desc: 'Compact current-state cockpit', category: 'lifecycle', audience: 'human',
+    flags: [
+      { flag: '--sprint=<N>', desc: 'Override inferred current sprint' },
+      { flag: '--json', desc: 'Output as JSON' },
+    ],
+  },
+  {
+    cmd: 'start', desc: 'Human start-of-work cockpit', category: 'lifecycle', audience: 'human',
+    flags: [
+      { flag: '--sprint=<N>', desc: 'Override inferred current sprint' },
+      { flag: '--ticket=<key>', desc: 'Claim and begin a ticket' },
+    ],
+  },
+  {
     cmd: 'quickstart', desc: 'Interactive tutorial for new users', category: 'lifecycle', audience: 'human',
   },
   {
@@ -134,6 +148,10 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
         { flag: '--phase=<phase>', desc: 'Initial phase (default: planning)' },
         { flag: '--touches=<paths>', desc: 'Comma-separated paths to check against sibling worktrees' },
         { flag: '--force', desc: 'Override pre-sprint reality-check blockers' },
+      ]},
+      { name: 'begin', desc: 'Bundled start + claim + briefing + prep flow', flags: [
+        { flag: '--sprint=<N>', desc: 'Sprint number (required)' },
+        { flag: '--ticket=<key>', desc: 'Ticket key to claim and prep' },
       ]},
       { name: 'gate', desc: 'Mark a gate as complete', flags: [
         { flag: '<name>', desc: 'Gate name to complete' },

--- a/src/cli/template-generator.ts
+++ b/src/cli/template-generator.ts
@@ -28,6 +28,8 @@ export function generateProjectContext(m: MetaphorDefinition): string {
 This project uses the SLOPE framework for sprint tracking.
 
 ## Commands
+- \`slope now\` — compact current-state cockpit
+- \`slope start [--ticket=KEY]\` — human start-of-work entry
 - \`slope card\` — view ${r.handicapCard.toLowerCase()}
 - \`slope validate\` — validate ${r.scorecard.toLowerCase()}s
 - \`slope review\` — generate sprint review
@@ -39,9 +41,14 @@ A SLOPE MCP server is configured in \`.mcp.json\`. Two tools:
 - \`execute\` — run JS with full SLOPE API in sandbox
 
 ## Sprint Workflow
-- **Pre-${r.sprint}:** \`slope briefing\` for handicap, hazards, gotchas
+- **Pre-${r.sprint}:** \`slope now\`, then \`slope start\` or \`slope start --ticket=KEY\`
 - **Per-${r.ticket}:** classify each ticket with approach + result + hazards
 - **Post-${r.sprint}:** \`slope validate\` ${r.scorecard.toLowerCase()}, \`slope review\`, update common-issues
+
+## Human Surface
+Humans ask for outcomes; agents use CLI primitives internally. Map release,
+PR review, issue triage, retro, and sprint execution requests to the relevant
+workflow without requiring humans to memorize claim/session/gate commands.
 
 See .claude/rules/ for detailed checklists.
 
@@ -81,12 +88,14 @@ Before starting a new phase or project:
 
 Before writing any code in a new sprint:
 
-1. **Run \`slope briefing\`** — Single command that outputs handicap snapshot, hazard index, nutrition alerts, filtered gotchas, and session continuity
+1. **Run \`slope now\`** — Compact cockpit with current sprint, state, claims, and next action
+2. **Run \`slope start\` or \`slope start --ticket=KEY\`** — Human entry point for sprint state, briefing, claim guidance, and prep
+3. **Run \`slope briefing\` when deeper context is needed** — Outputs handicap snapshot, hazard index, nutrition alerts, filtered gotchas, and session continuity
    - Use \`--categories=testing,api\` or \`--keywords=migration\` to filter for the sprint's work area
-2. **Verify previous ${r.scorecard.toLowerCase()} exists** — If the last sprint's ${r.scorecard.toLowerCase()} wasn't created, create it now
-3. **Branch hygiene check** — \`git branch -a\` to confirm no stale branches remain
-4. **Gap analysis** (if touching API or schema) — Read relevant docs and compare against implementation before writing code
-5. **Set ${r.onTarget.toLowerCase()} and slope** — ${r.onTarget} from ticket count (1-2=3, 3-4=4, 5+=5), slope from complexity factors
+4. **Verify previous ${r.scorecard.toLowerCase()} exists** — If the last sprint's ${r.scorecard.toLowerCase()} wasn't created, create it now
+5. **Branch hygiene check** — \`git branch -a\` to confirm no stale branches remain
+6. **Gap analysis** (if touching API or schema) — Read relevant docs and compare against implementation before writing code
+7. **Set ${r.onTarget.toLowerCase()} and slope** — ${r.onTarget} from ticket count (1-2=3, 3-4=4, 5+=5), slope from complexity factors
 
 ## Pre-${r.ticket} Routine (Per-Ticket, Before Code)
 
@@ -300,6 +309,8 @@ export function generateAgentsMd(m: MetaphorDefinition): string {
 This project uses the SLOPE framework for sprint tracking.
 
 ## Commands
+- \`slope now\` — compact current-state cockpit
+- \`slope start [--ticket=KEY]\` — human start-of-work entry
 - \`slope card\` — view ${r.handicapCard.toLowerCase()}
 - \`slope validate\` — validate ${r.scorecard.toLowerCase()}s
 - \`slope review\` — generate sprint review
@@ -311,9 +322,14 @@ A SLOPE MCP server is configured in \`opencode.json\`. Two tools:
 - \`execute\` — run JS with full SLOPE API in sandbox
 
 ## Sprint Workflow
-- **Pre-${r.sprint}:** \`slope briefing\` for handicap, hazards, gotchas
+- **Pre-${r.sprint}:** \`slope now\`, then \`slope start\` or \`slope start --ticket=KEY\`
 - **Per-${r.ticket}:** classify each ticket with approach + result + hazards
 - **Post-${r.sprint}:** \`slope validate\` ${r.scorecard.toLowerCase()}, \`slope review\`, update common-issues
+
+## Human Surface
+Humans ask for outcomes; agents use CLI primitives internally. Map release,
+PR review, issue triage, retro, and sprint execution requests to the relevant
+workflow without requiring humans to memorize claim/session/gate commands.
 
 ## Approach Complexity
 - ${clubs.driver}: risky/new territory
@@ -556,6 +572,8 @@ export function generateCursorrules(m: MetaphorDefinition, harness: 'cursor' | '
 This project uses the SLOPE framework for sprint tracking.
 
 ## Commands
+- \`slope now\` — compact current-state cockpit
+- \`slope start [--ticket=KEY]\` — human start-of-work entry
 - \`slope card\` — view ${r.handicapCard.toLowerCase()}
 - \`slope validate\` — validate ${r.scorecard.toLowerCase()}s
 - \`slope review\` — generate sprint review
@@ -567,9 +585,14 @@ A SLOPE MCP server is configured in \`${mcpPath}\`. Two tools:
 - \`execute\` — run JS with full SLOPE API in sandbox
 
 ## Sprint Workflow
-- **Pre-${r.sprint}:** \`slope briefing\` for handicap, hazards, gotchas
+- **Pre-${r.sprint}:** \`slope now\`, then \`slope start\` or \`slope start --ticket=KEY\`
 - **Per-${r.ticket}:** classify each ticket with approach + result + hazards
 - **Post-${r.sprint}:** \`slope validate\` ${r.scorecard.toLowerCase()}, \`slope review\`, update common-issues
+
+## Human Surface
+Humans ask for outcomes; agents use CLI primitives internally. Map release,
+PR review, issue triage, retro, and sprint execution requests to the relevant
+workflow without requiring humans to memorize claim/session/gate commands.
 
 ## Approach Complexity
 - ${clubs.driver}: risky/new territory
@@ -605,9 +628,11 @@ export function generateGenericChecklist(m: MetaphorDefinition): string {
 4. Run \`slope roadmap show\` — view dependency graph
 
 ## Pre-${r.sprint} (Sprint Start)
-1. Run \`slope briefing\` — handicap, hazards, gotchas, session continuity
-2. Verify previous ${r.scorecard.toLowerCase()} exists
-3. Set ${r.onTarget.toLowerCase()} (1-2 tickets=3, 3-4=4, 5+=5) and slope factors
+1. Run \`slope now\` — current sprint, state, claims, next action
+2. Run \`slope start\` or \`slope start --ticket=KEY\` — sprint state, briefing, claim guidance, prep
+3. Run \`slope briefing\` when deeper hazard context is needed
+4. Verify previous ${r.scorecard.toLowerCase()} exists
+5. Set ${r.onTarget.toLowerCase()} (1-2 tickets=3, 3-4=4, 5+=5) and slope factors
 
 ## Per-Ticket
 - **Before:** Select approach (${clubs.driver}/${clubs.long_iron}/${clubs.short_iron}/${clubs.wedge}/${clubs.putter}), scan hazards

--- a/tests/cli/commands/help.test.ts
+++ b/tests/cli/commands/help.test.ts
@@ -25,6 +25,8 @@ describe('slope help', () => {
 
     const output = consoleOutput.join('\n');
     expect(output).toContain('SLOPE - Human Command Surface');
+    expect(output).toContain('now');
+    expect(output).toContain('start');
     expect(output).toContain('briefing');
     expect(output).toContain('review');
     expect(output).toContain('doctor');

--- a/tests/cli/commands/now.test.ts
+++ b/tests/cli/commands/now.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { nowCommand } from '../../../src/cli/commands/now.js';
+import { createStore } from '../../../src/store/index.js';
+import type { RoadmapDefinition } from '../../../src/core/index.js';
+import { createSprintState, saveSprintState } from '../../../src/cli/sprint-state.js';
+
+let tmpDir: string;
+let originalCwd: string;
+
+function writeConfig(): void {
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+    store_path: '.slope/slope.db',
+  }, null, 2));
+}
+
+function writeRoadmap(): void {
+  const roadmap: RoadmapDefinition = {
+    name: 'Test Roadmap',
+    phases: [{ name: 'Human Surface', sprints: [150, 151] }],
+    sprints: [
+      {
+        id: 150,
+        theme: 'Command Audience Metadata',
+        par: 4,
+        slope: 2,
+        type: 'cli surface',
+        tickets: [
+          { key: 'S150-1', title: 'Done', club: 'short_iron', complexity: 'standard' },
+          { key: 'S150-2', title: 'Done too', club: 'short_iron', complexity: 'standard' },
+          { key: 'S150-3', title: 'Done three', club: 'wedge', complexity: 'small' },
+        ],
+      } as RoadmapDefinition['sprints'][number] & { status: string },
+      {
+        id: 151,
+        theme: 'Skill-First Human Cockpit',
+        par: 4,
+        slope: 3,
+        type: 'workflow + cli surface',
+        depends_on: [150],
+        tickets: [
+          { key: 'S151-1', title: 'Implement slope now', club: 'long_iron', complexity: 'moderate' },
+          { key: 'S151-2', title: 'Implement slope start', club: 'long_iron', complexity: 'moderate' },
+          { key: 'S151-3', title: 'Update skills', club: 'short_iron', complexity: 'standard' },
+        ],
+      } as RoadmapDefinition['sprints'][number] & { status: string },
+    ],
+  };
+  (roadmap.sprints[0] as RoadmapDefinition['sprints'][number] & { status: string }).status = 'complete';
+  (roadmap.sprints[1] as RoadmapDefinition['sprints'][number] & { status: string }).status = 'active';
+  mkdirSync(join(tmpDir, 'docs', 'backlog'), { recursive: true });
+  writeFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), JSON.stringify(roadmap, null, 2));
+}
+
+async function captureLog(fn: () => Promise<void>): Promise<string> {
+  const logs: string[] = [];
+  vi.spyOn(console, 'log').mockImplementation((...args) => {
+    logs.push(args.map(String).join(' '));
+  });
+  try {
+    await fn();
+  } finally {
+    vi.restoreAllMocks();
+  }
+  return logs.join('\n');
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-now-'));
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
+  writeConfig();
+  writeRoadmap();
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('slope now', () => {
+  it('prints a compact human cockpit with current sprint and next action', async () => {
+    saveSprintState(tmpDir, createSprintState(151, 'implementing'));
+    const store = createStore({ storePath: '.slope/slope.db', cwd: tmpDir });
+    await store.claim({ sprint_number: 151, player: 'test', target: 'S151-1', scope: 'ticket' });
+    store.close();
+
+    const output = await captureLog(() => nowCommand([]));
+
+    expect(output).toContain('SLOPE Now');
+    expect(output).toContain('Current: S151 - Skill-First Human Cockpit');
+    expect(output).toContain('Phase: Human Surface (1/2)');
+    expect(output).toContain('Sprint state: implementing');
+    expect(output).toContain('Claims: 1 active, 1 ticket');
+    expect(output).toContain('Next: Start S151-2: Implement slope start');
+    expect(output).toContain('Start: slope start --ticket=S151-2');
+    expect(output.split('\n').length).toBeLessThanOrEqual(14);
+  });
+
+  it('supports JSON output for agent consumers', async () => {
+    const output = await captureLog(() => nowCommand(['--json']));
+    const parsed = JSON.parse(output);
+
+    expect(parsed.sprint).toBe(151);
+    expect(parsed.roadmap.theme).toBe('Skill-First Human Cockpit');
+    expect(parsed.nextTicket.key).toBe('S151-1');
+  });
+});

--- a/tests/cli/commands/start.test.ts
+++ b/tests/cli/commands/start.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { sprintCommand } from '../../../src/cli/commands/sprint.js';
+import { briefingCommand } from '../../../src/cli/commands/briefing.js';
+import { startCommand } from '../../../src/cli/commands/start.js';
+
+vi.mock('../../../src/cli/commands/sprint.js', () => ({
+  sprintCommand: vi.fn(async () => {}),
+}));
+
+vi.mock('../../../src/cli/commands/briefing.js', () => ({
+  briefingCommand: vi.fn(async () => {}),
+}));
+
+let tmpDir: string;
+let originalCwd: string;
+
+function writeConfig(): void {
+  mkdirSync(join(tmpDir, '.slope'), { recursive: true });
+  writeFileSync(join(tmpDir, '.slope', 'config.json'), JSON.stringify({
+    currentSprint: 151,
+    store_path: '.slope/slope.db',
+  }, null, 2));
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'slope-start-'));
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
+  writeConfig();
+  vi.clearAllMocks();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('slope start', () => {
+  it('starts sprint state and compact briefing when no ticket is supplied', async () => {
+    await startCommand([]);
+
+    expect(sprintCommand).toHaveBeenCalledWith(['start', '--number=151', '--phase=implementing']);
+    expect(briefingCommand).toHaveBeenCalledWith(['--sprint=151', '--compact']);
+  });
+
+  it('delegates ticket starts to the bundled sprint begin flow', async () => {
+    await startCommand(['--ticket=S151-1']);
+
+    expect(sprintCommand).toHaveBeenCalledWith(['begin', '--sprint=151', '--ticket=S151-1']);
+    expect(briefingCommand).not.toHaveBeenCalled();
+  });
+
+  it('preserves explicit sprint overrides', async () => {
+    await startCommand(['--sprint=151.5', '--ticket=S151.5-1']);
+
+    expect(sprintCommand).toHaveBeenCalledWith(['begin', '--sprint=151.5', '--ticket=S151.5-1']);
+  });
+});

--- a/tests/cli/registry.test.ts
+++ b/tests/cli/registry.test.ts
@@ -39,9 +39,11 @@ describe('CLI_COMMAND_REGISTRY', () => {
       'doctor',
       'help',
       'init',
+      'now',
       'quickstart',
       'review',
       'roadmap',
+      'start',
       'status',
       'vision',
     ]);

--- a/tests/cli/template-generator.test.ts
+++ b/tests/cli/template-generator.test.ts
@@ -18,7 +18,10 @@ describe('generateProjectContext', () => {
     const content = generateProjectContext(golf);
     expect(content).toContain('SLOPE Project');
     expect(content).toContain('handicap card');
+    expect(content).toContain('slope now');
+    expect(content).toContain('slope start [--ticket=KEY]');
     expect(content).toContain('pre-round briefing');
+    expect(content).toContain('Human Surface');
     expect(content).toContain('Pre-Hole');
     expect(content).toContain('Per-Shot');
     expect(content).toContain('Post-Hole');
@@ -39,6 +42,8 @@ describe('generateSprintChecklist', () => {
   it('golf output matches golf terminology', () => {
     const content = generateSprintChecklist(golf);
     expect(content).toContain('Pre-Hole Routine (Sprint Start)');
+    expect(content).toContain('Run `slope now`');
+    expect(content).toContain('Run `slope start` or `slope start --ticket=KEY`');
     expect(content).toContain('Pre-Shot Routine (Per-Ticket, Before Code)');
     expect(content).toContain('Post-Shot Routine (Per-Ticket, After Completion)');
     expect(content).toContain('Post-Hole Routine (Sprint Completion)');
@@ -141,6 +146,8 @@ describe('generateAgentsMd', () => {
     expect(content).toContain('SLOPE Project');
     expect(content).toContain('opencode.json');
     expect(content).toContain('handicap card');
+    expect(content).toContain('slope now');
+    expect(content).toContain('Human Surface');
     expect(content).toContain('Commit Discipline');
     expect(content).toContain('Driver: risky');
   });
@@ -160,6 +167,8 @@ describe('generateCursorrules', () => {
     expect(content).toContain('SLOPE Project');
     expect(content).toContain('.cursor/mcp.json');
     expect(content).toContain('handicap card');
+    expect(content).toContain('slope now');
+    expect(content).toContain('Human Surface');
     expect(content).toContain('Pre-Hole');
     expect(content).toContain('Post-Hole');
     expect(content).toContain('Driver: risky');
@@ -181,6 +190,8 @@ describe('generateCursorrules', () => {
 describe('generateGenericChecklist', () => {
   it('golf output contains SLOPE commands', () => {
     const content = generateGenericChecklist(golf);
+    expect(content).toContain('slope now');
+    expect(content).toContain('slope start');
     expect(content).toContain('slope briefing');
     expect(content).toContain('slope validate');
     expect(content).toContain('slope review');


### PR DESCRIPTION
## Summary
- Add `slope now` as the compact current-state cockpit for sprint, phase, sprint state, claims, and next action.
- Add `slope start` as the human start-of-work entry, delegating ticket starts to the existing bundled `sprint begin` flow.
- Update bounded help, registry audience expectations, README, generated agent templates, and S151 closeout artifacts.
- Raise and triage #544 into S151.1 after local full-suite validation exposed an unrelated Windows git-analyzer timeout.

## Validation
- `corepack pnpm vitest run tests/cli/template-generator.test.ts tests/cli/commands/now.test.ts tests/cli/commands/start.test.ts tests/cli/commands/help.test.ts tests/cli/registry.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `node dist/cli/index.js now`
- `node dist/cli/index.js now --json`
- `node dist/cli/index.js start --help`
- `node dist/cli/index.js help`
- `node dist/cli/index.js validate docs/retros/sprint-151.json`
- `node dist/cli/index.js roadmap validate` (expected branch-local warning: S151 complete but not yet on main; S151.1 has 2-ticket historical warning)
- `node dist/cli/index.js docs check`
- `node dist/cli/index.js map --check`
- `git diff --check HEAD`

## Local full-suite note
- `corepack pnpm test` timed out locally under Windows CPU contention.
- Focused investigation isolated existing test-fixture timeout issue #544 in `tests/core/analyzers/git.test.ts`; it is triaged to S151.1 and not caused by this S151 cockpit change.