### PR TITLE
docs(S152): record v1.59.0 release closeout

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -1,6 +1,6 @@
 {
   "name": "SLOPE Development Roadmap",
-  "description": "Forward-looking roadmap from S61+. Phases 1-9 (S1-S47) are complete. S48-S60 were hardening, guard enforcement, and process sprints. This roadmap covers adoption, observability, guard maturity, multi-project, loop evolution, and issue-driven recovery. S61-S64 reflect what actually shipped (themes diverged from original plan). Note: the actual S69 diverged from the planned Referee sprint \u2014 a carryover patch kit ran instead. The Referee work was rescheduled as S78. S75.5 (The Bug Clearing) added 2026-05-02 to clear accumulated CLI bugs from external repos. S132-S136 were backfilled from shipped scorecards on 2026-06-05; S137 adds post-merge retro tooling and durable memory, S137.5 addresses Windows suite portability for #509, S138-S144 triage open GitHub issues #499/#501/#502/#503/#505/#507/#510/#511/#512/#513/#514/#515/#516/#517/#518 into focused recovery sprints, S145 closed validation-signal regressions #519/#520, S146 cleaned stale roadmap state plus decimal sprint shipped-artifact warnings (#522), S146.1 cut the v1.58.1 patch release while repairing release-bump staging (#524/#528), active inserted sprint status (#525), and guard test isolation (#526), S146.2 closes the decimal post-merge retro gap (#529), and S146.3 scopes workflow-step-gate to the relevant execution (#531).",
+  "description": "Forward-looking roadmap from S61+. Phases 1-9 (S1-S47) are complete. S48-S60 were hardening, guard enforcement, and process sprints. This roadmap covers adoption, observability, guard maturity, multi-project, loop evolution, and issue-driven recovery. S61-S64 reflect what actually shipped (themes diverged from original plan). Note: the actual S69 diverged from the planned Referee sprint \u2014 a carryover patch kit ran instead. The Referee work was rescheduled as S78. S75.5 (The Bug Clearing) added 2026-05-02 to clear accumulated CLI bugs from external repos. S132-S136 were backfilled from shipped scorecards on 2026-06-05; S137 adds post-merge retro tooling and durable memory, S137.5 addresses Windows suite portability for #509, S138-S144 triage open GitHub issues #499/#501/#502/#503/#505/#507/#510/#511/#512/#513/#514/#515/#516/#517/#518 into focused recovery sprints, S145 closed validation-signal regressions #519/#520, S146 cleaned stale roadmap state plus decimal sprint shipped-artifact warnings (#522), S146.1 cut the v1.58.1 patch release while repairing release-bump staging (#524/#528), active inserted sprint status (#525), and guard test isolation (#526), S146.2 closes the decimal post-merge retro gap (#529), S146.3 scopes workflow-step-gate to the relevant execution (#531), S148-S151.1 completed the human operating surface simplification and Windows git fixture hardening, S152 published v1.59.0, and S153 tracks semver recommendation hardening for #550.",
   "phases": [
     {
       "name": "Phase 10 \u2014 Adoption & Onboarding",
@@ -350,8 +350,17 @@
         151,
         151.1
       ],
-      "status": "planned",
+      "status": "complete",
       "note": "Plan and implement the higher-level SLOPE operating surface so humans see a small, memorable cockpit while agents and skills orchestrate the deeper CLI/MCP execution framework."
+    },
+    {
+      "name": "Phase 48 \u2014 Release Tooling Follow-up",
+      "sprints": [
+        152,
+        153
+      ],
+      "status": "planned",
+      "note": "Close out the v1.59.0 release memory and triage the semver recommendation gap discovered during release verification."
     }
   ],
   "sprints": [
@@ -4501,6 +4510,88 @@
           "complexity": "small",
           "depends_on": [
             "S151.1-3"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 152,
+      "theme": "v1.59.0 Release Cycle",
+      "par": 3,
+      "slope": 1,
+      "type": "release",
+      "status": "complete",
+      "score": 3,
+      "score_label": "par",
+      "depends_on": [
+        151.1
+      ],
+      "note": "Bump the root package and bundled Codex plugin to 1.59.0, merge PR #549 after CI, create GitHub release v1.59.0, and verify the trusted-publishing npm workflow.",
+      "tickets": [
+        {
+          "key": "S152-1",
+          "title": "Bump package and bundled Codex plugin manifest to 1.59.0",
+          "club": "wedge",
+          "complexity": "small"
+        },
+        {
+          "key": "S152-2",
+          "title": "Open and merge release PR #549 after CI passes",
+          "club": "wedge",
+          "complexity": "small",
+          "depends_on": [
+            "S152-1"
+          ]
+        },
+        {
+          "key": "S152-3",
+          "title": "Publish GitHub release v1.59.0 and verify npm latest",
+          "club": "short_iron",
+          "complexity": "standard",
+          "depends_on": [
+            "S152-2"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 153,
+      "theme": "Semver Recommendation Evidence Hardening",
+      "par": 3,
+      "slope": 2,
+      "type": "bugfix",
+      "status": "planned",
+      "depends_on": [
+        152
+      ],
+      "note": "Close #550 by making `slope version recommend` account for durable SLOPE release evidence when squash-merge subjects hide feature-level work.",
+      "tickets": [
+        {
+          "key": "S153-1",
+          "title": "Add durable roadmap or PR evidence to version recommendation for squash-merged feature work (#550)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 550
+        },
+        {
+          "key": "S153-2",
+          "title": "Explain semver evidence and ambiguity in version recommend output (#550)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 550,
+          "depends_on": [
+            "S153-1"
+          ]
+        },
+        {
+          "key": "S153-3",
+          "title": "Add regression coverage for squash-merge semver undercall prevention (#550)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 550,
+          "depends_on": [
+            "S153-1",
+            "S153-2"
           ]
         }
       ]

--- a/docs/retros/sprint-152-review.md
+++ b/docs/retros/sprint-152-review.md
@@ -1,0 +1,19 @@
+## Sprint 152: v1.59.0 Release Cycle
+
+**Status:** On schedule
+**Tickets:** 3 delivered
+
+### Tickets
+
+| Ticket | Approach | Outcome | Notes |
+|---|---|---|---|
+| S152-1 | Simple fix | Completed perfectly | Used `node scripts/version-bump.mjs 1.59.0` to update package.json and the bundled Codex plugin manifest together. |
+| S152-2 | Simple fix | Completed perfectly | Opened PR #549, watched ci, CodeQL, Analyze (actions), Analyze (javascript-typescript), and GitGuardian pass, then squash-merged the release bump to main. |
+| S152-3 | Standard approach | Completed perfectly | Created GitHub release v1.59.0, watched Publish to npm run 27173837982 pass, and verified `npm view @slope-dev/slope version --registry https://registry.npmjs.org` returned 1.59.0. |
+
+### Reflection
+
+- Clean and pleasantly boring in the important places: version bump, CI, release workflow, and registry verification all lined up.
+- **Tip:** Trust the GitHub Release trusted-publishing path for publication, but double-check semver intent when squash commits hide the shape of shipped work.
+- **Next:** S153 can make the release assistant smarter so the next version bump needs less human override.
+

--- a/docs/retros/sprint-152.json
+++ b/docs/retros/sprint-152.json
@@ -1,0 +1,161 @@
+{
+  "sprint_number": 152,
+  "player": "codex",
+  "theme": "v1.59.0 Release Cycle",
+  "par": 3,
+  "slope": 1,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-06-08",
+  "type": "release",
+  "skills_used": [
+    "slope-sprint-workflow",
+    "github"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow"
+  ],
+  "skill_gaps_found": [],
+  "shots": [
+    {
+      "ticket_key": "S152-1",
+      "title": "Bump package and bundled Codex plugin manifest to 1.59.0",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "`slope version recommend` undercalled the release as patch because squash commit subjects hid feature-level human-surface work; #550 was raised and triaged into S153."
+        }
+      ],
+      "notes": "Used `node scripts/version-bump.mjs 1.59.0` to update package.json and the bundled Codex plugin manifest together."
+    },
+    {
+      "ticket_key": "S152-2",
+      "title": "Open and merge release PR #549 after CI passes",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Opened PR #549, watched ci, CodeQL, Analyze (actions), Analyze (javascript-typescript), and GitGuardian pass, then squash-merged the release bump to main."
+    },
+    {
+      "ticket_key": "S152-3",
+      "title": "Publish GitHub release v1.59.0 and verify npm latest",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Created GitHub release v1.59.0, watched Publish to npm run 27173837982 pass, and verified `npm view @slope-dev/slope version --registry https://registry.npmjs.org` returned 1.59.0."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 3,
+    "fairways_total": 3,
+    "greens_in_regulation": 3,
+    "greens_total": 3,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "pin_position",
+      "impact": "none",
+      "description": "npm publication is handled by the GitHub Release to npm trusted-publishing workflow; no direct local `npm publish` command belongs in the release sprint."
+    },
+    {
+      "type": "rough",
+      "impact": "minor",
+      "description": "The release recommendation tool only saw squash commit subjects and therefore recommended patch despite feature-level shipped user surface."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Release version recommendations need durable SLOPE context, not only unreleased commit subjects.",
+      "outcome": "#550 was opened and triaged into S153 so the recommender can account for roadmap, sprint, or PR evidence when squash merges hide feature-level work."
+    },
+    {
+      "type": "lessons",
+      "description": "The release cycle should verify the GitHub/npm integration instead of trying to publish locally.",
+      "outcome": "PR #549 CI passed, GitHub release v1.59.0 triggered Publish to npm, and npm latest now reports 1.59.0."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "`corepack pnpm typecheck` passed locally before PR creation.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`corepack pnpm build` passed locally before PR creation.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`corepack pnpm test` passed locally: 235 files passed, 1 skipped; 3667 tests passed, 25 skipped.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "`node dist/cli/index.js roadmap validate` passed with only existing historical ticket-count warnings before the release bump PR.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "`node dist/cli/index.js map --check` reported the codebase map current before the release bump PR.",
+      "status": "healthy"
+    },
+    {
+      "category": "release",
+      "description": "PR #549 checks passed: ci, CodeQL, Analyze (actions), Analyze (javascript-typescript), and GitGuardian.",
+      "status": "healthy"
+    },
+    {
+      "category": "release",
+      "description": "Publish to npm run 27173837982 completed successfully and npm registry latest is 1.59.0.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "Clean and pleasantly boring in the important places: version bump, CI, release workflow, and registry verification all lined up.",
+    "advice_for_next_player": "Trust the GitHub Release trusted-publishing path for publication, but double-check semver intent when squash commits hide the shape of shipped work.",
+    "what_surprised_you": "The release recommender could undercall a minor release even though the roadmap and sprint history made the user-facing change clear.",
+    "excited_about_next": "S153 can make the release assistant smarter so the next version bump needs less human override."
+  },
+  "bunker_locations": [
+    "`slope version recommend` can undercall semver when it only inspects squash commit subjects.",
+    "Release scorecards should record the GitHub release workflow run and npm registry verification as the publication proof.",
+    "Post-release roadmap closeout must update phase status when all member sprints are complete."
+  ],
+  "yardage_book_updates": [
+    "v1.59.0 release PR: #549.",
+    "v1.59.0 GitHub release: https://github.com/srbryers/slope/releases/tag/v1.59.0.",
+    "Publish to npm workflow run: https://github.com/srbryers/slope/actions/runs/27173837982.",
+    "npm registry latest verified as 1.59.0.",
+    "#550 is triaged into S153 for semver recommendation evidence hardening."
+  ],
+  "course_management_notes": [
+    "Version bump commit on release branch: ac4de72.",
+    "Merged release commit on main: 006f777.",
+    "No direct local `npm publish` was run; publication used the GitHub release/npm trusted-publishing integration.",
+    "Phase 47 roadmap status was corrected from planned to complete during post-release closeout.",
+    "Phase 48 was added for S152 release memory and S153 #550 follow-up planning."
+  ],
+  "slope_factors": [
+    "minor_release",
+    "trusted_publisher_release",
+    "registry_verification",
+    "semver_recommendation_gap",
+    "roadmap_closeout"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add the S152 release scorecard and generated review for v1.59.0.
- Mark Phase 47 complete, add Phase 48, and record S152/S153 roadmap entries.
- Triage #550 into S153 after the release cycle exposed the semver recommendation undercall.

## Validation
- `node dist/cli/index.js validate`
- `node dist/cli/index.js roadmap validate` (valid; expected interim warning that S152 is not on `main` until this PR merges)
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js version`