### PR TITLE
Fix Codex guard shim status reporting

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -4,6 +4,7 @@ import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 import { detectPlatforms, type InitProvider } from './init.js';
+import { detectActiveHarnessGuardShims } from '../harness-hook-status.js';
 import { GUARD_DEFINITIONS } from '../../core/guard.js';
 import { hasMetaphor } from '../../core/metaphor.js';
 import { detectAdapter, SLOPE_BIN_PREAMBLE, writeOrUpdateManagedScript } from '../../core/harness.js';
@@ -667,8 +668,20 @@ function repairCodexProjectHooksConfig(cwd: string): boolean {
 function checkGuards(cwd: string, originalCwd = cwd): DoctorCheck[] {
   const checks: DoctorCheck[] = [];
   const hooksPath = join(cwd, '.slope', 'hooks.json');
+  const activeShims = detectActiveHarnessGuardShims(cwd);
+  const shimSummary = activeShims
+    .map(shim => `${shim.provider} ${shim.scope} shim (${shim.guardCount} guard command${shim.guardCount === 1 ? '' : 's'} in ${shim.configPath})`)
+    .join('; ');
 
   if (!existsSync(hooksPath)) {
+    if (activeShims.length > 0) {
+      checks.push({
+        name: 'guards',
+        status: 'ok',
+        message: `No internal hook registry found, but active harness guard shim detected: ${shimSummary}`,
+      });
+      return checks;
+    }
     checks.push({
       name: 'guards',
       status: 'warn',
@@ -689,6 +702,14 @@ function checkGuards(cwd: string, originalCwd = cwd): DoctorCheck[] {
     const totalGuards = GUARD_DEFINITIONS.length;
 
     if (installedCount === 0) {
+      if (activeShims.length > 0) {
+        checks.push({
+          name: 'guards',
+          status: 'ok',
+          message: `Internal hook registry has no guard entries, but active harness guard shim detected: ${shimSummary}`,
+        });
+        return checks;
+      }
       checks.push({
         name: 'guards',
         status: 'warn',

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -1,5 +1,6 @@
 import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { detectActiveHarnessGuardShims } from '../harness-hook-status.js';
 import { loadHooksConfig, saveHooksConfig } from '../hooks-config.js';
 import { getAllGuardDefinitions, loadPluginGuards, loadConfig, detectAdapter, getAdapter, listAdapters, SLOPE_BIN_PREAMBLE, writeOrUpdateManagedScript } from '../../core/index.js';
 import type { AnyGuardDefinition } from '../../core/index.js';
@@ -218,7 +219,17 @@ function listHooks(cwd: string, showAvailable: boolean): void {
 
   const config = loadHooksConfig(cwd);
   const names = Object.keys(config.installed);
+  const activeShims = detectActiveHarnessGuardShims(cwd);
+  const hasRegisteredGuards = names.some(name => name.startsWith('guard-'));
   if (names.length === 0) {
+    if (activeShims.length > 0) {
+      console.log('\nInstalled hooks:\n');
+      for (const shim of activeShims) {
+        console.log(`  active ${shim.provider} ${shim.scope} guard shim  guards: ${shim.guardCount}  config: ${shim.configPath}`);
+      }
+      console.log('\n  Internal .slope/hooks.json registry has no entries; harness shim is active.\n');
+      return;
+    }
     console.log('\nNo hooks installed. Run "slope hook list --available" to see options.\n');
     return;
   }
@@ -227,6 +238,12 @@ function listHooks(cwd: string, showAvailable: boolean): void {
   for (const name of names) {
     const entry = config.installed[name];
     console.log(`  ${name.padEnd(20)} provider: ${entry.provider}  installed: ${entry.installed_at}`);
+  }
+  if (activeShims.length > 0 && !hasRegisteredGuards) {
+    console.log('\nActive harness guard shims:\n');
+    for (const shim of activeShims) {
+      console.log(`  active ${shim.provider} ${shim.scope} guard shim  guards: ${shim.guardCount}  config: ${shim.configPath}`);
+    }
   }
   console.log('');
 }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -686,6 +686,12 @@ function writeCodexPluginHooksMetadata(pluginRoot: string): boolean {
   return writeJsonIfChanged(hooksPath, payload);
 }
 
+function installCodexProjectGuardShim(cwd: string): void {
+  const adapter = getAdapter('codex');
+  if (!adapter) return;
+  adapter.installGuards(cwd, GUARD_DEFINITIONS, { scope: 'project' });
+}
+
 function syncCodexPluginManifest(pluginRoot: string): boolean {
   const manifestPath = join(pluginRoot, '.codex-plugin', 'plugin.json');
   if (!existsSync(manifestPath)) return false;
@@ -921,6 +927,7 @@ function installForProvider(cwd: string, provider: InitProvider, metaphor: Metap
         }
       }
       installCodexPluginBundle(cwd);
+      installCodexProjectGuardShim(cwd);
       installDefaultHooks(cwd, 'codex');
       console.log('\n  Codex CLI: Guards installed to .codex/hooks.json');
       console.log('  Codex CLI: AGENTS.md provides project context');

--- a/src/cli/harness-hook-status.ts
+++ b/src/cli/harness-hook-status.ts
@@ -1,0 +1,66 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export interface ActiveHarnessGuardShim {
+  provider: 'codex';
+  scope: 'project' | 'user';
+  configPath: string;
+  guardCount: number;
+}
+
+type HookCommand = { command?: unknown };
+type HookGroup = { hooks?: unknown };
+
+function resolveCodexHome(): string {
+  const override = process.env.SLOPE_CODEX_HOME ?? process.env.CODEX_HOME;
+  return override && override.trim().length > 0 ? resolve(override.trim()) : join(homedir(), '.codex');
+}
+
+function collectCodexGuardNames(filePath: string): Set<string> {
+  const names = new Set<string>();
+  if (!existsSync(filePath)) return names;
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return names;
+  }
+
+  if (!parsed.hooks || typeof parsed.hooks !== 'object' || Array.isArray(parsed.hooks)) return names;
+
+  for (const groups of Object.values(parsed.hooks)) {
+    if (!Array.isArray(groups)) continue;
+    for (const group of groups as HookGroup[]) {
+      if (!group || typeof group !== 'object' || !Array.isArray(group.hooks)) continue;
+      for (const hook of group.hooks as HookCommand[]) {
+        const command = typeof hook?.command === 'string' ? hook.command : '';
+        if (!command.includes('slope-guard.sh')) continue;
+        const match = command.match(/slope-guard\.sh"?\s+([^\s"']+)/);
+        names.add(match?.[1] ?? command);
+      }
+    }
+  }
+
+  return names;
+}
+
+export function detectActiveHarnessGuardShims(cwd: string): ActiveHarnessGuardShim[] {
+  const candidates: ActiveHarnessGuardShim[] = [];
+  const projectHooksPath = join(cwd, '.codex', 'hooks.json');
+  const userHooksPath = join(resolveCodexHome(), 'hooks.json');
+
+  for (const item of [
+    { scope: 'project' as const, configPath: projectHooksPath },
+    { scope: 'user' as const, configPath: userHooksPath },
+  ]) {
+    const guardCount = collectCodexGuardNames(item.configPath).size;
+    if (guardCount > 0) {
+      candidates.push({ provider: 'codex', scope: item.scope, configPath: item.configPath, guardCount });
+    }
+  }
+
+  return candidates;
+}
+

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -254,6 +254,40 @@ describe('doctor checks', () => {
       expect(codexCheck!.fixable).toBe(true);
     });
 
+    it('treats an active Codex project guard shim as guard coverage', () => {
+      setupSlopeDir(cwd);
+      writeFileSync(join(cwd, '.slope', 'hooks.json'), JSON.stringify({
+        installed: {
+          'session-start': { provider: 'codex', installed_at: '2026-01-01T00:00:00.000Z' },
+          'session-end': { provider: 'codex', installed_at: '2026-01-01T00:00:00.000Z' },
+        },
+      }));
+      const hooksDir = join(cwd, '.codex', 'hooks');
+      mkdirSync(hooksDir, { recursive: true });
+      writeFileSync(join(hooksDir, 'slope-guard.sh'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+      writeFileSync(join(cwd, '.codex', 'hooks.json'), JSON.stringify({
+        hooks: {
+          PreToolUse: [{
+            matcher: 'apply_patch',
+            hooks: [{ type: 'command', command: '"./.codex/hooks/slope-guard.sh" claim-required' }],
+          }],
+          Stop: [{
+            hooks: [{ type: 'command', command: '"./.codex/hooks/slope-guard.sh" stop-check' }],
+          }],
+        },
+      }));
+
+      const checks = runDoctorChecks(cwd);
+      const guardCheck = checks.find(c => c.name === 'guards');
+
+      expect(guardCheck).toBeDefined();
+      expect(guardCheck!.status).toBe('ok');
+      expect(guardCheck!.message).toContain('active harness guard shim');
+      expect(guardCheck!.message).toContain('2 guard commands');
+      expect(guardCheck!.message).not.toContain('No guards active');
+      expect(guardCheck!.fixable).toBeUndefined();
+    });
+
     it('warns when SLOPE Codex hooks are installed at both project and user level', () => {
       setupSlopeDir(cwd);
       const previousCodexHome = process.env.SLOPE_CODEX_HOME;

--- a/tests/cli/commands/hook-codex.test.ts
+++ b/tests/cli/commands/hook-codex.test.ts
@@ -76,4 +76,51 @@ describe('slope hook add --harness=codex', () => {
     expect(group).toBeDefined();
     expect(group?.matcher?.split('|')).toEqual(expect.arrayContaining(['apply_patch', 'Edit', 'Write']));
   });
+
+  it('lists an active Codex guard shim when the internal registry is empty', async () => {
+    const log = vi.mocked(console.log);
+    mkdirSync(join(cwd, '.codex'), { recursive: true });
+    writeFileSync(join(cwd, '.codex', 'hooks.json'), JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          matcher: 'apply_patch',
+          hooks: [{ type: 'command', command: '"./.codex/hooks/slope-guard.sh" claim-required' }],
+        }],
+      },
+    }));
+
+    await hookCommand(['list']);
+
+    const output = log.mock.calls.map(call => call.join(' ')).join('\n');
+    expect(output).toContain('active codex project guard shim');
+    expect(output).toContain('Internal .slope/hooks.json registry has no entries; harness shim is active.');
+    expect(output).not.toContain('No hooks installed.');
+  });
+
+  it('lists an active Codex guard shim alongside session-only registry entries', async () => {
+    const log = vi.mocked(console.log);
+    writeFileSync(join(cwd, '.slope', 'hooks.json'), JSON.stringify({
+      installed: {
+        'session-start': { provider: 'codex', installed_at: '2026-01-01T00:00:00.000Z' },
+        'session-end': { provider: 'codex', installed_at: '2026-01-01T00:00:00.000Z' },
+      },
+    }));
+    mkdirSync(join(cwd, '.codex'), { recursive: true });
+    writeFileSync(join(cwd, '.codex', 'hooks.json'), JSON.stringify({
+      hooks: {
+        PreToolUse: [{
+          matcher: 'apply_patch',
+          hooks: [{ type: 'command', command: '"./.codex/hooks/slope-guard.sh" claim-required' }],
+        }],
+      },
+    }));
+
+    await hookCommand(['list']);
+
+    const output = log.mock.calls.map(call => call.join(' ')).join('\n');
+    expect(output).toContain('Installed hooks (2):');
+    expect(output).toContain('session-start');
+    expect(output).toContain('Active harness guard shims:');
+    expect(output).toContain('active codex project guard shim');
+  });
 });

--- a/tests/cli/init-codex.test.ts
+++ b/tests/cli/init-codex.test.ts
@@ -103,6 +103,15 @@ describe('slope init --codex (GH #309)', () => {
       runSlopeInit(cwd);
       expect(existsSync(join(cwd, '.codex', 'hooks', 'slope-session-start.sh'))).toBe(true);
       expect(existsSync(join(cwd, '.codex', 'hooks', 'slope-session-end.sh'))).toBe(true);
+      expect(existsSync(join(cwd, '.codex', 'hooks', 'slope-guard.sh'))).toBe(true);
+      expect(existsSync(join(cwd, '.codex', 'hooks.json'))).toBe(true);
+
+      const hooks = readJson(join(cwd, '.codex', 'hooks.json'));
+      const hookCommands = Object.values(hooks.hooks).flatMap((groups: any) =>
+        groups.flatMap((group: any) => group.hooks.map((hook: any) => hook.command)),
+      );
+      expect(hookCommands.some((command: string) => command.includes('claim-required'))).toBe(true);
+      expect(hookCommands.some((command: string) => command.includes('stop-check'))).toBe(true);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Closes #594.

Fixes Codex hook status reporting after `slope init --codex`:

- installs the active project `.codex/hooks.json` guard shim during Codex init, matching the existing setup copy
- teaches `slope doctor` to treat active Codex guard shims as guard coverage even when `.slope/hooks.json` has no guard entries
- teaches `slope hook list` to show active harness guard shims alongside session-only registry entries

## Root Cause

Codex guard execution can be represented by a harness shim in `.codex/hooks.json`, while SLOPE's internal `.slope/hooks.json` registry may only contain lifecycle hooks. Doctor and hook list only looked at the internal registry, so they reported an unguarded repo even when the Codex runtime shim was active.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run tests/cli/commands/doctor.test.ts tests/cli/commands/hook-codex.test.ts tests/cli/init-codex.test.ts --reporter=dot`
- `pnpm test -- --reporter=dot`
- CLI repro in a temp repo: `init --codex`, `doctor`, `hook list`
- `git diff --check`