### PR TITLE
Fix canonical S455 sprint identity

### DIFF
--- a/docs/retros/sprint-239-review.md
+++ b/docs/retros/sprint-239-review.md
@@ -1,0 +1,20 @@
+## Sprint 239 Review: Canonical S455 lifecycle identity
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 3 |
+| Slope | 0 |
+| Score | 3 |
+| Label | Par |
+| Fairway % | 100% (1/1) |
+| GIR % | 100% (1/1) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 1)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S239-1 | Long Iron | Green | - | 5 files changed; focused regressions, full tests, typecheck, build, docs, map, and compiled CLI smoke passed. |

--- a/docs/retros/sprint-239.json
+++ b/docs/retros/sprint-239.json
@@ -1,0 +1,46 @@
+{
+  "sprint_number": 239,
+  "theme": "Canonical S455 lifecycle identity",
+  "par": 3,
+  "slope": 0,
+  "score": 3,
+  "score_label": "par",
+  "date": "2026-07-11",
+  "shots": [
+    {
+      "ticket_key": "S239-1",
+      "title": "#605 Preserve canonical roadmap S455 lifecycle labels",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "5 files changed; focused regressions, full tests, typecheck, build, docs, map, and compiled CLI smoke passed."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 1,
+    "fairways_total": 1,
+    "greens_in_regulation": 1,
+    "greens_total": 1,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 0,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [],
+  "course_management_notes": [],
+  "slope_factors": [],
+  "_auto_generated": true,
+  "_commits": 1,
+  "_ci_signal": null,
+  "_pr_signal": null,
+  "_note": "Auto-generated from git only (no CI). Shots default to green. Provide --test-output for better scoring."
+}

--- a/src/cli/commands/next.ts
+++ b/src/cli/commands/next.ts
@@ -17,7 +17,7 @@ export function nextCommand(args: string[] = []): void {
   if (context.latestScorecard === 0) {
     console.log(`  No scorecards found. Next sprint: ${context.label}`);
   } else {
-    console.log(`  Latest scorecard: S${context.latestScorecard}`);
+    console.log(`  Latest scorecard: ${context.latestScorecardLabel}`);
     console.log(`  Next sprint: ${context.label}`);
   }
 
@@ -26,7 +26,7 @@ export function nextCommand(args: string[] = []): void {
   } else if (context.source === 'roadmap') {
     console.log(`  (selected from pending roadmap sprint${context.roadmapSprint?.theme ? `: ${context.roadmapSprint.theme}` : ''})`);
     if (context.latestScorecard > 0 && context.sprint !== nextCanonicalSprintId(context.latestScorecard)) {
-      console.log(`  (roadmap state overrides scorecard fallback to ${formatSprintLabel(nextCanonicalSprintId(context.latestScorecard))})`);
+      console.log(`  (roadmap state overrides scorecard fallback to ${context.scorecardFallbackLabel ?? formatSprintLabel(nextCanonicalSprintId(context.latestScorecard))})`);
     }
   } else {
     console.log(`  (auto-detected from scorecards)`);

--- a/src/cli/commands/sprint.ts
+++ b/src/cli/commands/sprint.ts
@@ -26,8 +26,8 @@ import {
   type SprintPhase,
   type SprintState,
 } from '../sprint-state.js';
-import { WorkflowEngine, loadWorkflow, resolveVariables, validateWorkflow, loadConfig, parseRoadmap, castRoadmapStructure, formatSprintLabel, formatSprintNumber, parseSprintNumber } from '../../core/index.js';
-import type { WorkflowDefinition, WorkflowExecution } from '../../core/index.js';
+import { WorkflowEngine, loadWorkflow, resolveVariables, validateWorkflow, loadConfig, parseRoadmap, castRoadmapStructure, formatSprintLabel, formatSprintNumber, formatRoadmapSprintLabel, parseSprintNumber } from '../../core/index.js';
+import type { RoadmapDefinition, WorkflowDefinition, WorkflowExecution } from '../../core/index.js';
 import { createHash } from 'node:crypto';
 import { formatActorName, formatActorSource, formatConflictSummary, resolveActor } from '../actor.js';
 import {
@@ -286,6 +286,29 @@ function commandValue(value: string): string {
     : `'${value.replaceAll("'", `'"'"'`)}`;
 }
 
+function loadRoadmapForSprintLabels(cwd: string): RoadmapDefinition | null {
+  const config = loadConfig(cwd);
+  const roadmapPath = join(cwd, config.roadmapPath);
+  if (!existsSync(roadmapPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(roadmapPath, 'utf8'));
+    const parsed = parseRoadmap(raw);
+    return parsed.roadmap ?? castRoadmapStructure(raw);
+  } catch {
+    return null;
+  }
+}
+
+function sprintLabelForCwd(cwd: string, sprint: number): string {
+  const roadmap = loadRoadmapForSprintLabels(cwd);
+  return roadmap ? formatRoadmapSprintLabel(roadmap, sprint) : formatSprintLabel(sprint);
+}
+
+function sprintNumberForCwd(cwd: string, sprint: number): string {
+  const label = sprintLabelForCwd(cwd, sprint);
+  return label.startsWith('S') ? label.slice(1) : label;
+}
+
 function actorRetryOption(args: string[]): string | null {
   for (const flag of ['--actor', '--player']) {
     const value = findOptionValue(args, flag);
@@ -504,6 +527,8 @@ async function beginCommand(args: string[], cwd: string): Promise<void> {
   }
 
   // Step 1: initialize without overwriting existing or corrupt local state.
+  const sprintLabel = sprintLabelForCwd(cwd, sprint);
+  const sprintNumber = sprintNumberForCwd(cwd, sprint);
   const initialized = initializeSprintState(cwd, createSprintState(sprint, 'planning'));
   if (initialized.status === 'corrupt') {
     console.error(`Refusing to begin: corrupt sprint evidence was preserved at ${relative(cwd, initialized.path)}.`);
@@ -515,12 +540,12 @@ async function beginCommand(args: string[], cwd: string): Promise<void> {
     cwd,
     state,
     sprint,
-    `begin ${formatSprintLabel(sprint)}`,
-    `slope sprint begin --sprint=${formatSprintNumber(sprint)} --ticket=${commandValue(ticket)}${retryActor ? ` ${retryActor}` : ''}`,
+    `begin ${sprintLabel}`,
+    `slope sprint begin --sprint=${sprintNumber} --ticket=${commandValue(ticket)}${retryActor ? ` ${retryActor}` : ''}`,
   )) {
-    console.log(`Sprint ${formatSprintNumber(sprint)}: already started (phase: ${state.phase}).`);
+    console.log(`Sprint ${sprintNumber}: already started (phase: ${state.phase}).`);
   } else {
-    console.log(`Sprint ${formatSprintNumber(sprint)}: started (phase: planning).`);
+    console.log(`Sprint ${sprintNumber}: started (phase: planning).`);
   }
 
   // Step 2: claim
@@ -549,7 +574,7 @@ async function beginCommand(args: string[], cwd: string): Promise<void> {
       if (overlaps.length > 0) {
         console.error(`\nClaim blocked — overlap conflict(s) detected:`);
         for (const c of overlaps) console.error(`  [!!] ${formatConflictSummary(c)}`);
-        console.error(`\nResolve conflicts or run \`slope claim --target=${ticket} --sprint=${formatSprintNumber(sprint)} --force\` to override.`);
+        console.error(`\nResolve conflicts or run \`slope claim --target=${ticket} --sprint=${sprintNumber} --force\` to override.`);
         process.exit(1);
       }
       const claim = await store.claim({ sprint_number: sprint, player, target: ticket, scope: 'ticket' });
@@ -566,10 +591,10 @@ async function beginCommand(args: string[], cwd: string): Promise<void> {
   console.log('\n' + '─'.repeat(50));
   try {
     const { briefingCommand } = await import('./briefing.js');
-    await briefingCommand([`--sprint=${formatSprintNumber(sprint)}`]);
+    await briefingCommand([`--sprint=${sprintNumber}`]);
   } catch (err) {
     console.error(`  Could not run briefing: ${(err as Error).message}`);
-    console.error(`  Sprint state was already created; retry with: slope briefing --sprint=${formatSprintNumber(sprint)}`);
+    console.error(`  Sprint state was already created; retry with: slope briefing --sprint=${sprintNumber}`);
   }
 
   // Step 4: prep --lite
@@ -644,7 +669,9 @@ async function startCommand(args: string[], cwd: string): Promise<void> {
     ...(retryActor ? [retryActor] : []),
     ...(force ? ['--force'] : []),
   ];
-  const retryStart = `slope sprint start --number=${formatSprintNumber(sprint)} --phase=${phase}${retryExtras.length > 0 ? ` ${retryExtras.join(' ')}` : ''}`;
+  const sprintLabel = sprintLabelForCwd(cwd, sprint);
+  const sprintNumber = sprintNumberForCwd(cwd, sprint);
+  const retryStart = `slope sprint start --number=${sprintNumber} --phase=${phase}${retryExtras.length > 0 ? ` ${retryExtras.join(' ')}` : ''}`;
 
   failOnCorruptSprintState(cwd);
   const existingResult = loadSprintStateResult(cwd);
@@ -654,7 +681,7 @@ async function startCommand(args: string[], cwd: string): Promise<void> {
       cwd,
       existing,
       sprint,
-      `start ${formatSprintLabel(sprint)}`,
+      `start ${sprintLabel}`,
       retryStart,
     );
     if (phaseValue && existing.phase !== phase) {
@@ -663,17 +690,17 @@ async function startCommand(args: string[], cwd: string): Promise<void> {
         console.error('Refusing to update phase because sprint state changed concurrently; retry the start command.');
         process.exit(1);
       }
-      console.log(`Sprint ${formatSprintNumber(sprint)} phase updated: ${phase}.`);
+      console.log(`Sprint ${sprintNumber} phase updated: ${phase}.`);
       return;
     }
-    console.log(`Sprint ${formatSprintNumber(sprint)} state already exists (phase: ${existing.phase}).`);
+    console.log(`Sprint ${sprintNumber} state already exists (phase: ${existing.phase}).`);
     return;
   }
 
   const roadmapReality = loadRoadmapReality(cwd);
   const blockingRoadmapIssues = blockingRoadmapIssuesForSprint(roadmapReality, sprint);
   if (blockingRoadmapIssues.length > 0 && !force) {
-    console.error(`\nPre-sprint reality check failed for ${formatSprintLabel(sprint)}:`);
+    console.error(`\nPre-sprint reality check failed for ${sprintLabel}:`);
     for (const issue of blockingRoadmapIssues) {
       console.error(`  [${issue.type}] ${issue.message}`);
     }
@@ -706,14 +733,14 @@ async function startCommand(args: string[], cwd: string): Promise<void> {
       cwd,
       initialized.state,
       sprint,
-      `start ${formatSprintLabel(sprint)}`,
+      `start ${sprintLabel}`,
       retryStart,
     );
-    console.log(`Sprint ${formatSprintNumber(sprint)} state already exists (phase: ${initialized.state.phase}).`);
+    console.log(`Sprint ${sprintNumber} state already exists (phase: ${initialized.state.phase}).`);
     return;
   }
   const autoClaim = await autoClaimSprint(cwd, sprint, actorOverride(args));
-  console.log(`Sprint ${formatSprintNumber(sprint)} started (phase: ${phase}). Use 'slope sprint gate <name>' to mark gates; review gates require evidence options.`);
+  console.log(`Sprint ${sprintNumber} started (phase: ${phase}). Use 'slope sprint gate <name>' to mark gates; review gates require evidence options.`);
   if (autoClaim) console.log(autoClaim);
 }
 
@@ -722,7 +749,7 @@ async function autoClaimSprint(cwd: string, sprint: number, explicitActor?: stri
   const actor = resolveActor(cwd, { explicitActor });
   const player = actor.name;
   const playerDisplay = formatActorName(actor);
-  const target = `sprint:${formatSprintLabel(sprint)}`;
+  const target = `sprint:${sprintLabelForCwd(cwd, sprint)}`;
 
   try {
     const store = await resolveStore(cwd);
@@ -762,9 +789,9 @@ function phaseCommand(args: string[], cwd: string): void {
 
   updateSprintPhase(cwd, phaseInput);
   if (before.phase === phaseInput) {
-    console.log(`Sprint ${formatSprintNumber(before.sprint)} already in ${phaseInput} phase.`);
+    console.log(`Sprint ${sprintNumberForCwd(cwd, before.sprint)} already in ${phaseInput} phase.`);
   } else {
-    console.log(`Sprint ${formatSprintNumber(before.sprint)} phase updated: ${before.phase} -> ${phaseInput}.`);
+    console.log(`Sprint ${sprintNumberForCwd(cwd, before.sprint)} phase updated: ${before.phase} -> ${phaseInput}.`);
   }
 }
 
@@ -890,7 +917,7 @@ function statusCommand(cwd: string): void {
     ? waivedReviews.length > 0 ? 'ready_for_pr_with_review_waiver' : 'ready_for_pr'
     : state.phase;
   const phaseContext = complete ? ' (all gates complete)' : ` (phase: ${state.phase})`;
-  console.log(`Sprint ${formatSprintNumber(state.sprint)} - status: ${derivedStatus}${phaseContext}`);
+  console.log(`Sprint ${sprintNumberForCwd(cwd, state.sprint)} - status: ${derivedStatus}${phaseContext}`);
   console.log(`Started: ${state.started_at}`);
   console.log(`Updated: ${state.updated_at}`);
   console.log('');

--- a/src/cli/sprint-inference.ts
+++ b/src/cli/sprint-inference.ts
@@ -3,13 +3,15 @@ import { join } from 'node:path';
 import {
   castRoadmapStructure,
   compareSprintIds,
+  compareRoadmapSprintIds,
   detectLatestSprint,
   formatSprintLabel,
-  isEncodedInsertedSprintId,
+  formatRoadmapSprintLabel,
   isRoadmapSprintPending,
   loadScorecards,
   nextCanonicalSprintId,
   parseRoadmap,
+  roadmapSprintOrderValue,
   sprintOrderValue,
 } from '../core/index.js';
 import type { RoadmapDefinition, RoadmapSprint, SlopeConfig } from '../core/index.js';
@@ -21,6 +23,9 @@ export interface InferredSprintContext {
   label: string;
   source: 'sprint-state' | 'config' | 'roadmap' | 'scorecards' | 'initial';
   latestScorecard: number;
+  latestScorecardLabel: string;
+  scorecardFallbackSprint?: number;
+  scorecardFallbackLabel?: string;
   roadmapSprint?: RoadmapSprint;
   staleSprintState?: {
     sprint: number;
@@ -47,46 +52,53 @@ export function loadRoadmapForInference(cwd: string, config: SlopeConfig): Roadm
 
 export function inferSprintContext(cwd: string = process.cwd(), config: SlopeConfig = loadConfig(cwd)): InferredSprintContext {
   const latestScorecard = detectLatestSprint(config, cwd);
+  const roadmap = loadRoadmapForInference(cwd, config);
+  const latestScorecardLabel = labelForSprint(latestScorecard, roadmap);
   const sprintState = loadSprintState(cwd);
-  const staleSprintState = activeStateCompletedByScorecards(sprintState, latestScorecard);
-  const staleConfigSprint = configuredSprintCompletedByScorecards(config.currentSprint, latestScorecard);
+  const staleSprintState = activeStateCompletedByScorecards(sprintState, latestScorecard, roadmap);
+  const staleConfigSprint = configuredSprintCompletedByScorecards(config.currentSprint, latestScorecard, roadmap);
   if (isActiveSprintState(sprintState) && !staleSprintState) {
     return {
       sprint: sprintState.sprint,
-      label: formatSprintLabel(sprintState.sprint),
+      label: labelForSprint(sprintState.sprint, roadmap),
       source: 'sprint-state',
       latestScorecard,
+      latestScorecardLabel,
     };
   }
 
   if (config.currentSprint && !staleConfigSprint) {
     return {
       sprint: config.currentSprint,
-      label: formatSprintLabel(config.currentSprint),
+      label: labelForSprint(config.currentSprint, roadmap),
       source: 'config',
       latestScorecard,
+      latestScorecardLabel,
       ...(staleSprintState ? { staleSprintState } : {}),
     };
   }
 
-  const roadmap = loadRoadmapForInference(cwd, config);
   const scorecards = loadScorecards(config, cwd);
   const completedIds = new Set<number>(scorecards.map(card => card.sprint_number));
   const pendingSprints = roadmap?.sprints
     .filter(sprint => {
       return isRoadmapSprintPending(sprint) && !completedIds.has(sprint.id);
     })
-    .sort((a, b) => compareSprintIds(a.id, b.id)) ?? [];
+    .sort((a, b) => compareSprintIdsForRoadmap(a.id, b.id, roadmap)) ?? [];
 
   const scorecardNext = latestScorecard > 0 ? nextCanonicalSprintId(latestScorecard) : 1;
-  const pending = choosePendingSprint(pendingSprints, latestScorecard, scorecardNext);
+  const scorecardFallbackLabel = labelForSprint(scorecardNext, roadmap);
+  const pending = choosePendingSprint(pendingSprints, latestScorecard, scorecardNext, roadmap);
 
   if (pending) {
     return {
       sprint: pending.id,
-      label: formatSprintLabel(pending.id),
+      label: labelForSprint(pending.id, roadmap),
       source: 'roadmap',
       latestScorecard,
+      latestScorecardLabel,
+      scorecardFallbackSprint: scorecardNext,
+      scorecardFallbackLabel,
       roadmapSprint: pending,
       ...(staleSprintState ? { staleSprintState } : {}),
       ...(staleConfigSprint ? { staleConfigSprint } : {}),
@@ -97,9 +109,12 @@ export function inferSprintContext(cwd: string = process.cwd(), config: SlopeCon
     const sprint = scorecardNext;
     return {
       sprint,
-      label: formatSprintLabel(sprint),
+      label: labelForSprint(sprint, roadmap),
       source: 'scorecards',
       latestScorecard,
+      latestScorecardLabel,
+      scorecardFallbackSprint: scorecardNext,
+      scorecardFallbackLabel,
       ...(staleSprintState ? { staleSprintState } : {}),
       ...(staleConfigSprint ? { staleConfigSprint } : {}),
     };
@@ -110,6 +125,9 @@ export function inferSprintContext(cwd: string = process.cwd(), config: SlopeCon
     label: 'S1',
     source: 'initial',
     latestScorecard: 0,
+    latestScorecardLabel: 'S0',
+    scorecardFallbackSprint: 1,
+    scorecardFallbackLabel: 'S1',
     ...(staleSprintState ? { staleSprintState } : {}),
     ...(staleConfigSprint ? { staleConfigSprint } : {}),
   };
@@ -118,25 +136,27 @@ export function inferSprintContext(cwd: string = process.cwd(), config: SlopeCon
 function activeStateCompletedByScorecards(
   sprintState: ReturnType<typeof loadSprintState>,
   latestScorecard: number,
+  roadmap: RoadmapDefinition | null,
 ): InferredSprintContext['staleSprintState'] | null {
   if (!isActiveSprintState(sprintState) || latestScorecard <= 0) return null;
-  if (sprintOrderValue(sprintState.sprint) > sprintOrderValue(latestScorecard)) return null;
+  if (orderForSprint(sprintState.sprint, roadmap) > orderForSprint(latestScorecard, roadmap)) return null;
   return {
     sprint: sprintState.sprint,
     phase: sprintState.phase,
-    reason: `completed scorecard evidence has advanced to ${formatSprintLabel(latestScorecard)}`,
+    reason: `completed scorecard evidence has advanced to ${labelForSprint(latestScorecard, roadmap)}`,
   };
 }
 
 function configuredSprintCompletedByScorecards(
   currentSprint: number | undefined,
   latestScorecard: number,
+  roadmap: RoadmapDefinition | null,
 ): InferredSprintContext['staleConfigSprint'] | null {
   if (!currentSprint || latestScorecard <= 0) return null;
-  if (sprintOrderValue(currentSprint) > sprintOrderValue(latestScorecard)) return null;
+  if (orderForSprint(currentSprint, roadmap) > orderForSprint(latestScorecard, roadmap)) return null;
   return {
     sprint: currentSprint,
-    reason: `completed scorecard evidence has advanced to ${formatSprintLabel(latestScorecard)}`,
+    reason: `completed scorecard evidence has advanced to ${labelForSprint(latestScorecard, roadmap)}`,
   };
 }
 
@@ -144,6 +164,7 @@ function choosePendingSprint(
   pendingSprints: RoadmapSprint[],
   latestScorecard: number,
   scorecardNext: number,
+  roadmap: RoadmapDefinition | null,
 ): RoadmapSprint | undefined {
   if (pendingSprints.length === 0) return undefined;
   if (latestScorecard === 0) return pendingSprints[0];
@@ -151,17 +172,30 @@ function choosePendingSprint(
   const exactNext = pendingSprints.find(sprint => sprint.id === scorecardNext);
   if (exactNext) return exactNext;
 
-  const nextOrder = sprintOrderValue(scorecardNext);
+  const nextOrder = orderForSprint(scorecardNext, roadmap);
   const insertedRecovery = pendingSprints.find(sprint =>
-    isInsertedSprintId(sprint.id) && sprintOrderValue(sprint.id) <= nextOrder,
+    isInsertedSprintId(sprint.id, roadmap) && orderForSprint(sprint.id, roadmap) <= nextOrder,
   );
   if (insertedRecovery) return insertedRecovery;
 
   return pendingSprints[0];
 }
 
-function isInsertedSprintId(id: number): boolean {
-  return !Number.isInteger(id) || isEncodedInsertedSprintId(id);
+function isInsertedSprintId(id: number, roadmap: RoadmapDefinition | null): boolean {
+  return !Number.isInteger(id) || orderForSprint(id, roadmap) !== id;
+}
+
+function labelForSprint(id: number, roadmap: RoadmapDefinition | null): string {
+  if (id <= 0) return `S${id}`;
+  return roadmap ? formatRoadmapSprintLabel(roadmap, id) : formatSprintLabel(id);
+}
+
+function orderForSprint(id: number, roadmap: RoadmapDefinition | null): number {
+  return roadmap ? roadmapSprintOrderValue(roadmap, id) : sprintOrderValue(id);
+}
+
+function compareSprintIdsForRoadmap(a: number, b: number, roadmap: RoadmapDefinition | null): number {
+  return roadmap ? compareRoadmapSprintIds(roadmap, a, b) : compareSprintIds(a, b);
 }
 
 export function maxSprintByOrder(ids: number[]): number {

--- a/tests/cli/commands/next.test.ts
+++ b/tests/cli/commands/next.test.ts
@@ -137,6 +137,30 @@ function writeLinearRoadmap(cwd: string): void {
   }));
 }
 
+function writeCanonicalPostHundredRoadmap(cwd: string): void {
+  writeFileSync(join(cwd, 'docs', 'backlog', 'roadmap.json'), JSON.stringify({
+    name: 'Canonical Post-100 Roadmap',
+    phases: [{ name: 'P1', sprints: [454, 455, 456] }],
+    sprints: [
+      { id: 454, theme: 'Done 454', par: 4, slope: 1, type: 'feature', status: 'complete', tickets: [
+        { key: 'S454-1', title: 'done', club: 'wedge', complexity: 'small' },
+        { key: 'S454-2', title: 'done', club: 'wedge', complexity: 'small' },
+        { key: 'S454-3', title: 'done', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 455, theme: 'Canonical 455', par: 4, slope: 1, type: 'feature', status: 'planned', tickets: [
+        { key: 'S455-1', title: 'current', club: 'wedge', complexity: 'small' },
+        { key: 'S455-2', title: 'current', club: 'wedge', complexity: 'small' },
+        { key: 'S455-3', title: 'current', club: 'wedge', complexity: 'small' },
+      ] },
+      { id: 456, theme: 'Later 456', par: 4, slope: 1, type: 'feature', status: 'planned', tickets: [
+        { key: 'S456-1', title: 'later', club: 'wedge', complexity: 'small' },
+        { key: 'S456-2', title: 'later', club: 'wedge', complexity: 'small' },
+        { key: 'S456-3', title: 'later', club: 'wedge', complexity: 'small' },
+      ] },
+    ],
+  }));
+}
+
 describe('slope next', () => {
   const repos: string[] = [];
 
@@ -288,6 +312,54 @@ describe('slope next', () => {
     expect(output).toContain('Next sprint: S454');
     expect(output).toContain('Warning: ignoring stale local sprint state S444 (planning)');
     expect(output).not.toContain('Next sprint: S444');
+  });
+
+  it('keeps canonical roadmap S455 distinct from legacy encoded S45.5 (#605)', () => {
+    const cwd = makeRepo();
+    repos.push(cwd);
+    writeScorecard(cwd, 454);
+    writeCanonicalPostHundredRoadmap(cwd);
+    const originalCwd = process.cwd();
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg = '') => logs.push(String(msg)));
+
+    try {
+      process.chdir(cwd);
+      nextCommand();
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const output = logs.join('\n');
+    expect(output).toContain('Latest scorecard: S454');
+    expect(output).toContain('Next sprint: S455');
+    expect(output).toContain('selected from pending roadmap sprint: Canonical 455');
+    expect(output).toContain('slope briefing --sprint=455');
+    expect(output).not.toContain('S45.5');
+  });
+
+  it('does not mark active canonical S455 sprint-state stale after S454 scorecard evidence (#605)', () => {
+    const cwd = makeRepo();
+    repos.push(cwd);
+    writeScorecard(cwd, 454);
+    writeCanonicalPostHundredRoadmap(cwd);
+    saveSprintState(cwd, createSprintState(455, 'planning'));
+    const originalCwd = process.cwd();
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((msg = '') => logs.push(String(msg)));
+
+    try {
+      process.chdir(cwd);
+      nextCommand();
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const output = logs.join('\n');
+    expect(output).toContain('Latest scorecard: S454');
+    expect(output).toContain('Next sprint: S455');
+    expect(output).not.toContain('ignoring stale local sprint state');
+    expect(output).not.toContain('S45.5');
   });
 
   it('falls back to the next canonical sprint after a decimal inserted scorecard', () => {

--- a/tests/cli/sprint-workflow.test.ts
+++ b/tests/cli/sprint-workflow.test.ts
@@ -638,6 +638,26 @@ describe('slope sprint phase', () => {
     expect(state.sprint).toBe(114.5);
   });
 
+  it('starts and reports canonical roadmap S455 instead of legacy encoded S45.5 (#605)', async () => {
+    writeRoadmapSprints([{ sprint: 455, status: 'planned' }]);
+
+    const output = await captureLog(() =>
+      sprintCommand(['begin', '--sprint=455', '--ticket=S455-1'])
+    );
+    const status = await captureLog(() =>
+      sprintCommand(['status'])
+    );
+    const state = JSON.parse(readFileSync(join(tmpDir, '.slope', 'sprint-state.json'), 'utf8'));
+
+    expect(output).toContain('Sprint 455: started');
+    expect(output).toContain('S455: Sprint 455');
+    expect(output).not.toContain('Sprint 45.5');
+    expect(output).not.toContain('S45.5');
+    expect(status).toContain('Sprint 455 - status');
+    expect(status).not.toContain('Sprint 45.5');
+    expect(state.sprint).toBe(455);
+  });
+
   it('updates an existing sprint state phase', async () => {
     await captureLog(() =>
       sprintCommand(['start', '--number=98', '--phase=planning'])


### PR DESCRIPTION
﻿## Summary
- Fixes #605 by carrying roadmap-aware sprint labels/order through `slope next` inference.
- Updates sprint lifecycle output for `begin`, `start`, `phase`, `status`, and auto-claim labels so roadmap-owned canonical S455 remains S455 instead of legacy S45.5.
- Adds regressions for canonical S455 selection, stale-state comparison after S454, and lifecycle begin/status output.

## Root cause
Global legacy inserted-sprint formatting treats integer IDs ending in 5, such as 455, as encoded decimal IDs. Roadmap-aware helpers already distinguish canonical S455 from legacy encoded S43.5, but `slope next` and sprint lifecycle output still recomputed labels/order through the global formatter.

## Validation
- `corepack pnpm@9.15.9 test -- tests/cli/commands/next.test.ts tests/cli/sprint-workflow.test.ts tests/core/roadmap.test.ts --reporter=dot`
- `corepack pnpm@9.15.9 run build`
- `corepack pnpm@9.15.9 run typecheck`
- compiled CLI smoke: `next`, `sprint begin --sprint=455 --ticket=S455-1`, and `sprint status` all report S455
- `git diff --check`
- `node dist/cli/index.js map --check`
- `node dist/cli/index.js docs generate --pretty`
- `node dist/cli/index.js docs check`
- `corepack pnpm@9.15.9 test -- --reporter=dot`
- `node dist/cli/index.js validate docs/retros/sprint-239.json`

## SLOPE
- Sprint: S239
- Gates: tests, code_review self-review, architect_review self-review, scorecard, review_md
