### PR TITLE
[codex] Release v1.59.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
## Summary

Patch release for the roadmap interview discoverability fix merged in PR #554.

## What changed

- Bumped `@slope-dev/slope` from `1.59.0` to `1.59.1`.
- Bumped the bundled Codex plugin manifest from `1.59.0` to `1.59.1`.

## Release intent

This is a patch release: the shipped change fixes a discoverability bug by adding a roadmap interview alias and harness guidance, without changing public API contracts or introducing breaking behavior.

## Validation

- `pnpm build` passed
- `pnpm typecheck` passed
- `pnpm test` passed: 235 files, 3670 tests, 25 skipped

After merge, create GitHub release `v1.59.1` from `main`; the trusted-publishing workflow should publish to npm.