### PR TITLE
Fix roadmap sync and sprint status regressions

### DIFF
--- a/docs/retros/sprint-237-review.md
+++ b/docs/retros/sprint-237-review.md
@@ -1,0 +1,25 @@
+## Sprint 237 Review: Open issue regression fixes
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 0 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (2/2) |
+| GIR % | 100% (2/2) |
+| Putts | 1 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 2)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S237-1 | Short Iron | Green | - | Stopped scorecard shots from overwriting, deleting, or retitling existing roadmap tickets; added regression coverage for multi-ticket scorecard shots. |
+| S237-2 | Wedge | In the Hole | - | Changed terminal sprint status output to show all-gates-complete without presenting stale phase: planning as current lifecycle truth. |
+
+### Course Management Notes
+
+- Issue-only sprints need explicit ticket representation in the scorecard when local roadmap tickets are absent.

--- a/docs/retros/sprint-237.json
+++ b/docs/retros/sprint-237.json
@@ -1,0 +1,55 @@
+{
+  "sprint_number": 237,
+  "theme": "Open issue regression fixes",
+  "par": 3,
+  "slope": 0,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-07-11",
+  "shots": [
+    {
+      "ticket_key": "S237-1",
+      "title": "#597 Preserve roadmap-owned tickets during roadmap sync",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Stopped scorecard shots from overwriting, deleting, or retitling existing roadmap tickets; added regression coverage for multi-ticket scorecard shots."
+    },
+    {
+      "ticket_key": "S237-2",
+      "title": "#598 Hide stale phase in ready_for_pr sprint status",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "Changed terminal sprint status output to show all-gates-complete without presenting stale phase: planning as current lifecycle truth."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 2,
+    "fairways_total": 2,
+    "greens_in_regulation": 2,
+    "greens_total": 2,
+    "putts": 1,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [
+    "Issue-only sprints need explicit ticket representation in the scorecard when local roadmap tickets are absent."
+  ],
+  "slope_factors": [],
+  "_commits": 1,
+  "_ci_signal": null,
+  "_pr_signal": null,
+  "_note": "Seeded from git and edited to represent the two GitHub issue tickets handled in this sprint."
+}

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -886,19 +886,6 @@ function scorecardToSprint(card: GolfScorecard): RoadmapSprint {
   };
 }
 
-function ticketIdentity(ticket: RoadmapTicket): string {
-  return ticket.key || ticket.id || '';
-}
-
-function mergeScorecardTickets(existingTickets: RoadmapTicket[], scorecardTickets: RoadmapTicket[]): RoadmapTicket[] {
-  const existingByKey = new Map(existingTickets.map(ticket => [ticketIdentity(ticket), ticket]));
-
-  return scorecardTickets.map(ticket => {
-    const existing = existingByKey.get(ticketIdentity(ticket));
-    return existing ? { ...existing, ...ticket } : ticket;
-  });
-}
-
 function modularAuthorityBlocksProjectionMutation(
   flags: Record<string, string>,
   cwd: string,
@@ -969,14 +956,16 @@ function syncSubcommand(flags: Record<string, string>, cwd: string): void {
     const existing = existingById.get(card.sprint_number);
 
     if (existing) {
-      // Update scorecard-derived fields, preserve manually-authored fields
+      // Update sprint-level scorecard-derived fields only. Tickets are roadmap-owned:
+      // scorecard shots are execution evidence and may be coarser, shorter, or
+      // grouped differently than the planning record. Do not overwrite, delete,
+      // add, or retitle existing roadmap tickets during sync.
       existing.theme = fromCard.theme;
       existing.par = fromCard.par;
       existing.slope = fromCard.slope;
       existing.type = fromCard.type;
-      existing.tickets = mergeScorecardTickets(existing.tickets, fromCard.tickets);
       (existing as RoadmapSprint & { status?: string }).status = 'complete';
-      // Preserve: sprint depends_on and ticket metadata such as depends_on/github_issue.
+      // Preserve: sprint depends_on and all ticket identity/metadata.
       updated++;
     } else {
       roadmap.sprints.push({ ...fromCard, status: 'complete' } as RoadmapSprint);

--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -889,7 +889,7 @@ function statusCommand(cwd: string): void {
   const derivedStatus = complete
     ? waivedReviews.length > 0 ? 'ready_for_pr_with_review_waiver' : 'ready_for_pr'
     : state.phase;
-  const phaseContext = complete ? ` (phase: ${state.phase}, all gates complete)` : ` (phase: ${state.phase})`;
+  const phaseContext = complete ? ' (all gates complete)' : ` (phase: ${state.phase})`;
   console.log(`Sprint ${formatSprintNumber(state.sprint)} - status: ${derivedStatus}${phaseContext}`);
   console.log(`Started: ${state.started_at}`);
   console.log(`Updated: ${state.updated_at}`);

--- a/tests/cli/roadmap.test.ts
+++ b/tests/cli/roadmap.test.ts
@@ -842,7 +842,7 @@ describe('slope roadmap sync', () => {
     expect(s8.depends_on).toEqual([7]);
   });
 
-  it('marks scorecard-backed sprints complete and preserves per-ticket metadata (#568)', () => {
+  it('marks scorecard-backed sprints complete while preserving roadmap-owned tickets (#568, #597)', () => {
     const roadmap = makeRoadmapJson({
       sprints: makeRoadmapJson().sprints.map(sprint => sprint.id === 8
         ? {
@@ -872,32 +872,66 @@ describe('slope roadmap sync', () => {
     const result = JSON.parse(readFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), 'utf8'));
     const s8 = result.sprints.find((s: { id: number }) => s.id === 8);
     expect(s8.status).toBe('complete');
-    expect(s8.tickets[0].title).toBe('Synced T1');
+    expect(s8.tickets[0].title).toBe('T1');
     expect(s8.tickets[0].github_issue).toBe(568);
     expect(s8.tickets[1].depends_on).toEqual(['S8-1']);
     expect(s8.tickets[1].github_issue).toBe(568);
     expect(s8.tickets[2].depends_on).toEqual(['S8-2']);
   });
 
-  it('maps club to complexity correctly', () => {
-    const roadmap = makeRoadmapJson();
+  it('does not collapse existing roadmap tickets when a scorecard shot covers multiple ticket keys (#597)', () => {
+    const roadmap = makeRoadmapJson({
+      sprints: makeRoadmapJson().sprints.map(sprint => sprint.id === 8
+        ? {
+          ...sprint,
+          tickets: [
+            { key: 'S8-1', title: 'Roadmap task 1', club: 'short_iron', complexity: 'standard' },
+            { key: 'S8-2', title: 'Roadmap task 2', club: 'wedge', complexity: 'small' },
+            { key: 'S8-3', title: 'Roadmap task 3', club: 'putter', complexity: 'trivial' },
+          ],
+        } as RoadmapDefinition['sprints'][number]
+        : sprint),
+    });
     writeRoadmap(tmpDir, roadmap);
     writeConfig(tmpDir, { scorecardDir: 'docs/retros', scorecardPattern: 'sprint-*.json', minSprint: 1 });
-    writeScorecard(tmpDir, 7, {
+    writeScorecard(tmpDir, 8, {
       shots: [
-        { ticket_key: 'S7-1', title: 'Driver', club: 'driver', result: 'green', hazards: [] },
-        { ticket_key: 'S7-2', title: 'Long Iron', club: 'long_iron', result: 'green', hazards: [] },
-        { ticket_key: 'S7-3', title: 'Putter', club: 'putter', result: 'green', hazards: [] },
+        { ticket_key: 'S8-1', title: 'S8-1 S8-2 S8-3: Did the whole sprint', club: 'short_iron', result: 'green', hazards: [] },
       ],
     });
 
     roadmapCommand(['sync']);
 
     const result = JSON.parse(readFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), 'utf8'));
-    const s7 = result.sprints.find((s: { id: number }) => s.id === 7);
-    expect(s7.tickets[0].complexity).toBe('moderate'); // driver
-    expect(s7.tickets[1].complexity).toBe('moderate'); // long_iron
-    expect(s7.tickets[2].complexity).toBe('trivial');  // putter
+    const s8 = result.sprints.find((s: { id: number }) => s.id === 8);
+    expect(s8.tickets.map((ticket: { key: string }) => ticket.key)).toEqual(['S8-1', 'S8-2', 'S8-3']);
+    expect(s8.tickets.map((ticket: { title: string }) => ticket.title)).toEqual([
+      'Roadmap task 1',
+      'Roadmap task 2',
+      'Roadmap task 3',
+    ]);
+  });
+
+  it('maps club to complexity correctly', () => {
+    const roadmap = makeRoadmapJson();
+    writeRoadmap(tmpDir, roadmap);
+    writeConfig(tmpDir, { scorecardDir: 'docs/retros', scorecardPattern: 'sprint-*.json', minSprint: 1 });
+    writeScorecard(tmpDir, 10, {
+      theme: 'New Sprint',
+      shots: [
+        { ticket_key: 'S10-1', title: 'Driver', club: 'driver', result: 'green', hazards: [] },
+        { ticket_key: 'S10-2', title: 'Long Iron', club: 'long_iron', result: 'green', hazards: [] },
+        { ticket_key: 'S10-3', title: 'Putter', club: 'putter', result: 'green', hazards: [] },
+      ],
+    });
+
+    roadmapCommand(['sync']);
+
+    const result = JSON.parse(readFileSync(join(tmpDir, 'docs', 'backlog', 'roadmap.json'), 'utf8'));
+    const s10 = result.sprints.find((s: { id: number }) => s.id === 10);
+    expect(s10.tickets[0].complexity).toBe('moderate'); // driver
+    expect(s10.tickets[1].complexity).toBe('moderate'); // long_iron
+    expect(s10.tickets[2].complexity).toBe('trivial');  // putter
   });
 
   it('dry-run shows changes without writing', () => {

--- a/tests/cli/sprint-workflow.test.ts
+++ b/tests/cli/sprint-workflow.test.ts
@@ -826,7 +826,8 @@ describe('slope sprint status', () => {
 
     const output = await captureLog(() => sprintCommand(['status']));
 
-    expect(output).toContain('status: ready_for_pr (phase: planning, all gates complete)');
+    expect(output).toContain('status: ready_for_pr (all gates complete)');
+    expect(output).not.toContain('phase: planning, all gates complete');
     expect(output).toContain('Next: create PR for this branch');
     expect(output).not.toContain('Remaining:');
   });


### PR DESCRIPTION
﻿## Summary

Fixes two currently open SLOPE issues:

- Closes #597 by making `slope roadmap sync` preserve existing roadmap-owned ticket identity, titles, and metadata. Scorecard shots still seed tickets for brand-new scorecard-backed sprints, but existing roadmap sprint tickets are no longer overwritten, deleted, or collapsed.
- Closes #598 by changing terminal sprint status output from `ready_for_pr (phase: planning, all gates complete)` to `ready_for_pr (all gates complete)`, avoiding stale phase as lifecycle truth while leaving persisted sprint state auditable.

## Validation

- `pnpm test -- tests/cli/roadmap.test.ts --reporter=dot` — 48 passed
- `pnpm test -- tests/cli/sprint-workflow.test.ts --reporter=dot` — 41 passed
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test -- --reporter=dot` — 4003 passed, 25 skipped
- `node dist/cli/index.js validate docs/retros/sprint-237.json` — valid with existing non-blocking metadata warnings
- `node dist/cli/index.js map --check` — current

## SLOPE

- Sprint 237 gates complete.
- Scorecard: `docs/retros/sprint-237.json`
- Review: `docs/retros/sprint-237-review.md`
