### PR TITLE
S245/Phase 54: supersede init-idempotency sprint, mark phase complete

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -451,8 +451,8 @@
         244,
         245
       ],
-      "status": "planned",
-      "note": "Issue-driven recovery for #608, #611, #615, #616, #617, #618, #619, #620, #621. Ordered by blast radius: reconciliation corrupts roadmap sources on every closeout, so it goes first."
+      "status": "complete",
+      "note": "Issue-driven recovery for #608, #611, #615, #616, #617, #618, #619, #620, #621. Ordered by blast radius: reconciliation corrupts roadmap sources on every closeout, so it went first. Completed 2026-07-16: S241-S244 shipped (PRs #622, #626, #627, #628); S245 superseded — #608 had already been fixed by S240 in v1.63.0."
     }
   ],
   "sprints": [
@@ -6128,11 +6128,11 @@
       "par": 3,
       "slope": 2,
       "type": "bugfix + cross-platform compatibility",
-      "status": "planned",
+      "status": "superseded",
       "depends_on": [
         242
       ],
-      "note": "Fix #608: slope init --codex appends a duplicate hook set with absolute worktree paths and prepends duplicate CODEBASE.md frontmatter. Re-running init must be a no-op when nothing changed.",
+      "note": "Superseded: #608 was already fixed on main by S240 (commit bbd75f5, shipped in v1.63.0) before this sprint could start. Verified 2026-07-16 in a sandbox: codex hook commands are repo-relative, re-running init is idempotent (only the intentional generated_at metadata changes), and existing CODEBASE.md frontmatter is replaced, not duplicated.",
       "tickets": [
         {
           "key": "S245-1",

--- a/docs/roadmap/phases/phase-54.yaml
+++ b/docs/roadmap/phases/phase-54.yaml
@@ -8,8 +8,8 @@ phase:
     - 243
     - 244
     - 245
-  status: planned
-  note: "Issue-driven recovery for #608, #611, #615, #616, #617, #618, #619, #620, #621. Ordered by blast radius: reconciliation corrupts roadmap sources on every closeout, so it goes first."
+  status: complete
+  note: "Issue-driven recovery for #608, #611, #615, #616, #617, #618, #619, #620, #621. Ordered by blast radius: reconciliation corrupts roadmap sources on every closeout, so it went first. Completed 2026-07-16: S241-S244 shipped (PRs #622, #626, #627, #628); S245 superseded — #608 had already been fixed by S240 in v1.63.0."
 sprints:
   - id: 241
     theme: Surgical Roadmap Reconciliation
@@ -127,10 +127,10 @@ sprints:
     par: 3
     slope: 2
     type: bugfix + cross-platform compatibility
-    status: planned
+    status: superseded
     depends_on:
       - 242
-    note: "Fix #608: slope init --codex appends a duplicate hook set with absolute worktree paths and prepends duplicate CODEBASE.md frontmatter. Re-running init must be a no-op when nothing changed."
+    note: "Superseded: #608 was already fixed on main by S240 (commit bbd75f5, shipped in v1.63.0) before this sprint could start. Verified 2026-07-16 in a sandbox: codex hook commands are repo-relative, re-running init is idempotent (only the intentional generated_at metadata changes), and existing CODEBASE.md frontmatter is replaced, not duplicated."
     tickets:
       - key: S245-1
         title: Emit repo-relative codex hook commands and merge instead of appending on re-init (#608)


### PR DESCRIPTION
## Summary

Closes out the Phase 54 recovery train.

- **S245 → superseded**: #608 (`slope init --codex` non-portable hooks + duplicate frontmatter) was already fixed on main by S240 (bbd75f5, shipped in v1.63.0). Verified in a sandbox on current main: hook commands are repo-relative (`"./.codex/hooks/slope-guard.sh"`), re-running init is idempotent apart from the intentional `generated_at` metadata, and existing CODEBASE.md frontmatter is replaced rather than duplicated.
- **Phase 54 → complete**: S241–S244 shipped via #622, #626, #627, #628, closing #615 #617 #618 #616 #611 #621 #619 #620.

Closes #608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)