### PR TITLE
Fix stale sprint-state next inference

### DIFF
--- a/docs/retros/sprint-238-review.md
+++ b/docs/retros/sprint-238-review.md
@@ -1,0 +1,20 @@
+## Sprint 238 Review: Stale sprint state recovery
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 0 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S238-1 | Short Iron | Green | - | 4 files changed; full tests, typecheck, build, docs, and map validation passed. |

--- a/docs/retros/sprint-238.json
+++ b/docs/retros/sprint-238.json
@@ -1,0 +1,46 @@
+{
+  "sprint_number": 238,
+  "theme": "Stale sprint state recovery",
+  "par": 3,
+  "slope": 0,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-07-11",
+  "shots": [
+    {
+      "ticket_key": "S238-1",
+      "title": "#601 Ignore stale local sprint state in next",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "4 files changed; full tests, typecheck, build, docs, and map validation passed."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [],
+  "slope_factors": [],
+  "_auto_generated": true,
+  "_commits": 1,
+  "_ci_signal": null,
+  "_pr_signal": null,
+  "_note": "Auto-generated from git only (no CI). Shots default to green. Provide --test-output for better scoring."
+}

--- a/src/cli/commands/next.ts
+++ b/src/cli/commands/next.ts
@@ -32,6 +32,15 @@ export function nextCommand(args: string[] = []): void {
     console.log(`  (auto-detected from scorecards)`);
   }
 
+  if (context.staleSprintState) {
+    console.log(`  Warning: ignoring stale local sprint state ${formatSprintLabel(context.staleSprintState.sprint)} (${context.staleSprintState.phase}); ${context.staleSprintState.reason}.`);
+    console.log('  Run `slope sprint reset` after confirming the merged sprint is closed, or `slope sprint begin --sprint=<N>` to replace the local slot.');
+  }
+  if (context.staleConfigSprint) {
+    console.log(`  Warning: ignoring stale configured currentSprint ${formatSprintLabel(context.staleConfigSprint.sprint)}; ${context.staleConfigSprint.reason}.`);
+    console.log('  Update .slope/config.json currentSprint or remove it after reconciling the merged sprint.');
+  }
+
   console.log('');
   console.log('  Quick start:');
   console.log(`    slope briefing --sprint=${context.sprint}`);

--- a/src/cli/sprint-inference.ts
+++ b/src/cli/sprint-inference.ts
@@ -22,6 +22,15 @@ export interface InferredSprintContext {
   source: 'sprint-state' | 'config' | 'roadmap' | 'scorecards' | 'initial';
   latestScorecard: number;
   roadmapSprint?: RoadmapSprint;
+  staleSprintState?: {
+    sprint: number;
+    phase: string;
+    reason: string;
+  };
+  staleConfigSprint?: {
+    sprint: number;
+    reason: string;
+  };
 }
 
 export function loadRoadmapForInference(cwd: string, config: SlopeConfig): RoadmapDefinition | null {
@@ -39,7 +48,9 @@ export function loadRoadmapForInference(cwd: string, config: SlopeConfig): Roadm
 export function inferSprintContext(cwd: string = process.cwd(), config: SlopeConfig = loadConfig(cwd)): InferredSprintContext {
   const latestScorecard = detectLatestSprint(config, cwd);
   const sprintState = loadSprintState(cwd);
-  if (isActiveSprintState(sprintState)) {
+  const staleSprintState = activeStateCompletedByScorecards(sprintState, latestScorecard);
+  const staleConfigSprint = configuredSprintCompletedByScorecards(config.currentSprint, latestScorecard);
+  if (isActiveSprintState(sprintState) && !staleSprintState) {
     return {
       sprint: sprintState.sprint,
       label: formatSprintLabel(sprintState.sprint),
@@ -48,12 +59,13 @@ export function inferSprintContext(cwd: string = process.cwd(), config: SlopeCon
     };
   }
 
-  if (config.currentSprint) {
+  if (config.currentSprint && !staleConfigSprint) {
     return {
       sprint: config.currentSprint,
       label: formatSprintLabel(config.currentSprint),
       source: 'config',
       latestScorecard,
+      ...(staleSprintState ? { staleSprintState } : {}),
     };
   }
 
@@ -76,6 +88,8 @@ export function inferSprintContext(cwd: string = process.cwd(), config: SlopeCon
       source: 'roadmap',
       latestScorecard,
       roadmapSprint: pending,
+      ...(staleSprintState ? { staleSprintState } : {}),
+      ...(staleConfigSprint ? { staleConfigSprint } : {}),
     };
   }
 
@@ -86,6 +100,8 @@ export function inferSprintContext(cwd: string = process.cwd(), config: SlopeCon
       label: formatSprintLabel(sprint),
       source: 'scorecards',
       latestScorecard,
+      ...(staleSprintState ? { staleSprintState } : {}),
+      ...(staleConfigSprint ? { staleConfigSprint } : {}),
     };
   }
 
@@ -94,6 +110,33 @@ export function inferSprintContext(cwd: string = process.cwd(), config: SlopeCon
     label: 'S1',
     source: 'initial',
     latestScorecard: 0,
+    ...(staleSprintState ? { staleSprintState } : {}),
+    ...(staleConfigSprint ? { staleConfigSprint } : {}),
+  };
+}
+
+function activeStateCompletedByScorecards(
+  sprintState: ReturnType<typeof loadSprintState>,
+  latestScorecard: number,
+): InferredSprintContext['staleSprintState'] | null {
+  if (!isActiveSprintState(sprintState) || latestScorecard <= 0) return null;
+  if (sprintOrderValue(sprintState.sprint) > sprintOrderValue(latestScorecard)) return null;
+  return {
+    sprint: sprintState.sprint,
+    phase: sprintState.phase,
+    reason: `completed scorecard evidence has advanced to ${formatSprintLabel(latestScorecard)}`,
+  };
+}
+
+function configuredSprintCompletedByScorecards(
+  currentSprint: number | undefined,
+  latestScorecard: number,
+): InferredSprintContext['staleConfigSprint'] | null {
+  if (!currentSprint || latestScorecard <= 0) return null;
+  if (sprintOrderValue(currentSprint) > sprintOrderValue(latestScorecard)) return null;
+  return {
+    sprint: currentSprint,
+    reason: `completed scorecard evidence has advanced to ${formatSprintLabel(latestScorecard)}`,
   };
 }
 

--- a/tests/cli/commands/next.test.ts
+++ b/tests/cli/commands/next.test.ts
@@ -267,6 +267,29 @@ describe('slope next', () => {
     expect(output).not.toContain('Next sprint: S1');
   });
 
+  it('warns and skips active local sprint-state older than completed scorecard evidence (#601)', () => {
+    const cwd = makeRepo();
+    repos.push(cwd);
+    writeScorecard(cwd, 453);
+    saveSprintState(cwd, createSprintState(444, 'planning'));
+    const originalCwd = process.cwd();
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg = '') => logs.push(String(msg)));
+
+    try {
+      process.chdir(cwd);
+      nextCommand();
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const output = logs.join('\n');
+    expect(output).toContain('Latest scorecard: S453');
+    expect(output).toContain('Next sprint: S454');
+    expect(output).toContain('Warning: ignoring stale local sprint state S444 (planning)');
+    expect(output).not.toContain('Next sprint: S444');
+  });
+
   it('falls back to the next canonical sprint after a decimal inserted scorecard', () => {
     const cwd = makeRepo();
     repos.push(cwd);

--- a/tests/cli/sprint-inference.test.ts
+++ b/tests/cli/sprint-inference.test.ts
@@ -64,4 +64,28 @@ describe('inferSprintContext', () => {
     expect(context.sprint).toBe(18);
     expect(context.source).toBe('config');
   });
+
+  it('ignores active local sprint-state older than completed scorecard evidence (#601)', () => {
+    mkdirSync(join(tmpDir, 'docs', 'retros'), { recursive: true });
+    writeFileSync(join(tmpDir, 'docs', 'retros', 'sprint-453.json'), JSON.stringify({
+      sprint_number: 453,
+      theme: 'Merged feature',
+      par: 3,
+      slope: 1,
+      score: 3,
+      shots: [],
+    }));
+    saveSprintState(tmpDir, createSprintState(444, 'planning'));
+
+    const context = inferSprintContext(tmpDir);
+
+    expect(context.sprint).toBe(454);
+    expect(context.source).toBe('scorecards');
+    expect(context.latestScorecard).toBe(453);
+    expect(context.staleSprintState).toMatchObject({
+      sprint: 444,
+      phase: 'planning',
+    });
+    expect(context.staleConfigSprint).toMatchObject({ sprint: 18 });
+  });
 });


### PR DESCRIPTION
﻿## Summary
- Fixes #601 by ignoring stale worktree-local `.slope/sprint-state.json` when newer completed scorecard evidence exists.
- Applies the same stale-evidence guard to configured `currentSprint` values.
- Adds `slope next` warnings with explicit recovery guidance instead of silently recommending historical work.
- Adds regression coverage for sprint inference and `slope next` output.

## Root cause
`slope next` trusted active local sprint state before checking durable scorecard evidence. After merges or worktree reuse, that let stale `.slope/sprint-state.json` point agents back at completed historical sprints.

## Validation
- `pnpm test -- tests/cli/sprint-inference.test.ts tests/cli/commands/next.test.ts --reporter=dot`
- `pnpm run typecheck`
- `git diff --check`
- `pnpm run build`
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js docs generate --pretty`
- `node dist/cli/index.js docs check`
- `pnpm test -- --reporter=dot`
- `node dist/cli/index.js validate docs/retros/sprint-238.json`

## SLOPE
- Sprint: S238
- Gates: tests, code_review self-review, architect_review self-review, scorecard, review_md
