### PR TITLE
[codex] Fix roadmap interview discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,9 +304,11 @@ orchestrate the rest of the CLI as execution primitives.
 | `npx slope briefing` | Pre-sprint hazard index, nutrition alerts, filtered gotchas |
 | `npx slope plan --complexity=<level>` | Club recommendation + training plan |
 | `npx slope next` | Show next sprint number |
+| `npx slope roadmap interview` | Run the project interview when planning input is needed |
 | `npx slope roadmap status [--sprint=N]` | Compact current roadmap state: active work, blockers, next ready, upcoming |
 | `npx slope roadmap status --full` | Full historical roadmap status |
 | `npx slope roadmap validate` | Validate roadmap dependencies and sprint status |
+| `npx slope vision create` + `npx slope roadmap generate` | Create vision-backed roadmap plans from concrete backlog signals |
 
 ### Review & Findings
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Install and initialize SLOPE for this project. Run these commands:
 2. npx slope map
 
 This will create opencode.json, .opencode/plugins/, AGENTS.md, and CODEBASE.md.
+For roadmap planning intake, run `npx slope roadmap interview --agent` or ask the MCP server for `search({ module: "init" })`.
 ```
 
 **What you get:**

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -1,6 +1,6 @@
 {
   "name": "SLOPE Development Roadmap",
-  "description": "Forward-looking roadmap from S61+. Phases 1-9 (S1-S47) are complete. S48-S60 were hardening, guard enforcement, and process sprints. This roadmap covers adoption, observability, guard maturity, multi-project, loop evolution, and issue-driven recovery. S61-S64 reflect what actually shipped (themes diverged from original plan). Note: the actual S69 diverged from the planned Referee sprint \u2014 a carryover patch kit ran instead. The Referee work was rescheduled as S78. S75.5 (The Bug Clearing) added 2026-05-02 to clear accumulated CLI bugs from external repos. S132-S136 were backfilled from shipped scorecards on 2026-06-05; S137 adds post-merge retro tooling and durable memory, S137.5 addresses Windows suite portability for #509, S138-S144 triage open GitHub issues #499/#501/#502/#503/#505/#507/#510/#511/#512/#513/#514/#515/#516/#517/#518 into focused recovery sprints, S145 closed validation-signal regressions #519/#520, S146 cleaned stale roadmap state plus decimal sprint shipped-artifact warnings (#522), S146.1 cut the v1.58.1 patch release while repairing release-bump staging (#524/#528), active inserted sprint status (#525), and guard test isolation (#526), S146.2 closes the decimal post-merge retro gap (#529), S146.3 scopes workflow-step-gate to the relevant execution (#531), S148-S151.1 completed the human operating surface simplification and Windows git fixture hardening, S152 published v1.59.0, and S153 tracks semver recommendation hardening for #550.",
+  "description": "Forward-looking roadmap from S61+. Phases 1-9 (S1-S47) are complete. S48-S60 were hardening, guard enforcement, and process sprints. This roadmap covers adoption, observability, guard maturity, multi-project, loop evolution, and issue-driven recovery. S61-S64 reflect what actually shipped (themes diverged from original plan). Note: the actual S69 diverged from the planned Referee sprint \u2014 a carryover patch kit ran instead. The Referee work was rescheduled as S78. S75.5 (The Bug Clearing) added 2026-05-02 to clear accumulated CLI bugs from external repos. S132-S136 were backfilled from shipped scorecards on 2026-06-05; S137 adds post-merge retro tooling and durable memory, S137.5 addresses Windows suite portability for #509, S138-S144 triage open GitHub issues #499/#501/#502/#503/#505/#507/#510/#511/#512/#513/#514/#515/#516/#517/#518 into focused recovery sprints, S145 closed validation-signal regressions #519/#520, S146 cleaned stale roadmap state plus decimal sprint shipped-artifact warnings (#522), S146.1 cut the v1.58.1 patch release while repairing release-bump staging (#524/#528), active inserted sprint status (#525), and guard test isolation (#526), S146.2 closes the decimal post-merge retro gap (#529), S146.3 scopes workflow-step-gate to the relevant execution (#531), S148-S151.1 completed the human operating surface simplification and Windows git fixture hardening, S152 published v1.59.0, S152.1 tracks roadmap interview discoverability across supported harness surfaces, and S153 tracks semver recommendation hardening for #550.",
   "phases": [
     {
       "name": "Phase 10 \u2014 Adoption & Onboarding",
@@ -357,10 +357,11 @@
       "name": "Phase 48 \u2014 Release Tooling Follow-up",
       "sprints": [
         152,
+        152.1,
         153
       ],
       "status": "planned",
-      "note": "Close out the v1.59.0 release memory and triage the semver recommendation gap discovered during release verification."
+      "note": "Close out the v1.59.0 release memory, repair roadmap interview discoverability across harness surfaces, and triage the semver recommendation gap discovered during release verification."
     }
   ],
   "sprints": [
@@ -4555,6 +4556,54 @@
       ]
     },
     {
+      "id": 152.1,
+      "theme": "Roadmap Interview Discoverability and Harness Routing",
+      "par": 4,
+      "slope": 2,
+      "type": "bugfix + dx",
+      "status": "planned",
+      "depends_on": [
+        152
+      ],
+      "note": "Make the existing project interview findable from roadmap-planning contexts so users and agents discover `slope interview`, `slope interview --agent`, the Pi `slope_interview` tool, and MCP init helpers instead of concluding the interview flow does not exist.",
+      "tickets": [
+        {
+          "key": "S152.1-1",
+          "title": "Add a `slope roadmap interview` alias or guided handoff to the existing interview/vision flow",
+          "club": "short_iron",
+          "complexity": "standard"
+        },
+        {
+          "key": "S152.1-2",
+          "title": "Cross-reference `slope interview`, `slope vision`, and `slope roadmap generate` in roadmap help and command metadata",
+          "club": "wedge",
+          "complexity": "small",
+          "depends_on": [
+            "S152.1-1"
+          ]
+        },
+        {
+          "key": "S152.1-3",
+          "title": "Verify interview discovery paths for supported harness surfaces: CLI, MCP init helpers, Pi extension, Codex/OpenCode adapter docs, and generic adapter guidance",
+          "club": "short_iron",
+          "complexity": "standard",
+          "depends_on": [
+            "S152.1-1",
+            "S152.1-2"
+          ]
+        },
+        {
+          "key": "S152.1-4",
+          "title": "Add regression coverage for roadmap interview alias/help plus agent and Pi discovery flows",
+          "club": "short_iron",
+          "complexity": "standard",
+          "depends_on": [
+            "S152.1-3"
+          ]
+        }
+      ]
+    },
+    {
       "id": 153,
       "theme": "Semver Recommendation Evidence Hardening",
       "par": 3,
@@ -4562,7 +4611,7 @@
       "type": "bugfix",
       "status": "planned",
       "depends_on": [
-        152
+        152.1
       ],
       "note": "Close #550 by making `slope version recommend` account for durable SLOPE release evidence when squash-merge subjects hide feature-level work.",
       "tickets": [

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -4561,7 +4561,9 @@
       "par": 4,
       "slope": 2,
       "type": "bugfix + dx",
-      "status": "planned",
+      "status": "complete",
+      "score": 4,
+      "score_label": "par",
       "depends_on": [
         152
       ],

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,6 +167,15 @@ Runs repo analysis (stack detection, file structure, testing framework, git hist
 
 ## Common Workflows
 
+### Planning a Roadmap
+
+```bash
+slope roadmap interview              # Guided project interview for planning input
+slope roadmap interview --agent      # JSON mode for agent harnesses
+slope vision create                  # Persist purpose and priorities
+slope roadmap generate --dry-run     # Preview generated roadmap from vision + backlog signals
+```
+
 ### Before a Sprint
 
 ```bash

--- a/docs/guides/codex-setup.md
+++ b/docs/guides/codex-setup.md
@@ -55,3 +55,7 @@ codex debug prompt-input 'global hooks only parse smoke'
 Then run a harmless command in a SLOPE repo and confirm `.slope/guard-metrics.jsonl` receives a fresh entry.
 
 To register the project-local plugin bundle as a Codex marketplace source, run `codex plugin marketplace add .codex` from the repository root.
+
+## Roadmap Planning
+
+For planning intake, use `slope roadmap interview` in human mode or `slope roadmap interview --agent` in JSON mode. MCP-driven Codex sessions can discover the same flow with `search({ module: "init" })`, then call `getInitQuestions()` and `submitInitAnswers()`.

--- a/docs/retros/sprint-152.1-review.md
+++ b/docs/retros/sprint-152.1-review.md
@@ -1,0 +1,70 @@
+## Sprint 152.1 Review: Roadmap Interview Discoverability and Harness Routing
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 2 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (4/4) |
+| GIR % | 100% (4/4) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 4)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S152.1-1 | Short Iron | In the Hole | - | Added `slope roadmap interview` as an alias that delegates to the existing interview command, including --agent JSON-mode coverage that writes the roadmap artifacts. |
+| S152.1-2 | Wedge | In the Hole | - | Updated roadmap help, registry metadata, README, and getting-started docs so roadmap planning points at the interview, vision, and generate flows. |
+| S152.1-3 | Short Iron | Green | - | Surfaced roadmap interview guidance through MCP init search descriptions, Pi onboarding/planning messages, Codex/OpenCode templates, generated adapter docs, and the generic adapter README. |
+| S152.1-4 | Short Iron | In the Hole | - | Added regression coverage for roadmap help discovery, CLI alias execution, MCP init search discoverability, Pi tool guidance, OpenCode slash-command description, and generated harness docs. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| Wind | minor | The sprint was triggered by an agent-discoverability miss: roadmap tooling existed, but supported harnesses did not make the interview flow obvious from roadmap-planning language. |
+
+### Hazards Discovered
+
+**Known hazards for future sprints:**
+- Roadmap planning language can drift away from the original `slope interview` and MCP init naming.
+- Harness prompt templates can silently lag CLI capabilities unless regression tests assert generated guidance.
+- Pi and OpenCode surfaces need explicit planning-language breadcrumbs because users may never inspect full CLI help.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | When an existing command is the right answer, add an alias and discovery breadcrumbs at the user phrase boundary instead of duplicating the workflow. | `slope roadmap interview` now routes to `slope interview`, while docs and harness prompts explain the existing vision/generate path. |
+| Lessons | Discovery bugs need harness-level assertions, not just CLI help assertions. | Coverage now spans CLI help/registry, MCP init search, Pi onboarding, OpenCode command text, Codex templates, and generic adapter output. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | `pnpm vitest run tests/cli/commands/interview.test.ts` passed: 5 tests. |
+| testing | healthy | `pnpm vitest run tests/cli/commands/help.test.ts tests/cli/registry.test.ts` passed: 13 tests. |
+| testing | healthy | `pnpm vitest run tests/cli/template-generator.test.ts tests/mcp/init-api.test.ts tests/packages/pi-extension.test.ts tests/packages/opencode-plugin.test.ts tests/core/adapters/generic.test.ts` passed: 107 tests. |
+| testing | healthy | `pnpm vitest run tests/cli/commands/interview.test.ts tests/cli/commands/help.test.ts tests/cli/registry.test.ts tests/cli/roadmap.test.ts tests/cli/template-generator.test.ts tests/mcp/init-api.test.ts tests/packages/pi-extension.test.ts tests/packages/opencode-plugin.test.ts tests/core/adapters/generic.test.ts` passed: 156 tests. |
+| testing | healthy | `pnpm test` passed: 235 files, 3670 tests, 25 skipped. |
+| testing | healthy | `pnpm build` passed. |
+| docs | healthy | `node dist/cli/index.js help roadmap` showed the new `slope roadmap interview` alias and planning breadcrumbs. |
+| docs | healthy | `node dist/cli/index.js validate docs/retros/sprint-152.1.json` passed with no errors or warnings. |
+| docs | healthy | `node dist/cli/index.js roadmap validate --path=docs/backlog/roadmap.json` passed with existing historical ticket-count warnings and the expected branch-not-on-main warning for S152.1 until merge. |
+
+### Course Management Notes
+
+- The issue was a supported-surface discoverability bug, not a missing interview engine.
+- The alias deliberately delegates to the existing interview command so behavior stays single-sourced.
+- Regression coverage is spread across execution, help metadata, MCP search, Pi, OpenCode, Codex template, and generic adapter output.
+
+### 19th Hole
+
+- **How did it feel?** A satisfying discoverability fix: the system already had the interview, but the doors into it were too easy for agents to miss.
+- **Advice for next player?** When a user asks for a high-level workflow, search command aliases, help metadata, MCP descriptions, and harness templates together; agents learn from all of those surfaces.
+- **What surprised you?** The fix was less about new capability and more about vocabulary. Adding `roadmap interview` made the existing flow line up with how people naturally ask for it.
+- **Excited about next?** S153 can now start after a cleaner planning surface, with the roadmap interview no longer hiding behind setup/init language.

--- a/docs/retros/sprint-152.1.json
+++ b/docs/retros/sprint-152.1.json
@@ -1,0 +1,164 @@
+{
+  "sprint_number": 152.1,
+  "player": "codex",
+  "theme": "Roadmap Interview Discoverability and Harness Routing",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-06-15",
+  "type": "bugfix + dx",
+  "skills_used": [
+    "slope-sprint-workflow"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow"
+  ],
+  "skill_gaps_found": [],
+  "shots": [
+    {
+      "ticket_key": "S152.1-1",
+      "title": "Add a `slope roadmap interview` alias or guided handoff to the existing interview/vision flow",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added `slope roadmap interview` as an alias that delegates to the existing interview command, including --agent JSON-mode coverage that writes the roadmap artifacts."
+    },
+    {
+      "ticket_key": "S152.1-2",
+      "title": "Cross-reference `slope interview`, `slope vision`, and `slope roadmap generate` in roadmap help and command metadata",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Updated roadmap help, registry metadata, README, and getting-started docs so roadmap planning points at the interview, vision, and generate flows."
+    },
+    {
+      "ticket_key": "S152.1-3",
+      "title": "Verify interview discovery paths for supported harness surfaces: CLI, MCP init helpers, Pi extension, Codex/OpenCode adapter docs, and generic adapter guidance",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Surfaced roadmap interview guidance through MCP init search descriptions, Pi onboarding/planning messages, Codex/OpenCode templates, generated adapter docs, and the generic adapter README."
+    },
+    {
+      "ticket_key": "S152.1-4",
+      "title": "Add regression coverage for roadmap interview alias/help plus agent and Pi discovery flows",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added regression coverage for roadmap help discovery, CLI alias execution, MCP init search discoverability, Pi tool guidance, OpenCode slash-command description, and generated harness docs."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "wind",
+      "impact": "minor",
+      "description": "The sprint was triggered by an agent-discoverability miss: roadmap tooling existed, but supported harnesses did not make the interview flow obvious from roadmap-planning language."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "When an existing command is the right answer, add an alias and discovery breadcrumbs at the user phrase boundary instead of duplicating the workflow.",
+      "outcome": "`slope roadmap interview` now routes to `slope interview`, while docs and harness prompts explain the existing vision/generate path."
+    },
+    {
+      "type": "lessons",
+      "description": "Discovery bugs need harness-level assertions, not just CLI help assertions.",
+      "outcome": "Coverage now spans CLI help/registry, MCP init search, Pi onboarding, OpenCode command text, Codex templates, and generic adapter output."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "`pnpm vitest run tests/cli/commands/interview.test.ts` passed: 5 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm vitest run tests/cli/commands/help.test.ts tests/cli/registry.test.ts` passed: 13 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm vitest run tests/cli/template-generator.test.ts tests/mcp/init-api.test.ts tests/packages/pi-extension.test.ts tests/packages/opencode-plugin.test.ts tests/core/adapters/generic.test.ts` passed: 107 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm vitest run tests/cli/commands/interview.test.ts tests/cli/commands/help.test.ts tests/cli/registry.test.ts tests/cli/roadmap.test.ts tests/cli/template-generator.test.ts tests/mcp/init-api.test.ts tests/packages/pi-extension.test.ts tests/packages/opencode-plugin.test.ts tests/core/adapters/generic.test.ts` passed: 156 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm test` passed: 235 files, 3670 tests, 25 skipped.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm build` passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "`node dist/cli/index.js help roadmap` showed the new `slope roadmap interview` alias and planning breadcrumbs.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "`node dist/cli/index.js validate docs/retros/sprint-152.1.json` passed with no errors or warnings.",
+      "status": "healthy"
+    },
+    {
+      "category": "docs",
+      "description": "`node dist/cli/index.js roadmap validate --path=docs/backlog/roadmap.json` passed with existing historical ticket-count warnings and the expected branch-not-on-main warning for S152.1 until merge.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A satisfying discoverability fix: the system already had the interview, but the doors into it were too easy for agents to miss.",
+    "advice_for_next_player": "When a user asks for a high-level workflow, search command aliases, help metadata, MCP descriptions, and harness templates together; agents learn from all of those surfaces.",
+    "what_surprised_you": "The fix was less about new capability and more about vocabulary. Adding `roadmap interview` made the existing flow line up with how people naturally ask for it.",
+    "excited_about_next": "S153 can now start after a cleaner planning surface, with the roadmap interview no longer hiding behind setup/init language."
+  },
+  "bunker_locations": [
+    "Roadmap planning language can drift away from the original `slope interview` and MCP init naming.",
+    "Harness prompt templates can silently lag CLI capabilities unless regression tests assert generated guidance.",
+    "Pi and OpenCode surfaces need explicit planning-language breadcrumbs because users may never inspect full CLI help."
+  ],
+  "yardage_book_updates": [
+    "src/cli/commands/roadmap.ts now accepts `slope roadmap interview` and documents the alias.",
+    "src/cli/registry.ts and help tests now advertise roadmap interview and the vision/generate path.",
+    "src/mcp/registry.ts and src/mcp/index.ts make roadmap interview language discover MCP init helpers.",
+    "packages/pi-extension/src/index.ts and packages/opencode-plugin/src/index.ts surface planning-interview guidance in harness UX.",
+    "src/cli/template-generator.ts, Codex skill templates, docs, and adapter README output now mention the roadmap interview flow."
+  ],
+  "course_management_notes": [
+    "The issue was a supported-surface discoverability bug, not a missing interview engine.",
+    "The alias deliberately delegates to the existing interview command so behavior stays single-sourced.",
+    "Regression coverage is spread across execution, help metadata, MCP search, Pi, OpenCode, Codex template, and generic adapter output."
+  ],
+  "slope_factors": [
+    "roadmap_planning_vocabulary",
+    "harness_discoverability",
+    "mcp_init_naming",
+    "agent_help_surface"
+  ]
+}

--- a/packages/opencode-plugin/src/index.ts
+++ b/packages/opencode-plugin/src/index.ts
@@ -131,7 +131,7 @@ export default function slopePlugin(ctx: OpenCodeContext): void {
 
   // ── Slash Commands ────────────────────────────────
 
-  ctx.registerCommand('slope', 'Run any SLOPE CLI command', async (args: string) => {
+  ctx.registerCommand('slope', 'Run any SLOPE CLI command; use "roadmap interview --agent" for planning interviews', async (args: string) => {
     return slopeCmd(args || 'briefing --compact', cwd);
   });
 

--- a/packages/pi-extension/src/index.ts
+++ b/packages/pi-extension/src/index.ts
@@ -649,7 +649,7 @@ export default function slopeExtension(pi: ExtensionAPI, _cwdOverride?: string):
 
   pi.on('session_start', async (_event, ctx) => {
     briefingInjected = false;
-    ctx.ui.notify('SLOPE loaded — use /slope, /sprint, /slope-settings, or ask for slope_* tools', 'info');
+    ctx.ui.notify('SLOPE loaded - use /slope, /sprint, /slope-settings, slope_interview, or other slope_* tools', 'info');
   });
 
   if (isSkillEnabled(settings, 'briefing')) {
@@ -674,7 +674,7 @@ export default function slopeExtension(pi: ExtensionAPI, _cwdOverride?: string):
               'This project has SLOPE initialized, but no sprint is active yet. Please help get things set up:\n\n' +
               '1. **Understand the project**: Read README.md, package.json, and explore key source files to understand what\'s been built.\n' +
               '2. **Index the codebase**: Run `slope map` to generate CODEBASE.md for architectural context.\n' +
-              '3. **Interview the user**: Ask 2–3 quick questions about the project goals, team size, and current priorities.\n' +
+              '3. **Interview the user**: Run the `slope_interview` tool, or use `slope roadmap interview --agent` from the CLI.\n' +
               '4. **Start Sprint 1**: Once you have context, suggest creating a sprint plan with `slope sprint start` or by editing docs/backlog/roadmap.json.\n\n' +
               'Session mode: adhoc (sprint-workflow guards are silenced until a sprint begins).\n' +
               'Use /slope or the slope_* tools anytime for SLOPE commands.',
@@ -716,8 +716,9 @@ export default function slopeExtension(pi: ExtensionAPI, _cwdOverride?: string):
             'The project is initialized and ready for sprint planning.\n\n' +
             'Suggested next steps:\n' +
             '1. Review docs/backlog/roadmap.json and refine the starter sprint\n' +
-            '2. Run `slope sprint start --number=1` to activate Sprint 1\n' +
-            '3. Use `slope sprint run S1 --workflow=sprint-standard` to begin execution\n\n' +
+            '2. If planning inputs are missing, run `slope_interview` or `slope roadmap interview --agent`\n' +
+            '3. Run `slope sprint start --number=1` to activate Sprint 1\n' +
+            '4. Use `slope sprint run S1 --workflow=sprint-standard` to begin execution\n\n' +
             'Session mode: planning (workflow guards are relaxed).',
           display: true,
         },

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -25,6 +25,7 @@ import {
 import type { RoadmapDefinition, RoadmapSprint, RoadmapTicket, RoadmapClub, GolfScorecard } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { buildRoadmapReality, formatRoadmapRealitySection } from '../pre-sprint-reality.js';
+import { interviewCommand } from './interview.js';
 
 // --- Helpers ---
 
@@ -729,11 +730,15 @@ export async function roadmapCommand(args: string[]): Promise<void> {
     case 'generate':
       await generateSubcommand(flags, cwd);
       break;
+    case 'interview':
+      await interviewCommand(args.slice(1));
+      break;
     default:
       console.log(`
 slope roadmap — Strategic planning tools
 
 Usage:
+  slope roadmap interview [--agent] [--force]       Run project interview for planning input
   slope roadmap validate [--path=<file>]     Schema + dependency graph checks
   slope roadmap review [--path=<file>]       Automated architect review
   slope roadmap status [--path=<file>] [--sprint=N] [--full]  Compact current progress
@@ -746,6 +751,10 @@ Options:
   --sprint=N       Override current sprint number (for status)
   --full           Show full roadmap history for status
   --dry-run        Show what would change without writing (for sync and generate)
+
+Interview delegates to \`slope interview\`. Use \`--agent\` for JSON I/O, or
+\`slope vision create/update\` plus \`slope roadmap generate\` when you already
+have planning answers.
 
 Generate requires concrete backlog signals from source TODO/FIXME/HACK comments
 or synced issue data. It fails instead of creating placeholder planning tickets

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -491,8 +491,12 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
 
   // ── Planning ───────────────────────────────────────────────────
   {
-    cmd: 'roadmap', desc: 'Strategic planning and roadmap tools', category: 'planning', audience: 'human',
+    cmd: 'roadmap', desc: 'Strategic planning, interview handoff, and roadmap tools', category: 'planning', audience: 'human',
     subcommands: [
+      { name: 'interview', desc: 'Run project interview for planning input (alias of slope interview)', flags: [
+        { flag: '--agent', desc: 'JSON I/O mode for agent harnesses' },
+        { flag: '--force', desc: 'Re-interview even if project already initialized' },
+      ]},
       { name: 'validate', desc: 'Schema + dependency graph checks', flags: [
         { flag: '--path=<file>', desc: 'Roadmap file path' },
       ]},
@@ -510,8 +514,9 @@ export const CLI_COMMAND_REGISTRY: readonly CliCommandMeta[] = [
         { flag: '--path=<file>', desc: 'Roadmap file path' },
         { flag: '--dry-run', desc: 'Preview without writing' },
       ]},
-      { name: 'generate', desc: 'Generate from vision + backlog analysis', flags: [
+      { name: 'generate', desc: 'Generate from vision + backlog analysis after slope vision create/update', flags: [
         { flag: '--path=<file>', desc: 'Output roadmap file path' },
+        { flag: '--dry-run', desc: 'Preview without writing' },
       ]},
     ],
   },

--- a/src/cli/template-generator.ts
+++ b/src/cli/template-generator.ts
@@ -34,11 +34,13 @@ This project uses the SLOPE framework for sprint tracking.
 - \`slope validate\` — validate ${r.scorecard.toLowerCase()}s
 - \`slope review\` — generate sprint review
 - \`slope briefing\` — ${r.briefing.toLowerCase()}
+- \`slope roadmap interview\` — collect planning input when roadmap direction is unclear
 
 ## MCP Tools
 A SLOPE MCP server is configured in \`.mcp.json\`. Two tools:
 - \`search\` — discover API functions, types, constants
 - \`execute\` — run JS with full SLOPE API in sandbox
+- \`search({ module: 'init' })\` — discover roadmap interview questions and submit helpers
 
 ## Sprint Workflow
 - **Pre-${r.sprint}:** \`slope now\`, then \`slope start\` or \`slope start --ticket=KEY\`
@@ -78,11 +80,12 @@ The SLOPE framework organizes sprint work into a hierarchy of routines${m.id ===
 Before starting a new phase or project:
 
 1. **Define the vision** — What does the end state look like? Document in a vision doc
-2. **Build the roadmap** — Create \`docs/backlog/roadmap.json\` with sprints, dependencies, and phases
-3. **Run \`slope roadmap validate\`** — Check for structural issues, dependency cycles, numbering gaps
-4. **Run \`slope roadmap review\`** — Automated architect review: scope balance, critical path, bottlenecks
-5. **Identify the critical path** — Run \`slope roadmap show\` to see the dependency graph and parallel tracks
-6. **Plan parallel tracks** — If sprints can run concurrently, plan for multi-agent execution
+2. **Run \`slope roadmap interview\` when direction is unclear** — Use \`--agent\` for JSON-mode agent harnesses
+3. **Build the roadmap** — Create \`docs/backlog/roadmap.json\` with sprints, dependencies, and phases
+4. **Run \`slope roadmap validate\`** — Check for structural issues, dependency cycles, numbering gaps
+5. **Run \`slope roadmap review\`** — Automated architect review: scope balance, critical path, bottlenecks
+6. **Identify the critical path** — Run \`slope roadmap show\` to see the dependency graph and parallel tracks
+7. **Plan parallel tracks** — If sprints can run concurrently, plan for multi-agent execution
 
 ## Pre-${r.sprint} Routine (Sprint Start)
 
@@ -315,11 +318,13 @@ This project uses the SLOPE framework for sprint tracking.
 - \`slope validate\` — validate ${r.scorecard.toLowerCase()}s
 - \`slope review\` — generate sprint review
 - \`slope briefing\` — ${r.briefing.toLowerCase()}
+- \`slope roadmap interview\` — collect planning input when roadmap direction is unclear
 
 ## MCP Tools
 A SLOPE MCP server is configured in \`opencode.json\`. Two tools:
 - \`search\` — discover API functions, types, constants
 - \`execute\` — run JS with full SLOPE API in sandbox
+- \`search({ module: 'init' })\` — discover roadmap interview questions and submit helpers
 
 ## Sprint Workflow
 - **Pre-${r.sprint}:** \`slope now\`, then \`slope start\` or \`slope start --ticket=KEY\`
@@ -441,10 +446,11 @@ The SLOPE framework organizes sprint work into a hierarchy of routines${m.id ===
 
 Before starting a new phase or project:
 
-1. **Build the roadmap** — Create \`docs/backlog/roadmap.json\` with sprints, dependencies, and phases
-2. **Run \`slope roadmap validate\`** — Check for dependency cycles, numbering gaps
-3. **Run \`slope roadmap review\`** — Scope balance, critical path, bottlenecks
-4. **Run \`slope roadmap show\`** — Dependency graph and parallel tracks
+1. **Run \`slope roadmap interview\` when direction is unclear** — Use \`--agent\` for JSON-mode agent harnesses
+2. **Build the roadmap** — Create \`docs/backlog/roadmap.json\` with sprints, dependencies, and phases
+3. **Run \`slope roadmap validate\`** — Check for dependency cycles, numbering gaps
+4. **Run \`slope roadmap review\`** — Scope balance, critical path, bottlenecks
+5. **Run \`slope roadmap show\`** — Dependency graph and parallel tracks
 
 ## Pre-${r.sprint} Routine (Sprint Start)
 
@@ -578,11 +584,13 @@ This project uses the SLOPE framework for sprint tracking.
 - \`slope validate\` — validate ${r.scorecard.toLowerCase()}s
 - \`slope review\` — generate sprint review
 - \`slope briefing\` — ${r.briefing.toLowerCase()}
+- \`slope roadmap interview\` — collect planning input when roadmap direction is unclear
 
 ## MCP Tools
 A SLOPE MCP server is configured in \`${mcpPath}\`. Two tools:
 - \`search\` — discover API functions, types, constants
 - \`execute\` — run JS with full SLOPE API in sandbox
+- \`search({ module: 'init' })\` — discover roadmap interview questions and submit helpers
 
 ## Sprint Workflow
 - **Pre-${r.sprint}:** \`slope now\`, then \`slope start\` or \`slope start --ticket=KEY\`
@@ -622,10 +630,11 @@ export function generateGenericChecklist(m: MetaphorDefinition): string {
   return `# SLOPE Sprint Checklist
 
 ## Pre-Tournament (Course Strategy)
-1. Build roadmap in \`docs/backlog/roadmap.json\`
-2. Run \`slope roadmap validate\` — check dependencies and structure
-3. Run \`slope roadmap review\` — scope balance, critical path, bottlenecks
-4. Run \`slope roadmap show\` — view dependency graph
+1. Run \`slope roadmap interview\` when planning direction is unclear
+2. Build roadmap in \`docs/backlog/roadmap.json\`
+3. Run \`slope roadmap validate\` — check dependencies and structure
+4. Run \`slope roadmap review\` — scope balance, critical path, bottlenecks
+5. Run \`slope roadmap show\` — view dependency graph
 
 ## Pre-${r.sprint} (Sprint Start)
 1. Run \`slope now\` — current sprint, state, claims, next action

--- a/src/core/adapters/generic.ts
+++ b/src/core/adapters/generic.ts
@@ -150,6 +150,11 @@ export class GenericAdapter implements HarnessAdapter {
         '{ "action": "allow" | "deny" | "context", "message": "...", "reason": "..." }',
         '```',
         '',
+        '## Roadmap Planning',
+        '',
+        'If an agent or user asks for a roadmap interview, run `slope roadmap interview`.',
+        'Agent harnesses can use `slope roadmap interview --agent` or MCP `search({ module: "init" })`.',
+        '',
         'See `guards-manifest.json` for the full list of guards and their hook events.',
         '',
       ].join('\n');

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1182,6 +1182,7 @@ function handleInitQuery(): string {
 
   sections.push('# SLOPE Init — Agent API\n');
   sections.push('Use `getInitQuestions()` and `submitInitAnswers()` to drive `slope init` programmatically.\n');
+  sections.push('For roadmap planning interviews, collect the same answers here or run `slope roadmap interview --agent` from the CLI.\n');
 
   sections.push('## Workflow\n');
   sections.push('1. Call `getInitQuestions()` to get interview steps with smart defaults');

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -853,14 +853,14 @@ export const SLOPE_REGISTRY: FunctionRegistryEntry[] = [
   {
     name: 'getInitQuestions',
     module: 'init',
-    description: 'Get interview steps for slope init with smart defaults pre-filled. See also: submitInitAnswers().',
+    description: 'Get roadmap interview/init steps with smart defaults pre-filled. Use when an agent needs a roadmap interview. See also: submitInitAnswers().',
     signature: 'getInitQuestions(): { steps: InterviewStep[], context: InterviewContext }',
     example: 'return getInitQuestions();',
   },
   {
     name: 'submitInitAnswers',
     module: 'init',
-    description: 'Run slope init with provided answers. See also: getInitQuestions().',
+    description: 'Submit roadmap interview/init answers and run slope init. See also: getInitQuestions().',
     signature: 'submitInitAnswers(answers: Record<string, unknown>, providers?: string[]): Promise<InitFromAnswersResult>',
     example: 'return await submitInitAnswers({ "project-name": "my-app", "metaphor": "gaming" }, ["claude-code"]);',
   },

--- a/templates/codex/plugins/slope/skills/slope-setup/SKILL.md
+++ b/templates/codex/plugins/slope/skills/slope-setup/SKILL.md
@@ -24,6 +24,10 @@ Use this when the user wants SLOPE available from an agent harness.
 4. Run `bash -n .codex/hooks/slope-guard.sh` or `bash -n ~/.codex/hooks/slope-guard.sh`.
 5. Restart Codex and review `/hooks` after hook changes.
 
+## Planning Discovery
+
+When the user asks for a roadmap interview, run `slope roadmap interview` or `slope roadmap interview --agent`. If using MCP directly, call `search({ module: "init" })` to discover `getInitQuestions()` and `submitInitAnswers()`.
+
 ## Explain
 
 Tell the user that the Codex plugin bundle groups SLOPE skills, MCP metadata, and future plugin-hook metadata under a named SLOPE integration. Active guard enforcement still uses the stable Codex hooks.json shim while Codex `plugin_hooks` is under development.

--- a/templates/codex/plugins/slope/skills/slope-sprint/SKILL.md
+++ b/templates/codex/plugins/slope/skills/slope-sprint/SKILL.md
@@ -12,6 +12,7 @@ Use these commands from the repository root.
 1. Run `slope sprint status`.
 2. If no sprint is active, run `slope next` and `slope briefing --sprint=<next>`.
 3. If a sprint is active, run `slope briefing --sprint=<active>` before editing.
+4. If the user asks for a roadmap interview or planning input, run `slope roadmap interview` or `slope roadmap interview --agent`; MCP agents can also search `module: "init"`.
 
 ## Start Or Claim
 

--- a/tests/cli/commands/help.test.ts
+++ b/tests/cli/commands/help.test.ts
@@ -68,6 +68,16 @@ describe('slope help', () => {
     expect(output).toContain('--target=<path>');
   });
 
+  it('shows roadmap interview and vision-generation breadcrumbs', async () => {
+    await helpCommand(['roadmap']);
+
+    const output = consoleOutput.join('\n');
+    expect(output).toContain('slope roadmap interview');
+    expect(output).toContain('alias of slope interview');
+    expect(output).toContain('slope vision create/update');
+    expect(output).toContain('--dry-run');
+  });
+
   it('teaches the --all escape hatch in help usage', async () => {
     await helpCommand(['--help']);
 

--- a/tests/cli/commands/interview.test.ts
+++ b/tests/cli/commands/interview.test.ts
@@ -59,6 +59,33 @@ describe('slope interview CLI', () => {
     expect(last.filesCreated).toBeDefined();
   });
 
+  it('roadmap interview alias reaches agent JSON mode', () => {
+    const result = execSync(
+      `node "${join(process.cwd(), 'dist/cli/index.js')}" roadmap interview --agent`,
+      {
+        cwd,
+        encoding: 'utf8',
+        input: JSON.stringify({ id: 'project-name', value: 'RoadmapProject' }) + '\n' +
+               JSON.stringify({ id: 'metaphor', value: 'golf' }) + '\n' +
+               JSON.stringify({ id: 'repo-url', value: '' }) + '\n' +
+               JSON.stringify({ id: 'sprint-number', value: '1' }) + '\n' +
+               JSON.stringify({ id: 'platforms', value: [] }) + '\n' +
+               JSON.stringify({ id: 'team-members', value: '' }) + '\n' +
+               JSON.stringify({ id: 'vision', value: 'Plan the product roadmap' }) + '\n' +
+               JSON.stringify({ id: 'deep-analysis', value: false }) + '\n',
+      }
+    );
+
+    const lines = result.trim().split('\n');
+    const first = JSON.parse(lines[0]);
+    expect(first.type).toBe('question');
+    expect(first.id).toBe('project-name');
+
+    const last = JSON.parse(lines[lines.length - 1]);
+    expect(last.type).toBe('complete');
+    expect(last.filesCreated).toContain(join(cwd, 'docs', 'backlog', 'roadmap.json'));
+  });
+
   it('agent mode rejects invalid JSON input', () => {
     const result = execSync(
       `node "${join(process.cwd(), 'dist/cli/index.js')}" interview --agent`,

--- a/tests/cli/roadmap.test.ts
+++ b/tests/cli/roadmap.test.ts
@@ -693,6 +693,10 @@ describe('slope roadmap (no subcommand)', () => {
 
     const output = consoleOutput.join('\n');
     expect(output).toContain('slope roadmap');
+    expect(output).toContain('slope roadmap interview');
+    expect(output).toContain('Interview delegates to `slope interview`');
+    expect(output).toContain('slope vision create/update');
+    expect(output).toContain('slope roadmap generate');
     expect(output).toContain('validate');
     expect(output).toContain('review');
     expect(output).toContain('status');

--- a/tests/cli/template-generator.test.ts
+++ b/tests/cli/template-generator.test.ts
@@ -20,6 +20,8 @@ describe('generateProjectContext', () => {
     expect(content).toContain('handicap card');
     expect(content).toContain('slope now');
     expect(content).toContain('slope start [--ticket=KEY]');
+    expect(content).toContain('slope roadmap interview');
+    expect(content).toContain("search({ module: 'init' })");
     expect(content).toContain('pre-round briefing');
     expect(content).toContain('Human Surface');
     expect(content).toContain('Pre-Hole');
@@ -44,6 +46,7 @@ describe('generateSprintChecklist', () => {
     expect(content).toContain('Pre-Hole Routine (Sprint Start)');
     expect(content).toContain('Run `slope now`');
     expect(content).toContain('Run `slope start` or `slope start --ticket=KEY`');
+    expect(content).toContain('Run `slope roadmap interview` when direction is unclear');
     expect(content).toContain('Pre-Shot Routine (Per-Ticket, Before Code)');
     expect(content).toContain('Post-Shot Routine (Per-Ticket, After Completion)');
     expect(content).toContain('Post-Hole Routine (Sprint Completion)');
@@ -147,6 +150,8 @@ describe('generateAgentsMd', () => {
     expect(content).toContain('opencode.json');
     expect(content).toContain('handicap card');
     expect(content).toContain('slope now');
+    expect(content).toContain('slope roadmap interview');
+    expect(content).toContain("search({ module: 'init' })");
     expect(content).toContain('Human Surface');
     expect(content).toContain('Commit Discipline');
     expect(content).toContain('Driver: risky');
@@ -168,6 +173,8 @@ describe('generateCursorrules', () => {
     expect(content).toContain('.cursor/mcp.json');
     expect(content).toContain('handicap card');
     expect(content).toContain('slope now');
+    expect(content).toContain('slope roadmap interview');
+    expect(content).toContain("search({ module: 'init' })");
     expect(content).toContain('Human Surface');
     expect(content).toContain('Pre-Hole');
     expect(content).toContain('Post-Hole');
@@ -193,6 +200,7 @@ describe('generateGenericChecklist', () => {
     expect(content).toContain('slope now');
     expect(content).toContain('slope start');
     expect(content).toContain('slope briefing');
+    expect(content).toContain('slope roadmap interview');
     expect(content).toContain('slope validate');
     expect(content).toContain('slope review');
     expect(content).toContain('slope card');

--- a/tests/core/adapters/generic.test.ts
+++ b/tests/core/adapters/generic.test.ts
@@ -131,6 +131,8 @@ describe('GenericAdapter', () => {
       const readme = readFileSync(join(hooksDir, 'README.md'), 'utf8');
       expect(readme).toContain('slope-guard.sh');
       expect(readme).toContain('PreToolUse');
+      expect(readme).toContain('slope roadmap interview');
+      expect(readme).toContain('search({ module: "init" })');
     });
 
     it('does not overwrite existing dispatcher', () => {

--- a/tests/mcp/init-api.test.ts
+++ b/tests/mcp/init-api.test.ts
@@ -107,6 +107,7 @@ describe('registry entries', () => {
     expect(entry!.module).toBe('init');
     expect(entry!.signature).toContain('InterviewStep');
     expect(entry!.signature).toContain('InterviewContext');
+    expect(entry!.description).toContain('roadmap interview');
   });
 
   it('submitInitAnswers entry has correct module and signature', () => {
@@ -114,5 +115,16 @@ describe('registry entries', () => {
     expect(entry).toBeDefined();
     expect(entry!.module).toBe('init');
     expect(entry!.signature).toContain('InitFromAnswersResult');
+    expect(entry!.description).toContain('roadmap interview');
+  });
+
+  it('roadmap interview search terms discover init helpers', () => {
+    const q = 'roadmap interview';
+    const matches = SLOPE_REGISTRY.filter((e) =>
+      e.name.toLowerCase().includes(q) || e.description.toLowerCase().includes(q),
+    ).map((e) => e.name);
+
+    expect(matches).toContain('getInitQuestions');
+    expect(matches).toContain('submitInitAnswers');
   });
 });

--- a/tests/packages/opencode-plugin.test.ts
+++ b/tests/packages/opencode-plugin.test.ts
@@ -67,6 +67,8 @@ describe('OpenCode Plugin', () => {
       expect(commands).toContain('slope');
       expect(commands).toContain('sprint');
       expect(commands).toContain('guard-check');
+      const slopeCommand = mockCtx.registerCommand.mock.calls.find((c: unknown[]) => c[0] === 'slope');
+      expect(slopeCommand?.[1]).toContain('roadmap interview --agent');
     });
 
     it('session.created injects briefing', async () => {

--- a/tests/packages/pi-extension.test.ts
+++ b/tests/packages/pi-extension.test.ts
@@ -134,6 +134,10 @@ describe('Pi Extension', () => {
         expect.stringContaining('SLOPE loaded'),
         'info',
       );
+      expect(ctx.ui.notify).toHaveBeenCalledWith(
+        expect.stringContaining('slope_interview'),
+        'info',
+      );
     });
 
     it('before_agent_start injects onboarding message for fresh project', async () => {
@@ -145,6 +149,8 @@ describe('Pi Extension', () => {
       const result = await handler({}, makeCtx(tmpDir));
       expect(result?.message.content).toContain('🎯 SLOPE Onboarding');
       expect(result?.message.content).toContain('slope map');
+      expect(result?.message.content).toContain('slope_interview');
+      expect(result?.message.content).toContain('slope roadmap interview --agent');
 
       // Second call should return nothing (dedup)
       const result2 = await handler({}, makeCtx(tmpDir));
@@ -256,6 +262,7 @@ describe('Pi Extension', () => {
 
       const result = await handler({}, makeCtx(tmpDir));
       expect(result?.message.content).toContain('Planning Phase');
+      expect(result?.message.content).toContain('slope_interview');
       expect(result?.message.content).toContain('sprint start');
     });
   });


### PR DESCRIPTION
## Summary

Fixes the roadmap interview discoverability gap by making the existing project interview reachable from roadmap-planning language and supported harness surfaces.

## What changed

- Added `slope roadmap interview` as an alias for the existing `slope interview` flow, including `--agent` JSON-mode coverage.
- Cross-referenced `slope interview`, `slope vision create/update`, and `slope roadmap generate` in roadmap help, command metadata, README, and getting-started docs.
- Surfaced roadmap interview guidance through MCP init helper descriptions, Pi extension onboarding/planning messages, OpenCode command text, Codex skill templates, generated harness contexts, and generic adapter output.
- Added S152.1 scorecard and review artifacts, and marked S152.1 complete in the roadmap.

## Root cause

The interview tooling existed, but roadmap-oriented requests did not map clearly onto the original `slope interview` / MCP init naming. Agents could reasonably conclude that roadmap tooling existed without a literal interview path.

## Validation

- `pnpm build`
- `pnpm vitest run tests/cli/commands/interview.test.ts tests/cli/commands/help.test.ts tests/cli/registry.test.ts tests/cli/roadmap.test.ts tests/cli/template-generator.test.ts tests/mcp/init-api.test.ts tests/packages/pi-extension.test.ts tests/packages/opencode-plugin.test.ts tests/core/adapters/generic.test.ts` passed: 156 tests
- `pnpm test` passed: 235 files, 3670 tests, 25 skipped
- `node dist/cli/index.js validate docs/retros/sprint-152.1.json` passed
- `node dist/cli/index.js roadmap validate --path=docs/backlog/roadmap.json` passed with existing historical warnings and the expected branch-not-on-main warning before merge
- `node dist/cli/index.js review docs/retros/sprint-152.1.json` generated `docs/retros/sprint-152.1-review.md`