### PR TITLE
Harden Windows git-backed test timing

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -4461,10 +4461,10 @@
     {
       "id": 151.1,
       "theme": "Windows Git Fixture Timeout Hardening",
-      "par": 3,
+      "par": 4,
       "slope": 2,
       "type": "test hardening",
-      "status": "planned",
+      "status": "complete",
       "depends_on": [
         151
       ],

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -4460,7 +4460,7 @@
     },
     {
       "id": 151.1,
-      "theme": "Windows Git Analyzer Timeout Hardening",
+      "theme": "Windows Git Fixture Timeout Hardening",
       "par": 3,
       "slope": 2,
       "type": "test hardening",
@@ -4468,7 +4468,7 @@
       "depends_on": [
         151
       ],
-      "note": "Close #544 by making the git analyzer daily-cadence regression deterministic under Windows/local CPU contention before the next release-validation loop depends on the full suite.",
+      "note": "Close #544 and #546 by making git-heavy fixtures deterministic under Windows/local CPU contention before the next release-validation loop depends on the full suite.",
       "tickets": [
         {
           "key": "S151.1-1",
@@ -4483,6 +4483,15 @@
           "complexity": "small",
           "depends_on": [
             "S151.1-1"
+          ]
+        },
+        {
+          "key": "S151.1-3",
+          "title": "Remove wall-clock sensitivity from the stop-check post-squash fixture (#546)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "depends_on": [
+            "S151.1-2"
           ]
         }
       ]

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -4468,7 +4468,7 @@
       "depends_on": [
         151
       ],
-      "note": "Close #544 and #546 by making git-heavy fixtures deterministic under Windows/local CPU contention before the next release-validation loop depends on the full suite.",
+      "note": "Close #544, #546, and #547 by making git-heavy fixtures and the Vitest timeout budget deterministic under Windows/local CPU contention before the next release-validation loop depends on the full suite.",
       "tickets": [
         {
           "key": "S151.1-1",
@@ -4492,6 +4492,15 @@
           "complexity": "standard",
           "depends_on": [
             "S151.1-2"
+          ]
+        },
+        {
+          "key": "S151.1-4",
+          "title": "Set a project-level Vitest timeout for git-backed integration tests (#547)",
+          "club": "wedge",
+          "complexity": "small",
+          "depends_on": [
+            "S151.1-3"
           ]
         }
       ]

--- a/docs/retros/sprint-151.1-review.md
+++ b/docs/retros/sprint-151.1-review.md
@@ -1,0 +1,75 @@
+## Sprint 151.1 Review: Windows Git Fixture Timeout Hardening
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 2 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (4/4) |
+| GIR % | 100% (4/4) |
+| Putts | 0 |
+| Penalties | 0 |
+| Hazard Penalties | 1 |
+
+### Shot-by-Shot (Tickets Delivered: 4)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S151.1-1 | Short Iron | In the Hole | — | Replaced the 65-process commit-tree history fixture with one git fast-import stream and removed the special 15s timeout from the daily-cadence test. |
+| S151.1-2 | Wedge | Green | Rough: The first full-suite validation surfaced a second Windows/local-load timeout in the stop-check post-squash fixture. | Focused git analyzer validation passed; the full suite exposed #546, which was raised and triaged into S151.1 before continuing. |
+| S151.1-3 | Short Iron | Green | Rough: After the stop-check fixture was hardened, full-suite contention showed the broader project-level 5s Vitest timeout was still too low for git-backed integration tests. | Replaced the temp bare remote and push choreography with direct remote-tracking refs that preserve the stale origin/feature false-positive scenario. |
+| S151.1-4 | Wedge | In the Hole | — | Added a 15s project-level Vitest timeout so Windows/full-suite git integration tests are not judged against the stock 5s unit-test budget. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| rough | minor | Full-suite Windows/local CPU contention made real-git fixture process startup the dominant timing cost. |
+| Wind | minor | S151.1 began as a two-ticket analyzer fix and expanded to four tickets as validation exposed #546 and #547. |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Rough | S151.1-2 | The first full-suite validation surfaced a second Windows/local-load timeout in the stop-check post-squash fixture. |
+| Rough | S151.1-3 | After the stop-check fixture was hardened, full-suite contention showed the broader project-level 5s Vitest timeout was still too low for git-backed integration tests. |
+
+**Known hazards for future sprints:**
+- Git history fixtures with many subprocesses are fragile on Windows under full-suite contention.
+- Post-squash remote-tracking states can be modeled with refs/remotes/origin/* without creating a temp bare remote.
+- The project-level Vitest timeout must account for git-backed integration tests, not just pure unit tests.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | When validation uncovers another same-class failure, raise and triage it immediately instead of burying it in the test log. | #546 and #547 were created during the sprint, added to the roadmap, fixed, and validated before closeout. |
+| Lessons | Fast git fixtures should simulate the needed refs or history directly instead of replaying remote workflows when the behavior under test does not require transport. | The analyzer uses fast-import history, and the stop-check guard uses direct remote-tracking refs for the post-squash state. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | `corepack pnpm vitest run tests/core/analyzers/git.test.ts tests/cli/guards/stop-check.test.ts --pool=forks --poolOptions.forks.singleFork --reporter=verbose` passed: 36 tests. |
+| testing | healthy | `corepack pnpm vitest run tests/cli/docs.test.ts tests/cli/commands/commit-ready.test.ts tests/cli/guards/stop-check.test.ts --reporter=verbose` passed: 32 tests. |
+| testing | healthy | `corepack pnpm test` passed after the fixes: 235 files passed, 1 skipped, 3667 tests passed, 25 skipped. |
+| testing | healthy | `corepack pnpm typecheck` and `corepack pnpm build` passed. |
+| docs | healthy | `node dist/cli/index.js roadmap validate` passed with only existing historical ticket-count warnings. |
+
+### Course Management Notes
+
+- Closed the original #544 analyzer timeout by removing the high-process-count fixture path.
+- Raised #546 for the stop-check post-squash fixture timeout and fixed it in S151.1.
+- Raised #547 for the broader Vitest default-timeout mismatch and fixed it in S151.1.
+- No review findings were recorded after code and architect review of the branch diff.
+
+### 19th Hole
+
+- **How did it feel?** A small fix became a useful little stress test of the SLOPE loop. The suite kept showing us the next brittle timing assumption, and the loop held.
+- **Advice for next player?** Treat git-backed tests as integration tests in both fixture design and timeout budgets. Make the fixture cheap first, then give the suite a realistic ceiling.
+- **What surprised you?** Even after removing expensive fixture choreography, full-suite Windows contention could push otherwise reasonable git tests past Vitest's stock 5s timeout.
+- **Excited about next?** Release validation now has a cleaner path: the local full suite is green again, and the surfaced failures are all tracked and closed by the same PR.
+

--- a/docs/retros/sprint-151.1.json
+++ b/docs/retros/sprint-151.1.json
@@ -1,0 +1,162 @@
+{
+  "sprint_number": 151.1,
+  "player": "codex",
+  "theme": "Windows Git Fixture Timeout Hardening",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-06-08",
+  "type": "test hardening",
+  "skills_used": [
+    "slope-sprint-workflow",
+    "github"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow"
+  ],
+  "skill_gaps_found": [],
+  "shots": [
+    {
+      "ticket_key": "S151.1-1",
+      "title": "Remove wall-clock sensitivity from the git analyzer daily-cadence fixture (#544)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Replaced the 65-process commit-tree history fixture with one git fast-import stream and removed the special 15s timeout from the daily-cadence test."
+    },
+    {
+      "ticket_key": "S151.1-2",
+      "title": "Validate focused git analyzer and full-suite behavior for #544",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The first full-suite validation surfaced a second Windows/local-load timeout in the stop-check post-squash fixture."
+        }
+      ],
+      "notes": "Focused git analyzer validation passed; the full suite exposed #546, which was raised and triaged into S151.1 before continuing."
+    },
+    {
+      "ticket_key": "S151.1-3",
+      "title": "Remove wall-clock sensitivity from the stop-check post-squash fixture (#546)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "After the stop-check fixture was hardened, full-suite contention showed the broader project-level 5s Vitest timeout was still too low for git-backed integration tests."
+        }
+      ],
+      "notes": "Replaced the temp bare remote and push choreography with direct remote-tracking refs that preserve the stale origin/feature false-positive scenario."
+    },
+    {
+      "ticket_key": "S151.1-4",
+      "title": "Set a project-level Vitest timeout for git-backed integration tests (#547)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added a 15s project-level Vitest timeout so Windows/full-suite git integration tests are not judged against the stock 5s unit-test budget."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 2,
+    "hazard_penalties": 1,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "rough",
+      "impact": "minor",
+      "description": "Full-suite Windows/local CPU contention made real-git fixture process startup the dominant timing cost."
+    },
+    {
+      "type": "wind",
+      "impact": "minor",
+      "description": "S151.1 began as a two-ticket analyzer fix and expanded to four tickets as validation exposed #546 and #547."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "When validation uncovers another same-class failure, raise and triage it immediately instead of burying it in the test log.",
+      "outcome": "#546 and #547 were created during the sprint, added to the roadmap, fixed, and validated before closeout."
+    },
+    {
+      "type": "lessons",
+      "description": "Fast git fixtures should simulate the needed refs or history directly instead of replaying remote workflows when the behavior under test does not require transport.",
+      "outcome": "The analyzer uses fast-import history, and the stop-check guard uses direct remote-tracking refs for the post-squash state."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "`corepack pnpm vitest run tests/core/analyzers/git.test.ts tests/cli/guards/stop-check.test.ts --pool=forks --poolOptions.forks.singleFork --reporter=verbose` passed: 36 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`corepack pnpm vitest run tests/cli/docs.test.ts tests/cli/commands/commit-ready.test.ts tests/cli/guards/stop-check.test.ts --reporter=verbose` passed: 32 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`corepack pnpm test` passed after the fixes: 235 files passed, 1 skipped, 3667 tests passed, 25 skipped.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`corepack pnpm typecheck` and `corepack pnpm build` passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "`node dist/cli/index.js roadmap validate` passed with only existing historical ticket-count warnings.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A small fix became a useful little stress test of the SLOPE loop. The suite kept showing us the next brittle timing assumption, and the loop held.",
+    "advice_for_next_player": "Treat git-backed tests as integration tests in both fixture design and timeout budgets. Make the fixture cheap first, then give the suite a realistic ceiling.",
+    "what_surprised_you": "Even after removing expensive fixture choreography, full-suite Windows contention could push otherwise reasonable git tests past Vitest's stock 5s timeout.",
+    "excited_about_next": "Release validation now has a cleaner path: the local full suite is green again, and the surfaced failures are all tracked and closed by the same PR."
+  },
+  "bunker_locations": [
+    "Git history fixtures with many subprocesses are fragile on Windows under full-suite contention.",
+    "Post-squash remote-tracking states can be modeled with refs/remotes/origin/* without creating a temp bare remote.",
+    "The project-level Vitest timeout must account for git-backed integration tests, not just pure unit tests."
+  ],
+  "yardage_book_updates": [
+    "tests/core/analyzers/git.test.ts now builds the daily-cadence history with one fast-import stream.",
+    "tests/cli/guards/stop-check.test.ts now simulates the post-squash remote-tracking state without a bare remote or pushes.",
+    "vitest.config.ts now sets a 15s testTimeout for Windows/full-suite git integration tests.",
+    "docs/backlog/roadmap.json records #544, #546, and #547 in S151.1 and marks the sprint complete."
+  ],
+  "course_management_notes": [
+    "Closed the original #544 analyzer timeout by removing the high-process-count fixture path.",
+    "Raised #546 for the stop-check post-squash fixture timeout and fixed it in S151.1.",
+    "Raised #547 for the broader Vitest default-timeout mismatch and fixed it in S151.1.",
+    "No review findings were recorded after code and architect review of the branch diff."
+  ],
+  "slope_factors": [
+    "windows_git_process_startup",
+    "full_suite_contention",
+    "test_fixture_hardening",
+    "validation_loop"
+  ]
+}

--- a/tests/cli/guards/stop-check.test.ts
+++ b/tests/cli/guards/stop-check.test.ts
@@ -61,25 +61,23 @@ describe('stop-check guard', () => {
 
   describe('post-squash-merge scenario', () => {
     it('does not false-positive when HEAD is at origin/main', async () => {
-      // Simulate a remote by creating a bare repo and pushing
-      const bareDir = mkdtempSync(join(tmpdir(), 'slope-bare-'));
-      execSync('git init --bare', { cwd: bareDir });
-      git(`remote add origin ${bareDir}`);
-      git('push -u origin main');
+      git('update-ref refs/remotes/origin/main HEAD');
 
-      // Create a branch, make a commit, push it
+      // Create a feature branch whose stale remote-tracking ref would look
+      // unpushed if the guard did not first recognize HEAD at origin/main.
       git('checkout -b feature');
       writeFileSync(join(tmpDir, 'feature.txt'), 'feat');
       git('add .');
       git('commit -m "feature"');
-      git('push -u origin feature');
+      git('update-ref refs/remotes/origin/feature HEAD');
 
-      // Simulate squash-merge: apply changes to main on remote
+      // Simulate squash-merge: apply equivalent changes to main, then move
+      // origin/main to that squash commit without invoking a temp remote.
       git('checkout main');
       writeFileSync(join(tmpDir, 'feature.txt'), 'feat');
       git('add .');
       git('commit -m "feat: feature (#1)"');
-      git('push origin main');
+      git('update-ref refs/remotes/origin/main HEAD');
 
       // Now switch back to feature branch and reset to origin/main
       // (this is what happens in a worktree after squash merge)
@@ -90,8 +88,6 @@ describe('stop-check guard', () => {
       // The guard should NOT block
       const result = await stopCheckGuard(makeStop(), tmpDir);
       expect(result.blockReason).toBeUndefined();
-
-      rmSync(bareDir, { recursive: true, force: true });
     });
   });
 

--- a/tests/core/analyzers/git.test.ts
+++ b/tests/core/analyzers/git.test.ts
@@ -19,29 +19,41 @@ function gitCommit(cwd: string, message: string): void {
   execSync(`git commit -m "${message}" --allow-empty`, { cwd, stdio: 'pipe' });
 }
 
-function gitOutput(cwd: string, args: string[], input?: string): string {
-  return execFileSync('git', args, {
-    cwd,
-    encoding: 'utf8',
-    input,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }).trim();
-}
-
-function gitFastEmptyHistory(cwd: string, count: number): void {
+function gitFastHistory(cwd: string, count: number): void {
   execFileSync('git', ['symbolic-ref', 'HEAD', 'refs/heads/main'], { cwd, stdio: 'pipe' });
-  const tree = gitOutput(cwd, ['mktree'], '');
-  let parent: string | null = null;
+  if (count <= 0) {
+    return;
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const lines = [
+    'blob',
+    'mark :1',
+    'data 1',
+    'x',
+  ];
 
   for (let i = 0; i < count; i++) {
-    const args = ['commit-tree', tree, '-m', `commit ${i}`];
-    if (parent) args.push('-p', parent);
-    parent = gitOutput(cwd, args);
+    const mark = i + 2;
+    const message = `commit ${i}`;
+    lines.push(
+      'commit refs/heads/main',
+      `mark :${mark}`,
+      `committer Test User <test@test.com> ${timestamp} +0000`,
+      `data ${Buffer.byteLength(message, 'utf8')}`,
+      message,
+    );
+    if (i > 0) {
+      lines.push(`from :${mark - 1}`);
+    }
+    lines.push('M 100644 :1 file.txt');
   }
 
-  if (parent) {
-    execFileSync('git', ['update-ref', 'refs/heads/main', parent], { cwd, stdio: 'pipe' });
-  }
+  execFileSync('git', ['fast-import', '--quiet'], {
+    cwd,
+    input: `${lines.join('\n')}\n`,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
 }
 
 function gitCommitFile(cwd: string, file: string, content: string, message: string): void {
@@ -117,11 +129,11 @@ describe('analyzeGit', () => {
   it('infers daily cadence from many commits', async () => {
     gitInit(tmpDir);
     // 65 commits in the "last 90 days" -> ~5 per week -> daily
-    gitFastEmptyHistory(tmpDir, 65);
+    gitFastHistory(tmpDir, 65);
 
     const result = await analyzeGit(tmpDir);
     expect(result.inferredCadence).toBe('daily');
-  }, 15000);
+  });
 
   it('infers sporadic cadence from few commits', async () => {
     gitInit(tmpDir);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
+    // Several CLI integration tests create temp git repositories; Windows
+    // process startup under full-suite contention can exceed Vitest's 5s default.
+    testTimeout: 15_000,
   },
 });


### PR DESCRIPTION
## Summary

- replace the git analyzer daily-cadence fixture with a single `git fast-import` history builder
- simplify the stop-check post-squash fixture to direct remote-tracking refs instead of a temp bare remote and pushes
- set a 15s Vitest project timeout for git-backed integration tests under Windows/full-suite contention
- close S151.1 with scorecard/review artifacts and roadmap status

Closes #544.
Closes #546.
Closes #547.

## Validation

- `corepack pnpm vitest run tests/core/analyzers/git.test.ts tests/cli/guards/stop-check.test.ts --pool=forks --poolOptions.forks.singleFork --reporter=verbose`
- `corepack pnpm vitest run tests/cli/docs.test.ts tests/cli/commands/commit-ready.test.ts tests/cli/guards/stop-check.test.ts --reporter=verbose`
- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `node dist/cli/index.js validate docs/retros/sprint-151.1.json`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`