### PR TITLE
[codex] S154 roadmap status integrity fixes

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -4667,7 +4667,9 @@
       "par": 4,
       "slope": 3,
       "type": "bugfix + workflow",
-      "status": "planned",
+      "status": "complete",
+      "score": 4,
+      "score_label": "par",
       "depends_on": [
         153
       ],

--- a/docs/retros/sprint-154-review.md
+++ b/docs/retros/sprint-154-review.md
@@ -1,0 +1,74 @@
+# Sprint 154 Review: Roadmap Reality and Sprint Status Integrity
+
+## SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 3 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (4/4) |
+| GIR % | 100% (4/4) |
+| Putts | 0 |
+| Penalties | 0 |
+
+## Shot-by-Shot (Tickets Delivered: 4)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S154-1 | Short Iron | In the Hole | - | Roadmap sync now marks scorecard-backed sprints complete and merges scorecard-derived ticket fields into existing tickets so metadata such as depends_on and github_issue survives. |
+| S154-2 | Long Iron | In the Hole | - | Shipped-sprint detection now parses git history per commit and ignores subject sprint refs when a commit only touches SLOPE metadata, while still counting scorecard artifacts as shipped evidence. |
+| S154-3 | Short Iron | In the Hole | - | `slope sprint status` now reports derived status ready_for_pr when all gates are complete, keeps the stored phase as context, and prints the PR/retro next action. |
+| S154-4 | Short Iron | In the Hole | - | Regression coverage now spans roadmap sync metadata preservation, metadata-only shipped attribution, and complete-gates sprint status output. |
+
+## Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| Rough | minor | Roadmap ticket metadata lives outside the narrow scorecard-derived fields, so sync needed to update durable execution data without wiping manually-authored dependency and GitHub issue context. |
+| Wind | minor | Post-merge housekeeping commits can mention the next planned sprint in their subject while only shipping prior-sprint SLOPE artifacts. |
+
+## Review Findings
+
+- Required architect review: no findings.
+- Optional code review: no findings.
+
+## Hazards Discovered
+
+**Known hazards for future sprints:**
+- Scorecard sync can accidentally strip roadmap-only ticket metadata if it replaces tickets wholesale.
+- Post-merge housekeeping commit subjects can mention a planned sprint without shipping that sprint.
+- Stored sprint phase alone can be misleading after all closeout gates pass.
+
+## Training Log
+
+| Type | Description | Outcome |
+|---|---|---|
+| Lessons | Roadmap sync should treat scorecards as shipment evidence without treating them as the whole sprint definition. | The sync path refreshes scorecard-owned fields, sets scorecard-backed sprints complete, and preserves per-ticket metadata. |
+| Lessons | Shipped-sprint attribution needs commit-level file context, not a repo-wide union of subjects and paths. | Metadata-only post-merge commits no longer ship the next planned sprint just because their subject names it. |
+| Lessons | Lifecycle output should report derived readiness when gates make the stored phase misleading. | Complete sprint gates now surface ready_for_pr and the concrete PR/retro next action. |
+
+## Nutrition Check (Development Health)
+
+| Category | Status | Notes |
+|---|---|---|
+| testing | healthy | `pnpm test tests/cli/roadmap.test.ts tests/core/analyzers/git.test.ts tests/cli/sprint-workflow.test.ts` passed: 3 files, 92 tests. |
+| testing | healthy | `pnpm typecheck` passed. |
+| testing | healthy | `pnpm build` passed. |
+| testing | healthy | `pnpm test` passed: 235 files, 3680 tests, 25 skipped. |
+| validation | healthy | `git diff --check origin/main...HEAD` passed. |
+| validation | healthy | `node dist/cli/index.js roadmap validate --path=docs/backlog/roadmap.json` passed with only existing historical ticket-count warnings. |
+
+## Course Management Notes
+
+- The PR should close GitHub issues #568, #563, and #567 after CI passes and the branch is merged.
+- Phase 49 remains planned because S155-S158 are still open.
+- The next sprint should start with S155 review-gate provenance and reviewer routing.
+
+## 19th Hole
+
+- **How did it feel?** A tidy trust-recovery sprint: three small user-facing inconsistencies all came from durable state being interpreted too broadly or too narrowly.
+- **Advice for next player?** When adding SLOPE automation around roadmap state, keep scorecard evidence, manually-authored roadmap metadata, and post-merge artifacts as separate signals until the command has enough context to merge them safely.
+- **What surprised you?** The status wording bug was not a state-machine failure; it was an output contract failure where all gates were done but the display still centered the stale stored phase.
+- **Excited about next?** S155 can build on this by making review-gate provenance just as explicit as sprint shipment and closeout readiness are now.

--- a/docs/retros/sprint-154.json
+++ b/docs/retros/sprint-154.json
@@ -1,0 +1,160 @@
+{
+  "sprint_number": 154,
+  "player": "codex",
+  "theme": "Roadmap Reality and Sprint Status Integrity",
+  "par": 4,
+  "slope": 3,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-06-23",
+  "type": "bugfix + workflow",
+  "skills_used": [
+    "slope-sprint-workflow",
+    "slope-sprint"
+  ],
+  "skills_recommended": [
+    "slope-sprint-workflow",
+    "slope-sprint"
+  ],
+  "skill_gaps_found": [],
+  "shots": [
+    {
+      "ticket_key": "S154-1",
+      "title": "Preserve ticket dependencies during roadmap sync and refuse broad destructive rewrites (#568)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Roadmap sync now marks scorecard-backed sprints complete and merges scorecard-derived ticket fields into existing tickets so metadata such as depends_on and github_issue survives."
+    },
+    {
+      "ticket_key": "S154-2",
+      "title": "Correct shipped-sprint attribution so post-merge housekeeping commits do not ship the next planned sprint (#563, #568)",
+      "club": "long_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Shipped-sprint detection now parses git history per commit and ignores subject sprint refs when a commit only touches SLOPE metadata, while still counting scorecard artifacts as shipped evidence."
+    },
+    {
+      "ticket_key": "S154-3",
+      "title": "Derive closeout-ready sprint status when all gates are complete instead of leaving phase planning active (#567)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "`slope sprint status` now reports derived status ready_for_pr when all gates are complete, keeps the stored phase as context, and prints the PR/retro next action."
+    },
+    {
+      "ticket_key": "S154-4",
+      "title": "Add regression fixtures for roadmap sync, shipped attribution, and all-gates-complete status (#568, #563, #567)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Regression coverage now spans roadmap sync metadata preservation, metadata-only shipped attribution, and complete-gates sprint status output."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 4,
+    "fairways_total": 4,
+    "greens_in_regulation": 4,
+    "greens_total": 4,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    {
+      "type": "rough",
+      "impact": "minor",
+      "description": "Roadmap ticket metadata lives outside the narrow scorecard-derived fields, so sync needed to update durable execution data without wiping manually-authored dependency and GitHub issue context."
+    },
+    {
+      "type": "wind",
+      "impact": "minor",
+      "description": "Post-merge housekeeping commits can mention the next planned sprint in their subject while only shipping prior-sprint SLOPE artifacts."
+    }
+  ],
+  "special_plays": [],
+  "training": [
+    {
+      "type": "lessons",
+      "description": "Roadmap sync should treat scorecards as shipment evidence without treating them as the whole sprint definition.",
+      "outcome": "The sync path refreshes scorecard-owned fields, sets scorecard-backed sprints complete, and preserves per-ticket metadata."
+    },
+    {
+      "type": "lessons",
+      "description": "Shipped-sprint attribution needs commit-level file context, not a repo-wide union of subjects and paths.",
+      "outcome": "Metadata-only post-merge commits no longer ship the next planned sprint just because their subject names it."
+    },
+    {
+      "type": "lessons",
+      "description": "Lifecycle output should report derived readiness when gates make the stored phase misleading.",
+      "outcome": "Complete sprint gates now surface ready_for_pr and the concrete PR/retro next action."
+    }
+  ],
+  "nutrition": [
+    {
+      "category": "testing",
+      "description": "`pnpm test tests/cli/roadmap.test.ts tests/core/analyzers/git.test.ts tests/cli/sprint-workflow.test.ts` passed: 3 files, 92 tests.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm typecheck` passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm build` passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "testing",
+      "description": "`pnpm test` passed: 235 files, 3680 tests, 25 skipped.",
+      "status": "healthy"
+    },
+    {
+      "category": "validation",
+      "description": "`git diff --check origin/main...HEAD` passed.",
+      "status": "healthy"
+    },
+    {
+      "category": "validation",
+      "description": "`node dist/cli/index.js roadmap validate --path=docs/backlog/roadmap.json` passed with only existing historical ticket-count warnings.",
+      "status": "healthy"
+    }
+  ],
+  "nineteenth_hole": {
+    "how_did_it_feel": "A tidy trust-recovery sprint: three small user-facing inconsistencies all came from durable state being interpreted too broadly or too narrowly.",
+    "advice_for_next_player": "When adding SLOPE automation around roadmap state, keep scorecard evidence, manually-authored roadmap metadata, and post-merge artifacts as separate signals until the command has enough context to merge them safely.",
+    "what_surprised_you": "The status wording bug was not a state-machine failure; it was an output contract failure where all gates were done but the display still centered the stale stored phase.",
+    "excited_about_next": "S155 can build on this by making review-gate provenance just as explicit as sprint shipment and closeout readiness are now."
+  },
+  "bunker_locations": [
+    "Scorecard sync can accidentally strip roadmap-only ticket metadata if it replaces tickets wholesale.",
+    "Post-merge housekeeping commit subjects can mention a planned sprint without shipping that sprint.",
+    "Stored sprint phase alone can be misleading after all closeout gates pass."
+  ],
+  "yardage_book_updates": [
+    "src/cli/commands/roadmap.ts now merges scorecard-derived ticket fields into existing ticket objects and marks scorecard-backed sprints complete.",
+    "src/core/analyzers/git.ts now parses shipped-sprint history per commit and suppresses subject refs for SLOPE metadata-only commits.",
+    "src/cli/commands/sprint.ts now shows ready_for_pr when all gates are complete and prints the PR/retro next action.",
+    "Regression coverage was added in tests/cli/roadmap.test.ts, tests/core/analyzers/git.test.ts, and tests/cli/sprint-workflow.test.ts."
+  ],
+  "course_management_notes": [
+    "Required architect review and optional code review found no issues.",
+    "The PR should close GitHub issues #568, #563, and #567 after CI passes and the branch is merged.",
+    "Phase 49 remains planned because S155-S158 are still open."
+  ],
+  "slope_factors": [
+    "roadmap_sync",
+    "git_history_attribution",
+    "sprint_status_output",
+    "regression_coverage"
+  ]
+}

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -547,6 +547,19 @@ function scorecardToSprint(card: GolfScorecard): RoadmapSprint {
   };
 }
 
+function ticketIdentity(ticket: RoadmapTicket): string {
+  return ticket.key || ticket.id || '';
+}
+
+function mergeScorecardTickets(existingTickets: RoadmapTicket[], scorecardTickets: RoadmapTicket[]): RoadmapTicket[] {
+  const existingByKey = new Map(existingTickets.map(ticket => [ticketIdentity(ticket), ticket]));
+
+  return scorecardTickets.map(ticket => {
+    const existing = existingByKey.get(ticketIdentity(ticket));
+    return existing ? { ...existing, ...ticket } : ticket;
+  });
+}
+
 function syncSubcommand(flags: Record<string, string>, cwd: string): void {
   const dryRun = flags['dry-run'] === 'true';
   const path = resolveRoadmapPath(flags, cwd);
@@ -590,11 +603,12 @@ function syncSubcommand(flags: Record<string, string>, cwd: string): void {
       existing.par = fromCard.par;
       existing.slope = fromCard.slope;
       existing.type = fromCard.type;
-      existing.tickets = fromCard.tickets;
-      // Preserve: depends_on (manually authored)
+      existing.tickets = mergeScorecardTickets(existing.tickets, fromCard.tickets);
+      (existing as RoadmapSprint & { status?: string }).status = 'complete';
+      // Preserve: sprint depends_on and ticket metadata such as depends_on/github_issue.
       updated++;
     } else {
-      roadmap.sprints.push(fromCard);
+      roadmap.sprints.push({ ...fromCard, status: 'complete' } as RoadmapSprint);
       added++;
     }
   }

--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -379,7 +379,9 @@ function statusCommand(cwd: string): void {
   }
 
   const complete = isSprintComplete(state);
-  console.log(`Sprint ${formatSprintNumber(state.sprint)} — phase: ${state.phase}${complete ? ' (all gates complete)' : ''}`);
+  const derivedStatus = complete ? 'ready_for_pr' : state.phase;
+  const phaseContext = complete ? ` (phase: ${state.phase}, all gates complete)` : ` (phase: ${state.phase})`;
+  console.log(`Sprint ${formatSprintNumber(state.sprint)} - status: ${derivedStatus}${phaseContext}`);
   console.log(`Started: ${state.started_at}`);
   console.log(`Updated: ${state.updated_at}`);
   console.log('');
@@ -392,6 +394,8 @@ function statusCommand(cwd: string): void {
   if (!complete) {
     const pending = pendingGates(state);
     console.log(`\nRemaining: ${pending.join(', ')}`);
+  } else {
+    console.log('\nNext: create PR for this branch; after merge, run post-merge retro.');
   }
 }
 

--- a/src/core/analyzers/git.ts
+++ b/src/core/analyzers/git.ts
@@ -60,6 +60,53 @@ export function extractSprintArtifactReferences(logLines: string[]): Set<number>
   return result;
 }
 
+interface GitSprintCommit {
+  subject: string;
+  files: string[];
+}
+
+function parseSprintLog(raw: string): GitSprintCommit[] {
+  return raw
+    .split('\x1e')
+    .map(block => block.trim())
+    .filter(Boolean)
+    .map(block => {
+      const [subject = '', ...files] = block
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(Boolean);
+      return { subject, files };
+    });
+}
+
+function isSlopeMetadataPath(file: string): boolean {
+  const normalized = file.replace(/\\/g, '/');
+  return normalized === 'docs/backlog/roadmap.json'
+    || /^docs\/retros\/sprint-\d+(?:\.\d+)?(?:\.json|-review\.md)$/i.test(normalized)
+    || /^\.slope\/retros\/post-merge\/sprint-\d+(?:\.\d+)?(?:-pr-\d+)?\.json$/i.test(normalized);
+}
+
+function isSlopeMetadataOnlyCommit(files: string[]): boolean {
+  return files.length > 0 && files.every(isSlopeMetadataPath);
+}
+
+function extractShippedSprintReferences(commits: GitSprintCommit[]): Set<number> {
+  const result = new Set<number>();
+
+  for (const commit of commits) {
+    const artifactRefs = extractSprintArtifactReferences(commit.files);
+    const subjectRefs = isSlopeMetadataOnlyCommit(commit.files)
+      ? new Set<number>()
+      : extractSprintReferences([commit.subject]);
+
+    for (const ref of unionSets(artifactRefs, subjectRefs)) {
+      result.add(ref);
+    }
+  }
+
+  return result;
+}
+
 function unionSets<T>(...sets: Set<T>[]): Set<T> {
   const result = new Set<T>();
   for (const set of sets) {
@@ -93,14 +140,8 @@ export function findShippedSprintsOnMain(cwd: string, ref?: string): Set<number>
     // Cap at 1000 commits — plenty for sprint references (a project would
     // need to ship hundreds of sprints to exhaust this) and avoids slowing
     // session-end Stop hooks on deep-history repos.
-    const subjects = git(`log ${r} --format=%s -n 1000`, cwd);
-    const files = git(`log ${r} --name-only --format= -n 1000`, cwd);
-    if (subjects || files) {
-      return unionSets(
-        extractSprintReferences(subjects ? subjects.split('\n') : []),
-        extractSprintArtifactReferences(files ? files.split('\n') : []),
-      );
-    }
+    const log = git(`log ${r} --format=%x1e%s --name-only -n 1000`, cwd);
+    if (log) return extractShippedSprintReferences(parseSprintLog(log));
   }
   return new Set();
 }

--- a/tests/cli/roadmap.test.ts
+++ b/tests/cli/roadmap.test.ts
@@ -623,6 +623,43 @@ describe('slope roadmap sync', () => {
     expect(s8.depends_on).toEqual([7]);
   });
 
+  it('marks scorecard-backed sprints complete and preserves per-ticket metadata (#568)', () => {
+    const roadmap = makeRoadmapJson({
+      sprints: makeRoadmapJson().sprints.map(sprint => sprint.id === 8
+        ? {
+          ...sprint,
+          status: 'planned',
+          tickets: [
+            { ...sprint.tickets[0], github_issue: 568 } as RoadmapDefinition['sprints'][number]['tickets'][number],
+            { ...sprint.tickets[1], depends_on: ['S8-1'], github_issue: 568 } as RoadmapDefinition['sprints'][number]['tickets'][number],
+            { ...sprint.tickets[2], depends_on: ['S8-2'] },
+          ],
+        } as RoadmapDefinition['sprints'][number]
+        : sprint),
+    });
+    writeRoadmap(tmpDir, roadmap);
+    writeConfig(tmpDir, { scorecardDir: 'docs/retros', scorecardPattern: 'sprint-*.json', minSprint: 1 });
+    writeScorecard(tmpDir, 8, {
+      theme: 'Updated Platform',
+      shots: [
+        { ticket_key: 'S8-1', title: 'Synced T1', club: 'short_iron', result: 'green', hazards: [] },
+        { ticket_key: 'S8-2', title: 'Synced T2', club: 'wedge', result: 'green', hazards: [] },
+        { ticket_key: 'S8-3', title: 'Synced T3', club: 'putter', result: 'green', hazards: [] },
+      ],
+    });
+
+    roadmapCommand(['sync']);
+
+    const result = JSON.parse(readFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), 'utf8'));
+    const s8 = result.sprints.find((s: { id: number }) => s.id === 8);
+    expect(s8.status).toBe('complete');
+    expect(s8.tickets[0].title).toBe('Synced T1');
+    expect(s8.tickets[0].github_issue).toBe(568);
+    expect(s8.tickets[1].depends_on).toEqual(['S8-1']);
+    expect(s8.tickets[1].github_issue).toBe(568);
+    expect(s8.tickets[2].depends_on).toEqual(['S8-2']);
+  });
+
   it('maps club to complexity correctly', () => {
     const roadmap = makeRoadmapJson();
     writeRoadmap(tmpDir, roadmap);

--- a/tests/cli/sprint-workflow.test.ts
+++ b/tests/cli/sprint-workflow.test.ts
@@ -572,6 +572,24 @@ describe('slope sprint phase', () => {
   });
 });
 
+describe('slope sprint status', () => {
+  it('shows derived closeout state and next action when all gates are complete (#567)', async () => {
+    await captureLog(() =>
+      sprintCommand(['start', '--number=16', '--phase=planning'])
+    );
+
+    for (const gate of ['tests', 'code_review', 'architect_review', 'scorecard', 'review_md']) {
+      await captureLog(() => sprintCommand(['gate', gate]));
+    }
+
+    const output = await captureLog(() => sprintCommand(['status']));
+
+    expect(output).toContain('status: ready_for_pr (phase: planning, all gates complete)');
+    expect(output).toContain('Next: create PR for this branch');
+    expect(output).not.toContain('Remaining:');
+  });
+});
+
 describe('slope sprint (help)', () => {
   it('shows help with workflow commands listed', async () => {
     const output = await captureLog(() =>

--- a/tests/core/analyzers/git.test.ts
+++ b/tests/core/analyzers/git.test.ts
@@ -64,6 +64,16 @@ function gitCommitFile(cwd: string, file: string, content: string, message: stri
   execSync(`git commit -m "${message}"`, { cwd, stdio: 'pipe' });
 }
 
+function gitCommitFiles(cwd: string, files: Array<[string, string]>, message: string): void {
+  for (const [file, content] of files) {
+    const fullPath = join(cwd, file);
+    mkdirSync(dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, content);
+  }
+  execSync('git add -A', { cwd, stdio: 'pipe' });
+  execSync(`git commit -m "${message}"`, { cwd, stdio: 'pipe' });
+}
+
 describe('analyzeGit', () => {
   let tmpDir: string;
 
@@ -274,6 +284,22 @@ describe('findShippedSprintsOnMain', () => {
     );
 
     expect(findShippedSprintsOnMain(tmpDir, 'HEAD')).toEqual(new Set([143.5]));
+  });
+
+  it('does not attribute SLOPE-only post-merge metadata commits to next planned sprint refs (#563)', () => {
+    gitInit(tmpDir);
+    gitCommitFiles(
+      tmpDir,
+      [
+        ['.slope/retros/post-merge/sprint-12-pr-3.json', '{}'],
+        ['docs/backlog/roadmap.json', '{"name":"Test"}'],
+        ['docs/retros/sprint-12.json', JSON.stringify({ sprint_number: 12 })],
+        ['docs/retros/sprint-12-review.md', '# S12 review\n'],
+      ],
+      'docs(S13): post-merge housekeeping',
+    );
+
+    expect(findShippedSprintsOnMain(tmpDir, 'HEAD')).toEqual(new Set([12]));
   });
 
   it('does not mark sprint scoping commits as shipped work', () => {


### PR DESCRIPTION
## Summary

S154 fixes the roadmap/status integrity issues found during triage:

- marks scorecard-backed roadmap sync results complete while preserving per-ticket metadata such as `depends_on` and `github_issue`
- avoids attributing metadata-only post-merge housekeeping commit subjects to the next planned sprint
- makes `slope sprint status` report derived `ready_for_pr` state when all closeout gates are complete
- records S154 scorecard/review artifacts and updates roadmap status

Closes #568.
Closes #563.
Closes #567.

## Validation

- `pnpm test tests/cli/roadmap.test.ts tests/core/analyzers/git.test.ts tests/cli/sprint-workflow.test.ts` passed: 3 files, 92 tests
- `pnpm typecheck` passed
- `pnpm build` passed
- `pnpm test` passed: 235 files, 3680 tests, 25 skipped
- `git diff --check origin/main...HEAD` passed
- `node dist/cli/index.js validate docs/retros/sprint-154.json` passed
- `node dist/cli/index.js roadmap validate --path=docs/backlog/roadmap.json` passed with only existing historical ticket-count warnings plus the expected pre-merge S154 shipped-on-main warning