### PR TITLE
[codex] Normalize SLOPE hook dispatchers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/docs/guides/codex-setup.md
+++ b/docs/guides/codex-setup.md
@@ -41,6 +41,8 @@ It also writes `.codex/.agents/plugins/marketplace.json` so `.codex/` can be use
 
 This bundle is the named SLOPE adapter boundary for Codex. It packages SLOPE skills, MCP server metadata, hook metadata, local marketplace metadata, and a dispatcher script over the SLOPE CLI. Keep using project or user `hooks.json` shims as the active guard runtime path until Codex `plugin_hooks` is stable.
 
+The plugin manifest intentionally declares only supported Codex plugin fields. It includes `skills` and `mcpServers`, but does not declare `hooks`; `hooks.json` remains metadata-only until Codex plugin hook loading is stable and validator-supported.
+
 `slope init --codex` updates SLOPE-owned plugin metadata on repeated runs. Existing non-SLOPE plugin manifests are left alone.
 
 ## Verification

--- a/docs/tech/codex-slope-hooks-handoff.md
+++ b/docs/tech/codex-slope-hooks-handoff.md
@@ -1,7 +1,7 @@
 # Codex SLOPE Hooks Handoff
 
 **Date:** 2026-05-16
-**Status:** Global Codex hooks are active locally; SLOPE plugin runtime hooks remain blocked by Codex plugin hook discovery. SLOPE now ships a named Codex plugin bundle for skills, MCP metadata, local marketplace metadata, and future plugin hook metadata.
+**Status:** Global Codex hooks are active locally; SLOPE plugin runtime hooks remain blocked by Codex plugin hook discovery. SLOPE now ships a named Codex plugin bundle for skills, MCP metadata, local marketplace metadata, and metadata-only future plugin hook definitions.
 
 ## Current Local State
 
@@ -39,8 +39,9 @@ In `/Users/sebastianbryers/Development/slope`:
 1. `src/core/adapters/codex.ts` installs project or user-level hook shims.
 2. `slope init --codex` generates a Codex plugin bundle for SLOPE with:
    - `.codex-plugin/plugin.json`
+   - a validator-compatible manifest that declares `skills` and `mcpServers`, not `hooks`
    - packaged guard dispatcher script
-   - bundled hook metadata for future plugin-hook support
+   - bundled metadata-only hook definitions for future plugin-hook support
    - `skills/` workflow guidance
    - `.mcp.json` server metadata
    - `.codex/.agents/plugins/marketplace.json` local marketplace metadata

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -5,7 +5,7 @@ import { execSync } from 'node:child_process';
 import { createConfig } from '../config.js';
 import { saveHooksConfig } from '../hooks-config.js';
 import { resolveMetaphor } from '../metaphor.js';
-import { detectPackageManager, createVision, analyzeStack, SLOPE_BIN_PREAMBLE, writeOrUpdateManagedScript, GUARD_DEFINITIONS } from '../../core/index.js';
+import { detectPackageManager, createVision, analyzeStack, SLOPE_BIN_PREAMBLE, writeOrUpdateManagedScript, GUARD_DEFINITIONS, normalizeShellScriptLineEndings } from '../../core/index.js';
 import type { StackProfile } from '../../core/analyzers/types.js';
 import type { MetaphorDefinition } from '../../core/index.js';
 import {
@@ -564,16 +564,31 @@ function copyCodexPluginTemplate(srcDir: string, destDir: string, relativeDir = 
       copied += result.copied;
       updated += result.updated;
     } else if (!existsSync(dest)) {
-      cpSync(src, dest);
-      if (relativePath === join('hooks', 'slope-guard.sh')) chmodSync(dest, 0o755);
+      copyCodexPluginFile(src, dest, relativePath);
       copied++;
-    } else if (isManagedCodexPluginFile(relativePath, dest) && readFileSync(src, 'utf8') !== readFileSync(dest, 'utf8')) {
-      cpSync(src, dest, { force: true });
-      if (relativePath === join('hooks', 'slope-guard.sh')) chmodSync(dest, 0o755);
+    } else if (isManagedCodexPluginFile(relativePath, dest) && codexPluginFileChanged(src, dest, relativePath)) {
+      copyCodexPluginFile(src, dest, relativePath);
       updated++;
     }
   }
   return { copied, updated };
+}
+
+function copyCodexPluginFile(src: string, dest: string, relativePath: string): void {
+  if (relativePath.replace(/\\/g, '/').endsWith('.sh')) {
+    writeFileSync(dest, normalizeShellScriptLineEndings(readFileSync(src, 'utf8')), { mode: 0o755 });
+    return;
+  }
+  cpSync(src, dest, { force: true });
+}
+
+function codexPluginFileChanged(src: string, dest: string, relativePath: string): boolean {
+  const srcContent = readFileSync(src, 'utf8');
+  const destContent = readFileSync(dest, 'utf8');
+  if (relativePath.replace(/\\/g, '/').endsWith('.sh')) {
+    return normalizeShellScriptLineEndings(srcContent) !== normalizeShellScriptLineEndings(destContent);
+  }
+  return srcContent !== destContent;
 }
 
 function isManagedCodexPluginFile(relativePath: string, destPath: string): boolean {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -679,12 +679,22 @@ function syncCodexPluginManifest(pluginRoot: string): boolean {
     const version = getSlopePackageVersion();
     if (version) manifest.version = version;
     manifest.skills = './skills/';
-    manifest.hooks = './hooks.json';
+    delete manifest.hooks;
     manifest.mcpServers = './.mcp.json';
+    normalizeCodexPluginDefaultPrompts(manifest);
     return writeJsonIfChanged(manifestPath, manifest);
   } catch {
     return false;
   }
+}
+
+function normalizeCodexPluginDefaultPrompts(manifest: Record<string, unknown>): void {
+  if (!isRecord(manifest.interface)) return;
+  const prompts = manifest.interface.defaultPrompt;
+  if (!Array.isArray(prompts)) return;
+  manifest.interface.defaultPrompt = prompts
+    .filter((prompt): prompt is string => typeof prompt === 'string')
+    .slice(0, 3);
 }
 
 function writeJsonIfChanged(filePath: string, value: unknown): boolean {
@@ -954,7 +964,7 @@ const PROVIDER_NEXT_STEPS: Partial<Record<InitProvider, string[]>> = {
   codex: [
     'Add SLOPE MCP server to .codex/config.toml: [mcp.slope] command="slope" args=["mcp"]',
     'Guards installed to .codex/hooks.json',
-    'Plugin bundle installed to .codex/plugins/slope with skills, MCP metadata, marketplace metadata, and future plugin_hooks metadata',
+    'Plugin bundle installed to .codex/plugins/slope with skills, MCP metadata, marketplace metadata, and metadata-only hook definitions',
     'Track docs/vision.md and docs/backlog/roadmap.json as source of truth (.slope/ stays local)',
     'Branch discipline: branch-before-commit guard blocks direct main commits — use feat/<desc>',
     'First sprint: slope vision create, slope roadmap validate, slope sprint begin --sprint=1 --ticket=S1-1',

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -7,7 +7,7 @@ import { existsSync, writeFileSync, readFileSync, mkdirSync, chmodSync } from 'n
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { HarnessAdapter, HarnessInstallOptions, ToolNameMap } from '../harness.js';
-import { registerAdapter, resolveToolMatcher } from '../harness.js';
+import { normalizeShellScriptLineEndings, registerAdapter, resolveToolMatcher } from '../harness.js';
 import type { GuardResult, AnyGuardDefinition, PreToolUseOutput, PostToolUseOutput, StopOutput, Suggestion } from '../guard.js';
 
 type CodexHookHandler = { type: string; command: string; timeout?: number; statusMessage?: string };
@@ -201,13 +201,13 @@ function writeCodexGuardDispatcher(scriptPath: string, userLevel: boolean): void
         'elif command -v slope >/dev/null 2>&1; then',
         '  SLOPE_BIN="$(command -v slope)"',
         'else',
-        '  SLOPE_BIN="npx --yes @slope-dev/slope"',
+        '  exec npx --yes @slope-dev/slope guard "$@"',
         'fi',
         '',
         'cd "$SLOPE_PROJECT_DIR"',
         'exec "$SLOPE_BIN" guard "$@"',
       ];
-  const script = [
+  const script = normalizeShellScriptLineEndings([
     '#!/usr/bin/env bash',
     '# SLOPE Codex guard dispatcher.',
     '',
@@ -217,10 +217,10 @@ function writeCodexGuardDispatcher(scriptPath: string, userLevel: boolean): void
     ...body,
     MANAGED_END,
     '',
-  ].join('\n');
+  ].join('\n'));
 
   if (existsSync(scriptPath)) {
-    const existing = readFileSync(scriptPath, 'utf8');
+    const existing = normalizeShellScriptLineEndings(readFileSync(scriptPath, 'utf8'));
     const startIdx = existing.indexOf(MANAGED_START);
     const endIdx = existing.indexOf(MANAGED_END);
     if (startIdx !== -1 && endIdx !== -1) {

--- a/src/core/harness.ts
+++ b/src/core/harness.ts
@@ -159,6 +159,10 @@ export const SLOPE_BIN_PREAMBLE: string[] = [
 const MANAGED_START = '# === SLOPE MANAGED (do not edit above this line) ===';
 const MANAGED_END = '# === SLOPE END ===';
 
+export function normalizeShellScriptLineEndings(content: string): string {
+  return content.replace(/\r\n?/g, '\n');
+}
+
 /**
  * Write or update a SLOPE-managed shell script.
  * - New file: writes `fullScript` as-is.
@@ -171,12 +175,15 @@ const MANAGED_END = '# === SLOPE END ===';
  * @returns 'created' | 'updated' | 'unchanged'
  */
 export function writeOrUpdateManagedScript(filePath: string, fullScript: string): 'created' | 'updated' | 'unchanged' {
+  const normalizedScript = normalizeShellScriptLineEndings(fullScript);
+
   if (!existsSync(filePath)) {
-    writeFileSync(filePath, fullScript, { mode: 0o755 });
+    writeFileSync(filePath, normalizedScript, { mode: 0o755 });
     return 'created';
   }
 
-  const existing = readFileSync(filePath, 'utf8');
+  const existingRaw = readFileSync(filePath, 'utf8');
+  const existing = normalizeShellScriptLineEndings(existingRaw);
   const startIdx = existing.indexOf(MANAGED_START);
   const endIdx = existing.indexOf(MANAGED_END);
   if (startIdx === -1 || endIdx === -1) {
@@ -185,14 +192,20 @@ export function writeOrUpdateManagedScript(filePath: string, fullScript: string)
   }
 
   // Extract managed body from the new full script
-  const newStartIdx = fullScript.indexOf(MANAGED_START);
-  const newEndIdx = fullScript.indexOf(MANAGED_END);
+  const newStartIdx = normalizedScript.indexOf(MANAGED_START);
+  const newEndIdx = normalizedScript.indexOf(MANAGED_END);
   if (newStartIdx === -1 || newEndIdx === -1) return 'unchanged';
 
-  const newManaged = fullScript.slice(newStartIdx + MANAGED_START.length, newEndIdx);
+  const newManaged = normalizedScript.slice(newStartIdx + MANAGED_START.length, newEndIdx);
   const oldManaged = existing.slice(startIdx + MANAGED_START.length, endIdx);
 
-  if (newManaged === oldManaged) return 'unchanged';
+  if (newManaged === oldManaged) {
+    if (existingRaw !== existing) {
+      writeFileSync(filePath, existing, { mode: 0o755 });
+      return 'updated';
+    }
+    return 'unchanged';
+  }
 
   // Preserve header + user content, replace only the managed section
   const header = existing.slice(0, startIdx + MANAGED_START.length);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -310,6 +310,7 @@ export {
   clearAdapters,
   resolveToolMatcher,
   SLOPE_BIN_PREAMBLE,
+  normalizeShellScriptLineEndings,
   writeOrUpdateManagedScript,
 } from './harness.js';
 export type {

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -17,16 +17,15 @@
     "hooks"
   ],
   "skills": "./skills/",
-  "hooks": "./hooks.json",
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "SLOPE",
-    "shortDescription": "Sprint tracking, guard hooks, and workflow skills for Codex.",
-    "longDescription": "Packages SLOPE's Codex-facing adapter boundary: guard hook metadata, a dispatcher over the SLOPE CLI, MCP server metadata, and skills for sprint setup, closeout, post-merge retros, and guard-warning handling. Runtime guard execution uses user or project hooks.json shims until Codex plugin_hooks is stable.",
+    "shortDescription": "Sprint tracking, guard shims, and workflow skills for Codex.",
+    "longDescription": "Packages SLOPE's Codex-facing adapter boundary: skills for sprint setup, closeout, post-merge retros, MCP server metadata, and metadata-only hook definitions for future Codex plugin hook support. Runtime guard execution uses user or project hooks.json shims until Codex plugin_hooks is stable.",
     "developerName": "SLOPE",
     "category": "Productivity",
     "capabilities": [
-      "Hooks",
+      "Guard Shims",
       "Skills",
       "MCP"
     ],
@@ -34,10 +33,9 @@
     "privacyPolicyURL": "https://github.com/srbryers/slope",
     "termsOfServiceURL": "https://github.com/srbryers/slope",
     "defaultPrompt": [
-      "Set up SLOPE for this repo from Codex.",
-      "Start or inspect the current SLOPE sprint.",
-      "Close out the sprint with validation and review.",
-      "Run a post-merge retro and save durable learnings."
+      "Set up SLOPE for this repo.",
+      "Start or inspect the current sprint.",
+      "Close out this sprint with review."
     ],
     "brandColor": "#2F6F5E"
   }

--- a/templates/codex/plugins/slope/hooks/slope-guard.sh
+++ b/templates/codex/plugins/slope/hooks/slope-guard.sh
@@ -17,7 +17,7 @@ elif [ -f "$SLOPE_PROJECT_DIR/dist/cli/index.js" ] && [ -f "$SLOPE_PROJECT_DIR/p
 elif command -v slope >/dev/null 2>&1; then
   SLOPE_BIN="$(command -v slope)"
 else
-  SLOPE_BIN="npx --yes @slope-dev/slope"
+  exec npx --yes @slope-dev/slope guard "$@"
 fi
 
 cd "$SLOPE_PROJECT_DIR"

--- a/templates/codex/plugins/slope/skills/slope-setup/SKILL.md
+++ b/templates/codex/plugins/slope/skills/slope-setup/SKILL.md
@@ -30,4 +30,4 @@ When the user asks for a roadmap interview, run `slope roadmap interview` or `sl
 
 ## Explain
 
-Tell the user that the Codex plugin bundle groups SLOPE skills, MCP metadata, and future plugin-hook metadata under a named SLOPE integration. Active guard enforcement still uses the stable Codex hooks.json shim while Codex `plugin_hooks` is under development.
+Tell the user that the Codex plugin bundle exposes SLOPE skills and MCP metadata under a named SLOPE integration. The bundle also includes metadata-only hook definitions for future Codex plugin-hook support, but the plugin manifest intentionally does not declare `hooks` because current Codex plugin validation rejects that field. Active guard enforcement uses the stable Codex hooks.json shim installed by `slope init --codex` while Codex `plugin_hooks` is under development.

--- a/tests/cli/init-codex.test.ts
+++ b/tests/cli/init-codex.test.ts
@@ -127,6 +127,8 @@ describe('slope init --codex (GH #309)', () => {
       expect(existsSync(dispatcherPath)).toBe(true);
       expect(existsSync(skillPath)).toBe(true);
       expect(existsSync(retroSkillPath)).toBe(true);
+      expect(readFileSync(dispatcherPath, 'utf8')).not.toContain('\r\n');
+      expect(readFileSync(dispatcherPath, 'utf8')).toContain('exec npx --yes @slope-dev/slope guard "$@"');
       expect(readFileSync(retroSkillPath, 'utf8')).toContain('slope retro post-merge');
 
       const { manifest, mcp } = expectValidCodexPluginBundle(pluginRoot);

--- a/tests/cli/init-codex.test.ts
+++ b/tests/cli/init-codex.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 
 const REPO_ROOT = resolve(__dirname, '..', '..');
 const SLOPE_BIN = resolve(REPO_ROOT, 'dist', 'cli', 'index.js');
+const STRICT_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
 
 function runSlopeInit(cwd: string, args: string[] = ['--codex']): string {
   return execFileSync(process.execPath, [SLOPE_BIN, 'init', ...args], {
@@ -15,11 +16,57 @@ function runSlopeInit(cwd: string, args: string[] = ['--codex']): string {
   });
 }
 
+function readJson(filePath: string): any {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function expectNonEmptyString(value: unknown): void {
+  expect(typeof value).toBe('string');
+  expect((value as string).length).toBeGreaterThan(0);
+}
+
+function expectValidCodexPluginBundle(pluginRoot: string): { manifest: any; mcp: any } {
+  const manifestPath = join(pluginRoot, '.codex-plugin', 'plugin.json');
+  const manifest = readJson(manifestPath);
+  expect(manifest.name).toBe('slope');
+  expect(manifest.version).toMatch(STRICT_SEMVER);
+  expectNonEmptyString(manifest.description);
+  expectNonEmptyString(manifest.author?.name);
+  expect(Object.prototype.hasOwnProperty.call(manifest, 'hooks')).toBe(false);
+  expect(manifest.skills).toBe('./skills/');
+  expect(manifest.mcpServers).toBe('./.mcp.json');
+  expect(existsSync(join(pluginRoot, manifest.skills))).toBe(true);
+  expect(existsSync(join(pluginRoot, manifest.mcpServers))).toBe(true);
+
+  const iface = manifest.interface;
+  expectNonEmptyString(iface?.displayName);
+  expectNonEmptyString(iface?.shortDescription);
+  expectNonEmptyString(iface?.longDescription);
+  expectNonEmptyString(iface?.developerName);
+  expectNonEmptyString(iface?.category);
+  expect(Array.isArray(iface?.capabilities)).toBe(true);
+  expect(iface.capabilities.length).toBeGreaterThan(0);
+  expect(Array.isArray(iface?.defaultPrompt)).toBe(true);
+  expect(iface.defaultPrompt.length).toBeLessThanOrEqual(3);
+  for (const prompt of iface.defaultPrompt) {
+    expectNonEmptyString(prompt);
+    expect(prompt.length).toBeLessThanOrEqual(128);
+  }
+
+  const mcp = readJson(join(pluginRoot, manifest.mcpServers));
+  expect(mcp.mcpServers.slope).toEqual({ command: 'slope', args: ['mcp'] });
+  return { manifest, mcp };
+}
+
 describe('slope init --codex (GH #309)', () => {
   beforeAll(() => {
     if (!existsSync(SLOPE_BIN)) {
       throw new Error(`dist not built — run \`pnpm build\` first. Expected ${SLOPE_BIN}`);
     }
+  });
+
+  it('keeps the bundled Codex plugin template validator-compatible', () => {
+    expectValidCodexPluginBundle(join(REPO_ROOT, 'templates', 'codex', 'plugins', 'slope'));
   });
 
   it('creates AGENTS.md with project context (#340)', () => {
@@ -82,16 +129,17 @@ describe('slope init --codex (GH #309)', () => {
       expect(existsSync(retroSkillPath)).toBe(true);
       expect(readFileSync(retroSkillPath, 'utf8')).toContain('slope retro post-merge');
 
-      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-      const marketplace = JSON.parse(readFileSync(marketplacePath, 'utf8'));
-      const mcp = JSON.parse(readFileSync(mcpPath, 'utf8'));
-      const hooks = JSON.parse(readFileSync(hooksPath, 'utf8'));
+      const { manifest, mcp } = expectValidCodexPluginBundle(pluginRoot);
+      const marketplace = readJson(marketplacePath);
+      const hooks = readJson(hooksPath);
       const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
       expect(manifest.name).toBe('slope');
       expect(manifest.version).toBe(pkg.version);
       expect(manifest.skills).toBe('./skills/');
-      expect(manifest.hooks).toBe('./hooks.json');
+      expect(Object.prototype.hasOwnProperty.call(manifest, 'hooks')).toBe(false);
       expect(manifest.mcpServers).toBe('./.mcp.json');
+      expect(marketplace.name).toBe('slope-local');
+      expect(marketplace.interface.displayName).toBe('SLOPE Local');
       expect(marketplace.plugins).toContainEqual({
         name: 'slope',
         source: { source: 'local', path: './plugins/slope' },
@@ -135,6 +183,14 @@ describe('slope init --codex (GH #309)', () => {
         name: 'slope',
         version: '0.0.1',
         hooks: './old-hooks.json',
+        interface: {
+          defaultPrompt: [
+            'Set up SLOPE for this repo from Codex.',
+            'Start or inspect the current SLOPE sprint.',
+            'Close out the sprint with validation and review.',
+            'Run a post-merge retro and save durable learnings.',
+          ],
+        },
       }, null, 2) + '\n');
 
       runSlopeInit(cwd);
@@ -148,8 +204,9 @@ describe('slope init --codex (GH #309)', () => {
 
       expect(manifest.version).toBe(pkg.version);
       expect(manifest.skills).toBe('./skills/');
-      expect(manifest.hooks).toBe('./hooks.json');
+      expect(Object.prototype.hasOwnProperty.call(manifest, 'hooks')).toBe(false);
       expect(manifest.mcpServers).toBe('./.mcp.json');
+      expect(manifest.interface.defaultPrompt).toHaveLength(3);
       expect(commands).toContain('"./hooks/slope-guard.sh" claim-required');
       expect(commands).toContain('"./hooks/slope-guard.sh" pr-review');
     } finally {

--- a/tests/core/adapters/codex.test.ts
+++ b/tests/core/adapters/codex.test.ts
@@ -212,7 +212,32 @@ describe('CodexAdapter', () => {
 
       const config = JSON.parse(readFileSync(join(tmpDir, '.codex', 'hooks.json'), 'utf8'));
       expect(config.hooks.PreToolUse).toBeDefined();
-      expect(readFileSync(join(tmpDir, '.codex', 'hooks', 'slope-guard.sh'), 'utf8')).toContain('#!/usr/bin/env bash');
+      const script = readFileSync(join(tmpDir, '.codex', 'hooks', 'slope-guard.sh'), 'utf8');
+      expect(script).toContain('#!/usr/bin/env bash');
+      expect(script).toContain('exec npx --yes @slope-dev/slope guard "$@"');
+      expect(script).not.toContain('SLOPE_BIN="npx --yes @slope-dev/slope"');
+      expect(script).not.toContain('\r\n');
+    });
+
+    it('normalizes CRLF in existing generated dispatchers on reinstall', () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), 'slope-codex-install-'));
+      const hooksDir = join(tmpDir, '.codex', 'hooks');
+      mkdirSync(hooksDir, { recursive: true });
+      const scriptPath = join(hooksDir, 'slope-guard.sh');
+      writeFileSync(scriptPath, [
+        '#!/usr/bin/env bash',
+        '# SLOPE Codex guard dispatcher.',
+        '',
+        '# === SLOPE MANAGED (do not edit above this line) ===',
+        'slope guard "$@"',
+        '# === SLOPE END ===',
+        '',
+      ].join('\r\n'));
+
+      const guards = GUARD_DEFINITIONS.filter(g => g.name === 'hazard');
+      adapter.installGuards(tmpDir, guards);
+
+      expect(readFileSync(scriptPath, 'utf8')).not.toContain('\r\n');
     });
 
     it('can install Codex guards to the user-level hooks directory', () => {

--- a/tests/core/harness.test.ts
+++ b/tests/core/harness.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtempSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -12,6 +12,7 @@ import {
   CLAUDE_CODE_TOOLS,
   TOOL_CATEGORIES,
   ADAPTER_PRIORITY,
+  writeOrUpdateManagedScript,
 } from '../../src/core/harness.js';
 import type { HarnessAdapter, ToolNameMap, ToolCategory } from '../../src/core/harness.js';
 import type { GuardResult } from '../../src/core/guard.js';
@@ -81,6 +82,44 @@ describe('harness adapter registry', () => {
     clearAdapters();
     expect(listAdapters()).toEqual([]);
     expect(getAdapter('claude-code')).toBeUndefined();
+  });
+});
+
+describe('writeOrUpdateManagedScript', () => {
+  it('writes new managed shell scripts with LF line endings', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'slope-managed-script-'));
+    const scriptPath = join(tmpDir, 'slope-guard.sh');
+    const script = [
+      '#!/usr/bin/env bash',
+      '# === SLOPE MANAGED (do not edit above this line) ===',
+      'slope guard "$@"',
+      '# === SLOPE END ===',
+      '',
+    ].join('\r\n');
+
+    const result = writeOrUpdateManagedScript(scriptPath, script);
+
+    expect(result).toBe('created');
+    expect(existsSync(scriptPath)).toBe(true);
+    expect(readFileSync(scriptPath, 'utf8')).not.toContain('\r\n');
+  });
+
+  it('normalizes CRLF in existing managed shell scripts even when content is current', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'slope-managed-script-'));
+    const scriptPath = join(tmpDir, 'slope-guard.sh');
+    const script = [
+      '#!/usr/bin/env bash',
+      '# === SLOPE MANAGED (do not edit above this line) ===',
+      'slope guard "$@"',
+      '# === SLOPE END ===',
+      '',
+    ].join('\n');
+    writeFileSync(scriptPath, script.replace(/\n/g, '\r\n'));
+
+    const result = writeOrUpdateManagedScript(scriptPath, script);
+
+    expect(result).toBe('updated');
+    expect(readFileSync(scriptPath, 'utf8')).toBe(script);
   });
 });
 


### PR DESCRIPTION
## Summary

- Normalize generated SLOPE shell hook scripts to LF so Codex hook dispatchers parse correctly on Windows checkouts.
- Fix the Codex npx fallback so it executes `npx --yes @slope-dev/slope guard ...` directly instead of treating the command string as a single executable path.
- Add regression coverage for managed script line endings, Codex guard reinstall behavior, and `slope init --codex` plugin bundle output.

## Root Cause

The generated shell scripts could retain CRLF endings from a Windows working tree, which makes Bash fail while parsing hook dispatcher conditionals. The Codex plugin dispatcher also stored the npx fallback as a space-containing string and later executed it as `"$SLOPE_BIN"`, which would fail when no local or global SLOPE binary was available.

## Validation

- `pnpm build`
- `pnpm test tests/core/harness.test.ts tests/core/adapters/codex.test.ts tests/cli/commands/hook-codex.test.ts tests/cli/init-codex.test.ts`
- `bash -n .codex/hooks/slope-guard.sh`
- `bash -n .codex/plugins/slope/hooks/slope-guard.sh`
- `node dist/cli/index.js doctor`