### PR TITLE
[codex] Release 1.59.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.59.1",
+  "version": "1.59.2",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.59.1",
+  "version": "1.59.2",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
## Summary

- Bump `@slope-dev/slope` from `1.59.1` to `1.59.2`.
- Keep the bundled Codex plugin manifest version in sync at `1.59.2`.

## Release Notes

Patch release for Codex plugin hook dispatchers:

- Generated shell hooks are normalized to LF so Bash can parse them on Windows checkouts.
- Codex npx fallback now executes `npx --yes @slope-dev/slope guard ...` directly.

## Validation

- `pnpm build`
- `pnpm test tests/cli/version.test.ts tests/cli/init-codex.test.ts tests/cli/package-metadata.test.ts`
- `node dist/cli/index.js version`

Note: full local `pnpm test` hit unrelated Windows git-fixture timeouts; GitHub CI is the full-suite gate for this release PR.