### PR TITLE
Release v1.59.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.58.5",
+  "version": "1.59.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.58.5",
+  "version": "1.59.0",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
## Summary
- Bump `@slope-dev/slope` from 1.58.5 to 1.59.0.
- Bump the bundled Codex plugin manifest from 1.58.5 to 1.59.0.

## Validation
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test`
- `node dist/cli/index.js version`
- `node dist/cli/index.js roadmap validate`
- `node dist/cli/index.js map --check`

## Release note
npm publishing is handled by the GitHub release / npm trusted publishing integration after this bump lands and CI passes.