### PR TITLE
[codex] Harden version recommend with SLOPE release evidence

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -360,7 +360,7 @@
         152.1,
         153
       ],
-      "status": "planned",
+      "status": "complete",
       "note": "Close out the v1.59.0 release memory, repair roadmap interview discoverability across harness surfaces, and triage the semver recommendation gap discovered during release verification."
     },
     {
@@ -4623,7 +4623,9 @@
       "par": 3,
       "slope": 2,
       "type": "bugfix",
-      "status": "planned",
+      "status": "complete",
+      "score": 3,
+      "score_label": "par",
       "depends_on": [
         152.1
       ],

--- a/docs/retros/sprint-153-review.md
+++ b/docs/retros/sprint-153-review.md
@@ -1,0 +1,67 @@
+## Sprint 153 Review: Semver Recommendation Evidence Hardening
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 2 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (3/3) |
+| GIR % | 100% (3/3) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 3)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S153-1 | Short Iron | In the Hole | - | Added SLOPE release-evidence collection for unreleased changelog entries by reading sprint references, commit subjects, changed scorecard paths, completed roadmap metadata, and scorecards. |
+| S153-2 | Wedge | In the Hole | - | `slope version recommend` now reports the conventional-commit tier, any durable SLOPE release evidence used, and when evidence raises the recommendation above the commit-subject tier. |
+| S153-3 | Short Iron | In the Hole | - | Added git-backed regression coverage for hidden feature-level scorecard evidence, planned roadmap work that must not promote, and completed roadmap metadata without a scorecard. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| Wind | minor | The v1.59.0 release cycle exposed that squash-merged feature work can lose conventional-commit signals even when SLOPE roadmap and scorecard evidence is durable. |
+| Rough | minor | The release smoke initially over-included old unreleased changes until local tags were fetched, reinforcing that version validation should begin with fresh tags. |
+
+### Hazards Discovered
+
+**Known hazards for future sprints:**
+- Squash commit subjects can hide feature-level work from semver recommendation.
+- Planned roadmap entries must not count as shipped release evidence.
+- Stale local tags can make version recommendation smokes over-include older release trains.
+
+### Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Durable SLOPE evidence should raise semver only when work is actually shipped. | The classifier ignores planned roadmap entries unless the sprint is complete or a scorecard exists, and plain bugfix/test/release/planning metadata remains patch-level. |
+| Lessons | Release recommendation tests need both undercall prevention and over-promotion guardrails. | Regression coverage now includes shipped feature evidence, planned feature evidence with no shipment, and completed roadmap metadata without a scorecard. |
+
+### Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | `pnpm test tests/cli/version.test.ts tests/cli/commands/version.test.ts` passed: 2 files, 11 tests. |
+| testing | healthy | `pnpm typecheck` passed. |
+| testing | healthy | `pnpm build` passed. |
+| testing | healthy | `pnpm test` passed: 235 files, 3677 tests, 25 skipped. |
+| validation | healthy | `git fetch origin --tags` followed by `node dist/cli/index.js version recommend` reported the current unreleased S153 work as patch-level before closeout artifacts, confirming no stale-tag overcount. |
+| validation | healthy | `node dist/cli/index.js validate docs/retros/sprint-153.json` passed with no errors or warnings. |
+
+### Course Management Notes
+
+- No code-review or architect-review findings were recorded for S153.
+- S153 remains a bugfix + release workflow sprint, so its own closeout evidence should not promote unrelated feature-level release guidance.
+- The PR should close GitHub issue #550 after CI passes and the branch is merged.
+
+### 19th Hole
+
+- **How did it feel?** A small but satisfying release-tooling repair: the command can now see the sprint evidence that humans were already using during release judgment.
+- **Advice for next player?** Fetch tags before release recommendation smokes, then compare conventional-commit output against scorecard and roadmap evidence before picking a semver level.
+- **What surprised you?** The important part was not just finding feature words; it was refusing to count planned roadmap work as shipped evidence.
+- **Excited about next?** The issue-driven recovery train can now move into roadmap/status integrity with release recommendation no longer blind to shipped SLOPE context.

--- a/docs/retros/sprint-153.json
+++ b/docs/retros/sprint-153.json
@@ -1,0 +1,146 @@
+{
+  "sprint_number": 153,
+  "player": "codex",
+  "theme": "Semver Recommendation Evidence Hardening",
+  "par": 3,
+  "slope": 2,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-06-20",
+  "type": "bugfix + release workflow",
+  "skills_used": [
+    "slope-sprint-workflow",
+    "slope-sprint"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "slope-sprint"
+  ],
+  "skill_gaps_found": [],
+  "shots": [
+    {
+      "ticket_key": "S153-1",
+      "title": "Add durable roadmap or PR evidence to version recommendation for squash-merged feature work (#550)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added SLOPE release-evidence collection for unreleased changelog entries by reading sprint references, commit subjects, changed scorecard paths, completed roadmap metadata, and scorecards."
+    },
+    {
+      "ticket_key": "S153-2",
+      "title": "Explain semver evidence and ambiguity in version recommend output (#550)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "`slope version recommend` now reports the conventional-commit tier, any durable SLOPE release evidence used, and when evidence raises the recommendation above the commit-subject tier."
+    },
+    {
+      "ticket_key": "S153-3",
+      "title": "Add regression coverage for squash-merge semver undercall prevention (#550)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Added git-backed regression coverage for hidden feature-level scorecard evidence, planned roadmap work that must not promote, and completed roadmap metadata without a scorecard."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 3,
+    "fairways_total": 3,
+    "greens_in_regulation": 3,
+    "greens_total": 3,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "wind",
+      "impact": "minor",
+      "description": "The v1.59.0 release cycle exposed that squash-merged feature work can lose conventional-commit signals even when SLOPE roadmap and scorecard evidence is durable."
+    },
+    {
+      "type": "rough",
+      "impact": "minor",
+      "description": "The release smoke initially over-included old unreleased changes until local tags were fetched, reinforcing that version validation should begin with fresh tags."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Durable SLOPE evidence should raise semver only when work is actually shipped.",
+      "outcome": "The classifier ignores planned roadmap entries unless the sprint is complete or a scorecard exists, and plain bugfix/test/release/planning metadata remains patch-level."
+    },
+    {
+      "type": "lessons",
+      "description": "Release recommendation tests need both undercall prevention and over-promotion guardrails.",
+      "outcome": "Regression coverage now includes shipped feature evidence, planned feature evidence with no shipment, and completed roadmap metadata without a scorecard."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "`pnpm test tests/cli/version.test.ts tests/cli/commands/version.test.ts` passed: 2 files, 11 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm typecheck` passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm build` passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm test` passed: 235 files, 3677 tests, 25 skipped.",
+      "status": "healthy"
+    },
+    {
+      "category": "validation",
+      "description": "`git fetch origin --tags` followed by `node dist/cli/index.js version recommend` reported the current unreleased S153 work as patch-level before closeout artifacts, confirming no stale-tag overcount.",
+      "status": "healthy"
+    },
+    {
+      "category": "validation",
+      "description": "`node dist/cli/index.js validate docs/retros/sprint-153.json` passed with no errors or warnings.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A small but satisfying release-tooling repair: the command can now see the sprint evidence that humans were already using during release judgment.",
+    "advice_for_next_player": "Fetch tags before release recommendation smokes, then compare conventional-commit output against scorecard and roadmap evidence before picking a semver level.",
+    "what_surprised_you": "The important part was not just finding feature words; it was refusing to count planned roadmap work as shipped evidence.",
+    "excited_about_next": "The issue-driven recovery train can now move into roadmap/status integrity with release recommendation no longer blind to shipped SLOPE context."
+  },
+  "bunker_locations": [
+    "Squash commit subjects can hide feature-level work from semver recommendation.",
+    "Planned roadmap entries must not count as shipped release evidence.",
+    "Stale local tags can make version recommendation smokes over-include older release trains."
+  ],
+  "yardage_book_updates": [
+    "src/cli/commands/version.ts now collects sprint references from changelog descriptions, scopes, commit subjects, and changed scorecard paths.",
+    "src/cli/commands/version.ts now reads roadmap and scorecard metadata to surface durable SLOPE release evidence in `version recommend`.",
+    "tests/cli/version.test.ts now covers hidden feature evidence, planned-work guardrails, and completed-roadmap fallback evidence."
+  ],
+  "course_management_notes": [
+    "No code-review or architect-review findings were recorded for S153.",
+    "S153 remains a bugfix + release workflow sprint, so its own closeout evidence should not promote unrelated feature-level release guidance.",
+    "The PR should close GitHub issue #550 after CI passes and the branch is merged."
+  ],
+  "slope_factors": [
+    "semver_inference",
+    "release_evidence",
+    "squash_merge",
+    "cli_output"
+  ]
+}

--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import { QUIET_STDIO } from '../../core/process.js';
+import type { ChangelogChange, RoadmapDefinition, RoadmapSprint } from '../../core/index.js';
 
 /**
  * slope version bump [<version>] [--dry-run]
@@ -243,6 +244,175 @@ function bumpMajor(version: string): string {
   return parts.join('.');
 }
 
+type VersionTier = 'patch' | 'minor' | 'major';
+type EvidenceSource = 'roadmap' | 'scorecard';
+
+export interface VersionReleaseEvidence {
+  source: EvidenceSource;
+  sprint: number;
+  theme: string;
+  tier: VersionTier;
+  reason: string;
+}
+
+const TIER_RANK: Record<VersionTier, number> = { patch: 0, minor: 1, major: 2 };
+const SPRINT_REF_RE = /\bS(\d+(?:\.\d+)?)(?:-\d+)?\b/g;
+const SCORECARD_PATH_RE = /(?:^|[/\\])docs[/\\]retros[/\\]sprint-(\d+(?:\.\d+)?)\.json$/;
+const GIT_HASH_RE = /^[a-f0-9]{7,40}$/i;
+const FEATURE_EVIDENCE_RE = /\b(feature|product surface|cli surface|human surface|user-facing|new command|cockpit|onboarding|plugin|adapter)\b/i;
+const BREAKING_EVIDENCE_RE = /\bbreaking\b/i;
+const PATCH_ONLY_TYPE_RE = /\b(bugfix|fix|planning|test|release|docs|documentation|chore)\b/i;
+
+function maxTier(a: VersionTier, b: VersionTier): VersionTier {
+  return TIER_RANK[b] > TIER_RANK[a] ? b : a;
+}
+
+function sprintFileId(sprint: number): string {
+  return Number.isInteger(sprint) ? String(sprint) : String(sprint);
+}
+
+function readJsonFile<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+function loadRoadmapSprints(cwd: string): Map<number, RoadmapSprint & { status?: string; note?: string }> {
+  const roadmap = readJsonFile<RoadmapDefinition>(join(cwd, 'docs', 'backlog', 'roadmap.json'));
+  const sprints = new Map<number, RoadmapSprint & { status?: string; note?: string }>();
+  for (const sprint of roadmap?.sprints ?? []) {
+    sprints.set(sprint.id, sprint as RoadmapSprint & { status?: string; note?: string });
+  }
+  return sprints;
+}
+
+function extractSprintIdsFromText(text: string | undefined): Set<number> {
+  const ids = new Set<number>();
+  if (!text) return ids;
+
+  for (const match of text.matchAll(SPRINT_REF_RE)) {
+    const id = Number(match[1]);
+    if (Number.isFinite(id)) ids.add(id);
+  }
+
+  return ids;
+}
+
+function gitOutput(cwd: string, args: string[]): string {
+  try {
+    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: QUIET_STDIO }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function commitSubject(cwd: string, hash: string): string {
+  if (!GIT_HASH_RE.test(hash)) return '';
+  return gitOutput(cwd, ['show', '-s', '--format=%s', hash]);
+}
+
+function commitChangedFiles(cwd: string, hash: string): string[] {
+  if (!GIT_HASH_RE.test(hash)) return [];
+  const raw = gitOutput(cwd, ['diff-tree', '--no-commit-id', '--name-only', '-r', hash]);
+  return raw ? raw.split('\n').map(line => line.trim()).filter(Boolean) : [];
+}
+
+function evidenceTierFromTypedText(type: string, text: string): VersionTier | null {
+  const combined = `${type} ${text}`;
+  if (BREAKING_EVIDENCE_RE.test(combined)) return 'major';
+  if (FEATURE_EVIDENCE_RE.test(type)) return 'minor';
+  if (PATCH_ONLY_TYPE_RE.test(type)) return null;
+  if (FEATURE_EVIDENCE_RE.test(combined)) return 'minor';
+  return null;
+}
+
+function scorecardEvidenceText(scorecard: Record<string, unknown> | null): string {
+  if (!scorecard) return '';
+  const shots = Array.isArray(scorecard.shots)
+    ? scorecard.shots
+      .map(shot => typeof shot === 'object' && shot ? (shot as { title?: unknown; notes?: unknown }) : null)
+      .filter(Boolean)
+      .map(shot => String(shot!.title ?? ''))
+      .join(' ')
+    : '';
+  const factors = Array.isArray(scorecard.slope_factors) ? scorecard.slope_factors.join(' ') : '';
+  return [
+    scorecard.theme,
+    shots,
+    factors,
+  ].map(value => String(value ?? '')).join(' ');
+}
+
+function roadmapEvidenceText(sprint: (RoadmapSprint & { note?: string }) | undefined): string {
+  if (!sprint) return '';
+  const tickets = (sprint.tickets ?? []).map(ticket => ticket.title).join(' ');
+  return [sprint.theme, sprint.type, sprint.note, tickets].map(value => String(value ?? '')).join(' ');
+}
+
+function releaseEvidenceForSprint(
+  cwd: string,
+  sprintId: number,
+  roadmapSprints: Map<number, RoadmapSprint & { status?: string; note?: string }>,
+): VersionReleaseEvidence | null {
+  const roadmapSprint = roadmapSprints.get(sprintId);
+  const scorecard = readJsonFile<Record<string, unknown>>(join(cwd, 'docs', 'retros', `sprint-${sprintFileId(sprintId)}.json`));
+  const shipped = roadmapSprint?.status === 'complete' || Boolean(scorecard);
+  if (!shipped) return null;
+
+  const scorecardType = String(scorecard?.type ?? '');
+  const roadmapType = String(roadmapSprint?.type ?? '');
+  const scorecardTier = evidenceTierFromTypedText(scorecardType, scorecardEvidenceText(scorecard));
+  const roadmapTier = evidenceTierFromTypedText(roadmapType, roadmapEvidenceText(roadmapSprint));
+  const tier = scorecardTier && roadmapTier ? maxTier(scorecardTier, roadmapTier) : scorecardTier ?? roadmapTier;
+  if (!tier) return null;
+
+  const source: EvidenceSource = scorecard ? 'scorecard' : 'roadmap';
+  const theme = String(scorecard?.theme ?? roadmapSprint?.theme ?? `Sprint ${sprintFileId(sprintId)}`);
+  const type = String(scorecard?.type ?? roadmapSprint?.type ?? 'unknown type');
+
+  return {
+    source,
+    sprint: sprintId,
+    theme,
+    tier,
+    reason: type,
+  };
+}
+
+export function collectSlopeReleaseEvidence(
+  cwd: string,
+  changes: Pick<ChangelogChange, 'hash' | 'description' | 'scope'>[],
+): VersionReleaseEvidence[] {
+  const roadmapSprints = loadRoadmapSprints(cwd);
+  const sprintIds = new Set<number>();
+
+  for (const change of changes) {
+    for (const id of extractSprintIdsFromText(change.description)) sprintIds.add(id);
+    for (const id of extractSprintIdsFromText(change.scope)) sprintIds.add(id);
+
+    if (!change.hash) continue;
+    for (const id of extractSprintIdsFromText(commitSubject(cwd, change.hash))) sprintIds.add(id);
+
+    for (const file of commitChangedFiles(cwd, change.hash)) {
+      const scorecardMatch = file.match(SCORECARD_PATH_RE);
+      if (!scorecardMatch) continue;
+      const id = Number(scorecardMatch[1]);
+      if (Number.isFinite(id)) sprintIds.add(id);
+    }
+  }
+
+  const evidence = new Map<number, VersionReleaseEvidence>();
+  for (const sprintId of [...sprintIds].sort((a, b) => a - b)) {
+    const item = releaseEvidenceForSprint(cwd, sprintId, roadmapSprints);
+    if (item) evidence.set(sprintId, item);
+  }
+
+  return [...evidence.values()];
+}
+
 async function versionRecommend(cwd: string): Promise<void> {
   const { parseChangelog } = await import('./docs.js');
 
@@ -262,10 +432,17 @@ async function versionRecommend(cwd: string): Promise<void> {
     else counts.other++;
   }
 
-  let tier: string;
-  if (counts.breaking > 0) tier = 'major';
-  else if (counts.feat > 0) tier = 'minor';
-  else tier = 'patch';
+  let conventionalTier: VersionTier;
+  if (counts.breaking > 0) conventionalTier = 'major';
+  else if (counts.feat > 0) conventionalTier = 'minor';
+  else conventionalTier = 'patch';
+
+  const evidence = collectSlopeReleaseEvidence(cwd, unreleased.changes);
+  const evidenceTier = evidence.reduce<VersionTier>(
+    (current, item) => maxTier(current, item.tier),
+    'patch',
+  );
+  const tier = maxTier(conventionalTier, evidenceTier);
 
   const currentVersion = getCurrentVersion(cwd);
   const nextVersion = tier === 'major' ? bumpMajor(currentVersion)
@@ -274,7 +451,20 @@ async function versionRecommend(cwd: string): Promise<void> {
 
   console.log(`\nUnreleased changes since v${currentVersion}: ${unreleased.changes.length}`);
   console.log(`  feat: ${counts.feat}, fix: ${counts.fix}, docs: ${counts.docs}, chore: ${counts.chore}, breaking: ${counts.breaking}`);
+  console.log(`  Conventional commit tier: ${conventionalTier}`);
+  if (evidence.length > 0) {
+    console.log(`  SLOPE release evidence: ${evidenceTier}`);
+    for (const item of evidence) {
+      console.log(`    - S${sprintFileId(item.sprint)} ${item.theme} (${item.source}: ${item.reason})`);
+    }
+  } else if (counts.feat === 0 && (counts.other > 0 || counts.docs > 0 || counts.chore > 0)) {
+    console.log('  SLOPE release evidence: none found for shipped feature-level roadmap or scorecard work');
+  }
   console.log(`\n  Recommended: ${tier} (${currentVersion} → ${nextVersion})\n`);
+
+  if (TIER_RANK[tier] > TIER_RANK[conventionalTier]) {
+    console.log('  Recommendation raised above commit-subject tier by durable SLOPE evidence.\n');
+  }
 
   if (counts.feat > 0) {
     console.log('  Includes new features — check release-policy.md for slope-web content review guidance.\n');

--- a/tests/cli/version.test.ts
+++ b/tests/cli/version.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 import { getVersionBumpStagePaths, versionCommand } from '../../src/cli/commands/version.js';
 
 let tmpDir: string;
@@ -23,6 +24,31 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
+
+function git(args: string[]): string {
+  return execFileSync('git', args, { cwd: tmpDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function gitInit(): void {
+  git(['init']);
+  git(['config', 'user.email', 'test@test.com']);
+  git(['config', 'user.name', 'Test User']);
+}
+
+function gitCommit(message: string): void {
+  git(['add', '-A']);
+  git(['commit', '-m', message]);
+}
+
+function writeJson(path: string, data: unknown): void {
+  const fullPath = join(tmpDir, path);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, JSON.stringify(data, null, 2));
+}
+
+function output(): string {
+  return consoleSpy.mock.calls.map(c => c[0]).join('\n');
+}
 
 describe('versionCommand', () => {
   // GH #300: default version output must read from the installed slope
@@ -83,5 +109,118 @@ describe('versionCommand', () => {
 
   it('stages only package.json when no bundled Codex plugin manifest exists', () => {
     expect(getVersionBumpStagePaths(tmpDir)).toEqual(['package.json']);
+  });
+
+  it('raises recommendation to minor from shipped SLOPE scorecard evidence when squash subjects hide feature work (#550)', async () => {
+    gitInit();
+    gitCommit('chore: initial release');
+    git(['tag', 'v1.0.0']);
+
+    writeJson('docs/backlog/roadmap.json', {
+      name: 'Test Roadmap',
+      phases: [{ name: 'Phase 1', sprints: [42] }],
+      sprints: [{
+        id: 42,
+        theme: 'Human Cockpit',
+        par: 4,
+        slope: 2,
+        type: 'cli product surface',
+        status: 'complete',
+        tickets: [{
+          key: 'S42-1',
+          title: 'Implement a compact user-facing command cockpit',
+          club: 'short_iron',
+          complexity: 'standard',
+        }],
+      }],
+    });
+    writeJson('docs/retros/sprint-42.json', {
+      sprint_number: 42,
+      theme: 'Human Cockpit',
+      type: 'cli product surface',
+      shots: [{
+        ticket_key: 'S42-1',
+        title: 'Implement a compact user-facing command cockpit',
+        notes: 'Shipped new human-facing CLI behavior.',
+      }],
+      slope_factors: ['cli_surface'],
+    });
+    gitCommit('Human cockpit shipped (#1)');
+
+    await versionCommand(['recommend']);
+    const text = output();
+
+    expect(text).toContain('Conventional commit tier: patch');
+    expect(text).toContain('SLOPE release evidence: minor');
+    expect(text).toContain('S42 Human Cockpit');
+    expect(text).toContain('Recommended: minor (1.5.0');
+    expect(text).toContain('Recommendation raised above commit-subject tier');
+  });
+
+  it('does not raise recommendation from planned roadmap feature work without shipped evidence', async () => {
+    gitInit();
+    gitCommit('chore: initial release');
+    git(['tag', 'v1.0.0']);
+
+    writeJson('docs/backlog/roadmap.json', {
+      name: 'Test Roadmap',
+      phases: [{ name: 'Phase 1', sprints: [43] }],
+      sprints: [{
+        id: 43,
+        theme: 'Future Human Cockpit',
+        par: 4,
+        slope: 2,
+        type: 'cli product surface',
+        status: 'planned',
+        tickets: [{
+          key: 'S43-1',
+          title: 'Plan a future user-facing command cockpit',
+          club: 'short_iron',
+          complexity: 'standard',
+        }],
+      }],
+    });
+    gitCommit('docs(roadmap): plan S43');
+
+    await versionCommand(['recommend']);
+    const text = output();
+
+    expect(text).toContain('Conventional commit tier: patch');
+    expect(text).toContain('SLOPE release evidence: none found');
+    expect(text).toContain('Recommended: patch (1.5.0');
+    expect(text).not.toContain('SLOPE release evidence: minor');
+  });
+
+  it('raises recommendation from completed roadmap metadata when scorecard evidence is absent', async () => {
+    gitInit();
+    gitCommit('chore: initial release');
+    git(['tag', 'v1.0.0']);
+
+    writeJson('docs/backlog/roadmap.json', {
+      name: 'Test Roadmap',
+      phases: [{ name: 'Phase 1', sprints: [44] }],
+      sprints: [{
+        id: 44,
+        theme: 'Command Cockpit',
+        par: 4,
+        slope: 2,
+        type: 'cli product surface',
+        status: 'complete',
+        tickets: [{
+          key: 'S44-1',
+          title: 'Ship a compact user-facing command cockpit',
+          club: 'short_iron',
+          complexity: 'standard',
+        }],
+      }],
+    });
+    gitCommit('docs(roadmap): close S44');
+
+    await versionCommand(['recommend']);
+    const text = output();
+
+    expect(text).toContain('SLOPE release evidence: minor');
+    expect(text).toContain('S44 Command Cockpit (roadmap: cli product surface)');
+    expect(text).toContain('Recommended: minor (1.5.0');
   });
 });


### PR DESCRIPTION
## Summary

- Teach `slope version recommend` to collect shipped SLOPE release evidence from sprint references, commit subjects, changed scorecard files, completed roadmap metadata, and scorecards.
- Show the conventional-commit tier, SLOPE evidence tier, evidence items, and when durable evidence raises the recommendation above commit-subject inference.
- Add regression coverage for the v1.59.0 squash-merge undercall case, planned-roadmap guardrails, and completed-roadmap fallback evidence.
- Record S153 closeout artifacts and mark Phase 48/S153 complete in the roadmap.

## Root Cause

`version recommend` only trusted unreleased commit subjects. Squash merges can hide feature-level work even when SLOPE roadmap and scorecard evidence clearly show a shipped CLI/product surface change.

## Validation

- `pnpm test tests/cli/version.test.ts tests/cli/commands/version.test.ts` passed: 2 files, 11 tests.
- `pnpm typecheck` passed.
- `pnpm build` passed.
- `pnpm test` passed: 235 files, 3677 tests, 25 skipped.
- `node dist/cli/index.js validate docs/retros/sprint-153.json` passed with no errors or warnings.
- `node dist/cli/index.js roadmap validate --path=docs/backlog/roadmap.json` passed with existing historical ticket-count warnings and the expected S153 not-on-main warning before merge.
- `node dist/cli/index.js version recommend` reports the current S153 branch as patch-level and finds no shipped feature-level evidence for this bugfix closeout.

Closes #550.