### PR TITLE
S246: Session and worktree isolation — end the worktree deadlock (#630, #631, #625, #624)

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -453,6 +453,17 @@
       ],
       "status": "complete",
       "note": "Issue-driven recovery for #608, #611, #615, #616, #617, #618, #619, #620, #621. Ordered by blast radius: reconciliation corrupts roadmap sources on every closeout, so it went first. Completed 2026-07-16: S241-S244 shipped (PRs #622, #626, #627, #628); S245 superseded — #608 had already been fixed by S240 in v1.63.0."
+    },
+    {
+      "name": "Phase 55 — Late-July Issue Recovery",
+      "description": "Triage of the eleven open GitHub issues (2026-07-15 to 2026-07-25) into themed recovery sprints. Worktree/session deadlocks lead because they hard-block autonomous agents, followed by roadmap projection safety (silent planning-work loss), then CLI argument and reference correctness.",
+      "sprints": [
+        246,
+        247,
+        248
+      ],
+      "status": "in_progress",
+      "note": "Issue-driven recovery for #623, #624, #625, #630, #631, #632, #633, #634, #635, #636, #637. Ordered by blast radius: #630/#631 deadlock any worktree session while a primary session is live (no shell, no reads, no way to file the bug), so isolation goes first. #637 silently destroys committed planning work on a success exit, so projection safety goes second. CLI correctness closes last."
     }
   ],
   "sprints": [
@@ -6150,6 +6161,148 @@
           "depends_on": [
             "S245-1"
           ]
+        }
+      ]
+    },
+    {
+      "id": 246,
+      "theme": "Session and Worktree Isolation",
+      "par": 5,
+      "slope": 5,
+      "type": "bugfix + guard reliability",
+      "status": "planned",
+      "note": "Fix #631/#630 (worktree-check evaluates hook input.cwd — the launch dir — so a session moved into a worktree is judged against the primary checkout's session store and deadlocks; the guard also auto-registers the denied session as role primary, and slope session start is missing from the recovery exemptions), #625 (claim-required treats out-of-repo scratchpad .ts writes as implementation edits), and #624 (post-merge retro does not advance sprint status across worktrees). Root theme: session identity has uncoordinated channels and guard/CLI resolve different stores, so the guard's own printed remediation can never clear the block.",
+      "tickets": [
+        {
+          "key": "S246-1",
+          "title": "Classify guard session location by the tool call's target path and shell cwd rather than hook input.cwd (#631,",
+          "club": "driver",
+          "complexity": "moderate",
+          "github_issue": 631
+        },
+        {
+          "key": "S246-2",
+          "title": "Resolve the same session store in guards and the slope session CLI so printed remediations can clear the state the guard reads (#630,",
+          "club": "driver",
+          "complexity": "moderate",
+          "github_issue": 630,
+          "depends_on": [
+            "S246-1"
+          ]
+        },
+        {
+          "key": "S246-3",
+          "title": "Stop auto-registering a denied session as role primary and exempt slope session start/heartbeat from the recovery allowlist (#631)",
+          "club": "long_iron",
+          "complexity": "moderate",
+          "github_issue": 631,
+          "depends_on": [
+            "S246-1"
+          ]
+        },
+        {
+          "key": "S246-4",
+          "title": "Scope claim-required to the repo working tree and exclude temp/scratchpad roots (#625)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 625
+        },
+        {
+          "key": "S246-5",
+          "title": "Advance sprint status to complete across worktrees after a successful post-merge retro (#624)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 624,
+          "depends_on": [
+            "S246-2"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 247,
+      "theme": "Roadmap Projection Safety and Sprint Identity",
+      "par": 5,
+      "slope": 5,
+      "type": "bugfix + data integrity",
+      "status": "planned",
+      "depends_on": [
+        246
+      ],
+      "note": "Fix #637 (slope validate regenerates the docs/backlog/roadmap.json projection as a side effect, silently discarding committed edits and exiting success — cost a whole phase of planning work in the Fathoms repo, and reproduced across operators), #636 (focused evidence labels the generated projection as 'Roadmap source'), #635 (sprint IDs are stored as JSON numbers so 458.10 aliases 458.1), and #632 (docs-only commits mentioning a sprint key count as shipped implementation). Also fixes a defect found during S246 pre-round: isEncodedInsertedSprintId treats any integer 200-999 ending in 5 as a legacy encoded half-sprint, so this repo's own S245 renders as S24.5 in slope now and roadmap status.",
+      "tickets": [
+        {
+          "key": "S247-1",
+          "title": "Add a generated-file marker to the roadmap projection and refuse to discard unexplained divergence without --force (#637)",
+          "club": "driver",
+          "complexity": "moderate",
+          "github_issue": 637
+        },
+        {
+          "key": "S247-2",
+          "title": "Make slope validate read-only and leave projection regeneration to slope roadmap compile (#637)",
+          "club": "long_iron",
+          "complexity": "moderate",
+          "github_issue": 637,
+          "depends_on": [
+            "S247-1"
+          ]
+        },
+        {
+          "key": "S247-3",
+          "title": "Label canonical source, owning bundle, and generated projection distinctly in focused roadmap evidence (#636)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 636
+        },
+        {
+          "key": "S247-4",
+          "title": "Preserve sprint IDs canonically so 458.10 and 458.1 are distinct, and stop mis-rendering integer IDs ending in 5 as decimals (#635)",
+          "club": "driver",
+          "complexity": "moderate",
+          "github_issue": 635
+        },
+        {
+          "key": "S247-5",
+          "title": "Exclude docs-only and range-mention commits from roadmap validate shipped-commit detection (#632)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 632
+        }
+      ]
+    },
+    {
+      "id": 248,
+      "theme": "CLI Argument and Reference Correctness",
+      "par": 4,
+      "slope": 2,
+      "type": "bugfix + CLI correctness",
+      "status": "planned",
+      "depends_on": [
+        247
+      ],
+      "note": "Fix #633 (slope review ignores --sprint and --help and always renders the highest-numbered scorecard, so an older sprint cannot generate its review), #634 (the plan-review hook detects 0 tickets on a bold/bulleted ticket list and downgrades a Standard-tier plan to Skip), and #623 (slope pr finalize sweeps every #N from commit messages — including triage/planning commits — while missing issues named in the comma/paren form).",
+      "tickets": [
+        {
+          "key": "S248-1",
+          "title": "Parse --sprint and --help in slope review instead of always rendering the highest-numbered scorecard (#633)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 633
+        },
+        {
+          "key": "S248-2",
+          "title": "Detect ticket keys matching S<n>-<n> anywhere in a plan so bulleted ticket lists select the correct review tier (#634)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 634
+        },
+        {
+          "key": "S248-3",
+          "title": "Derive Closes lines only from fix-intent commit trailers and parse multi-issue references like (#615, #617) (#623)",
+          "club": "long_iron",
+          "complexity": "moderate",
+          "github_issue": 623
         }
       ]
     }

--- a/docs/retros/rollovers/sprint-222-to-246-503731c57d58679b.json
+++ b/docs/retros/rollovers/sprint-222-to-246-503731c57d58679b.json
@@ -1,0 +1,334 @@
+{
+  "version": 1,
+  "kind": "sprint_rollover",
+  "transition_id": "cec2f6377741a3f9",
+  "from_sprint": 222,
+  "to_sprint": 246,
+  "from_label": "S222",
+  "to_label": "S246",
+  "recorded_at": "2026-07-25T15:03:02.676Z",
+  "actor": {
+    "name": "srbry",
+    "source": "env:USERNAME"
+  },
+  "request": {
+    "from": 222,
+    "to": 246,
+    "force": false
+  },
+  "forced": false,
+  "eligibility": {
+    "from_terminal": true,
+    "target_dependency_eligible": true,
+    "blocking_dependencies": [],
+    "target_dependencies": [],
+    "completion_evidence": {
+      "roadmap_complete": [
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        114.5,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        137.5,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        143.5,
+        143.6,
+        143.7,
+        143.8,
+        143.9,
+        143.95,
+        143.97,
+        143.98,
+        143.99,
+        144,
+        145,
+        146,
+        146.1,
+        146.2,
+        146.3,
+        148,
+        149,
+        150,
+        151,
+        151.1,
+        152,
+        152.1,
+        153,
+        154,
+        216,
+        217,
+        218,
+        219,
+        220,
+        221,
+        222,
+        223,
+        224,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        233,
+        234,
+        235,
+        236,
+        241,
+        242,
+        243,
+        244
+      ],
+      "scorecards": [
+        235,
+        222,
+        223,
+        224,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        241,
+        242,
+        243
+      ],
+      "local_terminal": [
+        222
+      ]
+    },
+    "scorecard_artifacts": [
+      {
+        "sprint": 235,
+        "path": "docs/retros/sprint-235.json",
+        "sha256": "e634d45f8ceacc0931e9bffc6c4cb23cbf90b5461486937ed4fc55dc95e6944b"
+      },
+      {
+        "sprint": 222,
+        "path": "docs/retros/sprint-222.json",
+        "sha256": "e71c5a0ada133f85f95ff7fdf4959607803dab06d80fcb3e4e3b5753b9383950"
+      },
+      {
+        "sprint": 223,
+        "path": "docs/retros/sprint-223.json",
+        "sha256": "4aa327cd6be5abc5c835884d1d9bb961ee128d80b98599546d3d941814e7de4d"
+      },
+      {
+        "sprint": 224,
+        "path": "docs/retros/sprint-224.json",
+        "sha256": "575b8c4257f93567d2a7d32ef3fe559a8edab9ebab1e7feca98467ebc97ec5d8"
+      },
+      {
+        "sprint": 226,
+        "path": "docs/retros/sprint-226.json",
+        "sha256": "ac593a709ec1b43cea0568e5763278a28a753c84f883c11bdb679dc1a8702eb4"
+      },
+      {
+        "sprint": 227,
+        "path": "docs/retros/sprint-227.json",
+        "sha256": "0d7cfd1369eed43cf16181028441b9e1ce189947e2ca87582a5977bceda5c3c9"
+      },
+      {
+        "sprint": 228,
+        "path": "docs/retros/sprint-228.json",
+        "sha256": "5a735e31e8289de103bcd794f54770e037b618e6c8a6dbe5bc48fb84964f6860"
+      },
+      {
+        "sprint": 229,
+        "path": "docs/retros/sprint-229.json",
+        "sha256": "a2335698910481237b15578e63563b7cd61d3fe192b28af7e2c525dacbea13c5"
+      },
+      {
+        "sprint": 230,
+        "path": "docs/retros/sprint-230.json",
+        "sha256": "daf6c651c004bb0e5dc1ad6577add3a30189fffc914b1910b59506c3049a01e2"
+      },
+      {
+        "sprint": 231,
+        "path": "docs/retros/sprint-231.json",
+        "sha256": "a1beb32eff3ffd28b76a1e0032b252d6a566c5f73b59ed1373511bf37db7a6d3"
+      },
+      {
+        "sprint": 232,
+        "path": "docs/retros/sprint-232.json",
+        "sha256": "3282dd8455a1ddfd869c3e0cf0603a538093e8a052f408d369ab6ead1acc0eda"
+      },
+      {
+        "sprint": 241,
+        "path": "docs/retros/sprint-241.json",
+        "sha256": "9ffa3e294bc7f2320ec1139d9af497bd3bb87ba84c30df7c32bd9d18568c244b"
+      },
+      {
+        "sprint": 242,
+        "path": "docs/retros/sprint-242.json",
+        "sha256": "1317a7ee733e92cc103444b3d01cf9d5a72ee7bc7485c24319a1460e572dfd13"
+      },
+      {
+        "sprint": 243,
+        "path": "docs/retros/sprint-243.json",
+        "sha256": "4e142665cda433e32161a9fb114aa9a018d05b769671ea221eeed755408b7d65"
+      }
+    ],
+    "expected_next": 246
+  },
+  "roadmap": {
+    "path": "docs/backlog/roadmap.json",
+    "sha256": "61de6634bc1da1130121c07576acc496549e73881172914df2c0e94d2576320b",
+    "from_status": "complete",
+    "to_status": "planned"
+  },
+  "prior_state_sha256": "f3ab626131ea4d9e72d03fd224794cf70674723c8da0839dba23866f6c1635f3",
+  "prior_state": {
+    "sprint": 222,
+    "phase": "complete",
+    "gates": {
+      "tests": true,
+      "code_review": true,
+      "architect_review": true,
+      "scorecard": true,
+      "review_md": true
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local implementing-agent release review; evidence includes pre-merge targeted regressions (26 files, 340 tests), merged focused suite (10 files, 216 tests), merged full Vitest (238 files, 3746 tests), tsc --noEmit, build, roadmap validate, map --check, version smoke, npm latest check, and npm dry-run for 1.60.0. No independent reviewer or PR review was run locally before PR creation.",
+        "updated_at": "2026-06-27T23:34:16.705Z"
+      },
+      "architect_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local implementing-agent release architecture review; scope covered mainline integration, roadmap conflict resolution, version bump, release branch hygiene, S155-S158 supersession, S216-S222 completion, and trusted-publishing handoff. No independent architecture reviewer or PR review was run locally before PR creation.",
+        "updated_at": "2026-06-27T23:34:23.193Z"
+      }
+    },
+    "started_at": "2026-06-27T23:15:58.984Z",
+    "updated_at": "2026-06-27T23:34:30.227Z",
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    }
+  },
+  "next_state": {
+    "sprint": 246,
+    "phase": "planning",
+    "gates": {
+      "tests": false,
+      "code_review": false,
+      "architect_review": false,
+      "scorecard": false,
+      "review_md": false
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "pending",
+        "evidence": []
+      },
+      "architect_review": {
+        "provenance": "pending",
+        "evidence": []
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T15:03:02.676Z",
+    "updated_at": "2026-07-25T15:03:02.676Z",
+    "rollover": {
+      "transition_id": "cec2f6377741a3f9",
+      "from_sprint": 222,
+      "audit_path": "docs/retros/rollovers/sprint-222-to-246-503731c57d58679b.json",
+      "recorded_at": "2026-07-25T15:03:02.676Z",
+      "forced": false
+    }
+  },
+  "claims_policy": "unchanged",
+  "sessions_policy": "unchanged"
+}

--- a/docs/retros/sprint-246-review.md
+++ b/docs/retros/sprint-246-review.md
@@ -1,0 +1,47 @@
+
+## Sprint 246 Review: Session and Worktree Isolation
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 5 |
+| Slope | 5 |
+| Score | 6 |
+| Label | Bogey |
+| Fairway % | 100% (5/5) |
+| GIR % | 100% (5/5) |
+| Putts | 0 |
+| Penalties | 0 |
+| Hazard Penalties | 1 |
+
+### Shot-by-Shot (Tickets Delivered: 5)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S246-1 | Driver | Green | Bunker: First implementation ran the worktree lookup eagerly after the git-common-dir check, adding two git subprocess calls to every guard invocation (a hot path on Edit/Write/Bash) and shifting the programmed execFileSync mock sequences of five existing tests. Restructured to check lazily on the would-deny path only, reusing the worktree list the guidance formatter already computes. | Trusts where work actually lands. An edit landing in the primary checkout still denies, so the #499 EnterWorktree guidance is preserved; pinned by a new both-directions integration test pair. |
+| S246-2 | Driver | Green | -- | New src/cli/session-scope.ts resolves the primary checkout via --git-common-dir. Nine session CLI call sites plus worktree reconciliation share it, so the printed remediation can clear what the guard reads. The guard primary-checkout branch already had cwd equal to primary, so no redundant git call was added there. |
+| S246-3 | Long Iron | Green | Rough: Changed the register call ide from the hardcoded claude-code to resolveIde(input) as a drive-by improvement, breaking an existing assertion. Reverted to keep the diff focused; the ide detection inconsistency between register and reconcile remains a separate concern. | Registration moved to the pass path and skipped when a record already exists. Verified registerSession does not auto-assign swarm_id, so reordering cannot break swarm-member exclusion. |
+| S246-4 | Wedge | In the Hole | Bunker: The stated cause in the issue (guard classifies any .ts write as implementation regardless of path) was wrong: findImplementationWritePath already scoped to the repo. Instrumenting the real functions showed the defect was upstream in resolveEffectiveHookCwd, which derives cwd from the tool target path; canonicalHookCwd fell back to the raw path, so an out-of-repo write made the scratchpad the workspace root. Fixing it there fixes every guard at once and needs no temp-dir denylist. | Also guarded the Codex workdir memo on both write and read: one out-of-repo call previously pinned the whole session, and caches from older versions kept doing so after the fix. |
+| S246-5 | Short Iron | Green | Rough: Adding a session-scope import to sprint-state.ts broke the atomic-write concurrency test, which compiles a hand-listed subset of CLI modules into a temp dir for child processes. New transitive dependencies must be added to that list. | updateSprintPhaseForSprintAcrossWorktrees applies the conditional update to every checkout; worktrees holding a different sprint are reported unmatched and untouched. The caller also discarded matched/changed and printed reconciled unconditionally, which is why a closeout that reconciled nothing still reported success. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| undefined | undefined | undefined |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Bunker | S246-1 | First implementation ran the worktree lookup eagerly after the git-common-dir check, adding two git subprocess calls to every guard invocation (a hot path on Edit/Write/Bash) and shifting the programmed execFileSync mock sequences of five existing tests. Restructured to check lazily on the would-deny path only, reusing the worktree list the guidance formatter already computes. |
+| Rough | S246-3 | Changed the register call ide from the hardcoded claude-code to resolveIde(input) as a drive-by improvement, breaking an existing assertion. Reverted to keep the diff focused; the ide detection inconsistency between register and reconcile remains a separate concern. |
+| Bunker | S246-4 | The stated cause in the issue (guard classifies any .ts write as implementation regardless of path) was wrong: findImplementationWritePath already scoped to the repo. Instrumenting the real functions showed the defect was upstream in resolveEffectiveHookCwd, which derives cwd from the tool target path; canonicalHookCwd fell back to the raw path, so an out-of-repo write made the scratchpad the workspace root. Fixing it there fixes every guard at once and needs no temp-dir denylist. |
+| Rough | S246-5 | Adding a session-scope import to sprint-state.ts broke the atomic-write concurrency test, which compiles a hand-listed subset of CLI modules into a temp dir for child processes. New transitive dependencies must be added to that list. |
+
+### Course Management Notes
+
+- Verify an issue reproduces against current main before fixing it. The #625 stated cause was wrong and two other issues in this batch were already fixed.
+- claim-required returns ask even in adhoc mode, which the session briefing describes as sprint-workflow guards silenced. Demanding a claim in a mode that means not running sprint workflow is contradictory and trains agents to ignore the guard.
+

--- a/docs/retros/sprint-246.json
+++ b/docs/retros/sprint-246.json
@@ -1,0 +1,110 @@
+{
+  "sprint_number": 246,
+  "theme": "Session and Worktree Isolation",
+  "par": 5,
+  "slope": 5,
+  "score": 6,
+  "score_label": "bogey",
+  "date": "2026-07-25",
+  "shots": [
+    {
+      "ticket_key": "S246-1",
+      "title": "Classify guard session location by the tool call target path rather than hook input.cwd (#631, #630)",
+      "club": "driver",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "First implementation ran the worktree lookup eagerly after the git-common-dir check, adding two git subprocess calls to every guard invocation (a hot path on Edit/Write/Bash) and shifting the programmed execFileSync mock sequences of five existing tests. Restructured to check lazily on the would-deny path only, reusing the worktree list the guidance formatter already computes.",
+          "gotcha_id": "self:hot-path"
+        }
+      ],
+      "notes": "Trusts where work actually lands. An edit landing in the primary checkout still denies, so the #499 EnterWorktree guidance is preserved; pinned by a new both-directions integration test pair."
+    },
+    {
+      "ticket_key": "S246-2",
+      "title": "Resolve the same session store in guards and the slope session CLI (#630, #631)",
+      "club": "driver",
+      "result": "green",
+      "hazards": [],
+      "notes": "New src/cli/session-scope.ts resolves the primary checkout via --git-common-dir. Nine session CLI call sites plus worktree reconciliation share it, so the printed remediation can clear what the guard reads. The guard primary-checkout branch already had cwd equal to primary, so no redundant git call was added there."
+    },
+    {
+      "ticket_key": "S246-3",
+      "title": "Stop auto-registering a denied session as primary and exempt session start/heartbeat (#631)",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Changed the register call ide from the hardcoded claude-code to resolveIde(input) as a drive-by improvement, breaking an existing assertion. Reverted to keep the diff focused; the ide detection inconsistency between register and reconcile remains a separate concern.",
+          "gotcha_id": "self:scope-creep"
+        }
+      ],
+      "notes": "Registration moved to the pass path and skipped when a record already exists. Verified registerSession does not auto-assign swarm_id, so reordering cannot break swarm-member exclusion."
+    },
+    {
+      "ticket_key": "S246-4",
+      "title": "Scope claim-required to the repo working tree and exclude temp/scratchpad roots (#625)",
+      "club": "wedge",
+      "result": "in_the_hole",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "major",
+          "description": "The stated cause in the issue (guard classifies any .ts write as implementation regardless of path) was wrong: findImplementationWritePath already scoped to the repo. Instrumenting the real functions showed the defect was upstream in resolveEffectiveHookCwd, which derives cwd from the tool target path; canonicalHookCwd fell back to the raw path, so an out-of-repo write made the scratchpad the workspace root. Fixing it there fixes every guard at once and needs no temp-dir denylist.",
+          "gotcha_id": "self:diagnose-before-fix"
+        }
+      ],
+      "notes": "Also guarded the Codex workdir memo on both write and read: one out-of-repo call previously pinned the whole session, and caches from older versions kept doing so after the fix."
+    },
+    {
+      "ticket_key": "S246-5",
+      "title": "Advance sprint status to complete across worktrees after post-merge retro (#624)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "Adding a session-scope import to sprint-state.ts broke the atomic-write concurrency test, which compiles a hand-listed subset of CLI modules into a temp dir for child processes. New transitive dependencies must be added to that list.",
+          "gotcha_id": "self:module-subset"
+        }
+      ],
+      "notes": "updateSprintPhaseForSprintAcrossWorktrees applies the conditional update to every checkout; worktrees holding a different sprint are reported unmatched and untouched. The caller also discarded matched/changed and printed reconciled unconditionally, which is why a closeout that reconciled nothing still reported success."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 5,
+    "fairways_total": 5,
+    "greens_in_regulation": 5,
+    "greens_total": 5,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 4,
+    "hazard_penalties": 1,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Installed slope binary (published v1.63.0) predates main, so guard hooks in this session ran code without the fixes until a local node_modules/.bin shim was added."
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [
+    "Guard cwd is derived, not given: resolveEffectiveHookCwd prefers tool_input workdir, then the tool target path, then transcript, then a persisted memo. Any of these can relocate a guard notion of the workspace.",
+    "worktree-check unit tests program execFileSync with ordered mockReturnValueOnce sequences. Adding a git call anywhere in the guard shifts every downstream expectation.",
+    "The worktree-check pass-sentinel lives in the real tmpdir and outlives the process; tests must reset it for every session id they use, on entry as well as exit.",
+    "tests/cli/atomic-write.test.ts compiles a hand-listed module subset for child processes; new transitive imports of sprint-state or session-state must be added there."
+  ],
+  "course_management_notes": [
+    "Verify an issue reproduces against current main before fixing it. The #625 stated cause was wrong and two other issues in this batch were already fixed.",
+    "claim-required returns ask even in adhoc mode, which the session briefing describes as sprint-workflow guards silenced. Demanding a claim in a mode that means not running sprint workflow is contradictory and trains agents to ignore the guard."
+  ]
+}

--- a/docs/roadmap/phases/phase-55.yaml
+++ b/docs/roadmap/phases/phase-55.yaml
@@ -1,0 +1,112 @@
+version: "1"
+phase:
+  name: Phase 55 — Late-July Issue Recovery
+  description: Triage of the eleven open GitHub issues (2026-07-15 to 2026-07-25) into themed recovery sprints. Worktree/session deadlocks lead because they hard-block autonomous agents, followed by roadmap projection safety (silent planning-work loss), then CLI argument and reference correctness.
+  sprints:
+    - 246
+    - 247
+    - 248
+  status: in_progress
+  note: "Issue-driven recovery for #623, #624, #625, #630, #631, #632, #633, #634, #635, #636, #637. Ordered by blast radius: #630/#631 deadlock any worktree session while a primary session is live (no shell, no reads, no way to file the bug), so isolation goes first. #637 silently destroys committed planning work on a success exit, so projection safety goes second. CLI correctness closes last."
+sprints:
+  - id: 246
+    theme: Session and Worktree Isolation
+    par: 5
+    slope: 5
+    type: bugfix + guard reliability
+    status: planned
+    note: "Fix #631/#630 (worktree-check evaluates hook input.cwd — the launch dir — so a session moved into a worktree is judged against the primary checkout's session store and deadlocks; the guard also auto-registers the denied session as role primary, and slope session start is missing from the recovery exemptions), #625 (claim-required treats out-of-repo scratchpad .ts writes as implementation edits), and #624 (post-merge retro does not advance sprint status across worktrees). Root theme: session identity has uncoordinated channels and guard/CLI resolve different stores, so the guard's own printed remediation can never clear the block."
+    tickets:
+      - key: S246-1
+        title: Classify guard session location by the tool call's target path and shell cwd rather than hook input.cwd (#631, #630)
+        club: driver
+        complexity: moderate
+        github_issue: 631
+      - key: S246-2
+        title: Resolve the same session store in guards and the slope session CLI so printed remediations can clear the state the guard reads (#630, #631)
+        club: driver
+        complexity: moderate
+        github_issue: 630
+        depends_on:
+          - S246-1
+      - key: S246-3
+        title: "Stop auto-registering a denied session as role primary and exempt slope session start/heartbeat from the recovery allowlist (#631)"
+        club: long_iron
+        complexity: moderate
+        github_issue: 631
+        depends_on:
+          - S246-1
+      - key: S246-4
+        title: Scope claim-required to the repo working tree and exclude temp/scratchpad roots (#625)
+        club: wedge
+        complexity: small
+        github_issue: 625
+      - key: S246-5
+        title: Advance sprint status to complete across worktrees after a successful post-merge retro (#624)
+        club: short_iron
+        complexity: standard
+        github_issue: 624
+        depends_on:
+          - S246-2
+  - id: 247
+    theme: Roadmap Projection Safety and Sprint Identity
+    par: 5
+    slope: 5
+    type: bugfix + data integrity
+    status: planned
+    depends_on:
+      - 246
+    note: "Fix #637 (slope validate regenerates the docs/backlog/roadmap.json projection as a side effect, silently discarding committed edits and exiting success — cost a whole phase of planning work in the Fathoms repo, and reproduced across operators), #636 (focused evidence labels the generated projection as 'Roadmap source'), #635 (sprint IDs are stored as JSON numbers so 458.10 aliases 458.1), and #632 (docs-only commits mentioning a sprint key count as shipped implementation). Also fixes a defect found during S246 pre-round: isEncodedInsertedSprintId treats any integer 200-999 ending in 5 as a legacy encoded half-sprint, so this repo's own S245 renders as S24.5 in slope now and roadmap status."
+    tickets:
+      - key: S247-1
+        title: "Add a generated-file marker to the roadmap projection and refuse to discard unexplained divergence without --force (#637)"
+        club: driver
+        complexity: moderate
+        github_issue: 637
+      - key: S247-2
+        title: Make slope validate read-only and leave projection regeneration to slope roadmap compile (#637)
+        club: long_iron
+        complexity: moderate
+        github_issue: 637
+        depends_on:
+          - S247-1
+      - key: S247-3
+        title: Label canonical source, owning bundle, and generated projection distinctly in focused roadmap evidence (#636)
+        club: short_iron
+        complexity: standard
+        github_issue: 636
+      - key: S247-4
+        title: "Preserve sprint IDs canonically so 458.10 and 458.1 are distinct, and stop mis-rendering integer IDs ending in 5 as decimals (#635)"
+        club: driver
+        complexity: moderate
+        github_issue: 635
+      - key: S247-5
+        title: Exclude docs-only and range-mention commits from roadmap validate shipped-commit detection (#632)
+        club: short_iron
+        complexity: standard
+        github_issue: 632
+  - id: 248
+    theme: CLI Argument and Reference Correctness
+    par: 4
+    slope: 2
+    type: bugfix + CLI correctness
+    status: planned
+    depends_on:
+      - 247
+    note: "Fix #633 (slope review ignores --sprint and --help and always renders the highest-numbered scorecard, so an older sprint cannot generate its review), #634 (the plan-review hook detects 0 tickets on a bold/bulleted ticket list and downgrades a Standard-tier plan to Skip), and #623 (slope pr finalize sweeps every #N from commit messages — including triage/planning commits — while missing issues named in the comma/paren form)."
+    tickets:
+      - key: S248-1
+        title: "Parse --sprint and --help in slope review instead of always rendering the highest-numbered scorecard (#633)"
+        club: short_iron
+        complexity: standard
+        github_issue: 633
+      - key: S248-2
+        title: "Detect ticket keys matching S<n>-<n> anywhere in a plan so bulleted ticket lists select the correct review tier (#634)"
+        club: wedge
+        complexity: small
+        github_issue: 634
+      - key: S248-3
+        title: "Derive Closes lines only from fix-intent commit trailers and parse multi-issue references like (#615, #617) (#623)"
+        club: long_iron
+        complexity: moderate
+        github_issue: 623

--- a/docs/roadmap/project.yaml
+++ b/docs/roadmap/project.yaml
@@ -93,3 +93,5 @@ sources:
     kind: phase
   - path: phases/phase-54.yaml
     kind: phase
+  - path: phases/phase-55.yaml
+    kind: phase

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -371,21 +371,36 @@ function normalizePath(rawPath: string, baseCwd: string): string {
 }
 
 function canonicalHookCwd(path: string): string {
+  return resolveWorkspaceRoot(path) ?? path;
+}
+
+/**
+ * Resolve a path to the workspace root that owns it — the nearest ancestor with
+ * .slope/config.json, else the enclosing git toplevel. Returns null when the
+ * path belongs to no workspace at all (e.g. a harness scratchpad under /tmp).
+ *
+ * Callers that *infer* a cwd must treat null as "no workspace" rather than
+ * adopting the orphan directory: doing so would relocate every guard's notion
+ * of the workspace to a directory with no .slope state, which both discards the
+ * real sprint state and defeats repo-scoped path checks (GH #625).
+ */
+function resolveWorkspaceRoot(path: string): string | null {
   const start = existingDirectory(path);
-  const slopeRoot = start ? findAncestorWithSlopeConfig(start) : null;
+  if (!start) return null;
+
+  const slopeRoot = findAncestorWithSlopeConfig(start);
   if (slopeRoot) return slopeRoot;
 
-  if (start) {
-    try {
-      return execFileSync('git', ['-C', start, 'rev-parse', '--show-toplevel'], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-        timeout: 3000,
-      }).trim();
-    } catch { /* not a git repo */ }
-  }
+  try {
+    const toplevel = execFileSync('git', ['-C', start, 'rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 3000,
+    }).trim();
+    if (toplevel) return toplevel;
+  } catch { /* not a git repo */ }
 
-  return path;
+  return null;
 }
 
 function existingDirectory(path: string): string | null {
@@ -427,7 +442,11 @@ function extractToolInputPathCwd(input: HookInput, baseCwd: string): string | nu
     if (typeof value !== 'string' || value.trim().length === 0) continue;
     const absolute = isAbsolute(value) ? value : resolve(baseCwd, value);
     if (!existingDirectory(dirname(absolute))) continue;
-    return canonicalHookCwd(dirname(absolute));
+    // Only adopt a path-derived cwd when the target lives in a real workspace.
+    // A write to a harness scratchpad outside any repo must not become the
+    // guard's workspace root (GH #625).
+    const workspace = resolveWorkspaceRoot(dirname(absolute));
+    if (workspace) return workspace;
   }
   return null;
 }
@@ -532,8 +551,10 @@ function readRememberedCodexWorkdir(input: HookInput, fallbackCwd: string): stri
     if (!existsSync(path)) return null;
     const parsed = JSON.parse(readFileSync(path, 'utf8')) as { cwd?: unknown };
     if (typeof parsed.cwd !== 'string' || parsed.cwd.trim().length === 0) return null;
-    const remembered = canonicalHookCwd(parsed.cwd.trim());
-    return existsSync(remembered) ? remembered : null;
+    // Never replay a memo that does not resolve to a real workspace. A cache
+    // written before this check (or by an older version) must not keep
+    // relocating the workspace to an out-of-repo directory (GH #625).
+    return resolveWorkspaceRoot(parsed.cwd.trim());
   } catch {
     return null;
   }
@@ -554,6 +575,9 @@ function comparisonPath(path: string): string {
 function rememberCodexWorkdir(input: HookInput, resolution: HookCwdResolution): void {
   const sessionId = typeof input.session_id === 'string' ? input.session_id.trim() : '';
   if (!sessionId || resolution.source === 'remembered') return;
+  // Only cache a cwd that belongs to a real workspace, so a single out-of-repo
+  // tool call cannot pin the whole session to a non-workspace directory (#625).
+  if (!resolveWorkspaceRoot(resolution.cwd)) return;
 
   try {
     const path = codexWorkdirStatePath(sessionId);

--- a/src/cli/commands/retro.ts
+++ b/src/cli/commands/retro.ts
@@ -22,6 +22,7 @@ import {
   buildRetroMemoryPlans,
   persistRetroMemories,
   parseSprintNumber,
+  formatSprintLabel,
 } from '../../core/index.js';
 import type {
   MemoryCategory,
@@ -32,7 +33,8 @@ import type {
   RoadmapSprint,
 } from '../../core/index.js';
 import { loadConfig } from '../config.js';
-import { updateSprintPhaseForSprint } from '../sprint-state.js';
+import { updateSprintPhaseForSprintAcrossWorktrees } from '../sprint-state.js';
+import type { WorktreePhaseReconcile } from '../sprint-state.js';
 
 interface BackfillOptions {
   sprint?: number;
@@ -524,9 +526,12 @@ async function postMergeSubcommand(args: string[]): Promise<void> {
   const record = buildSavedRetro(retro, memory);
   const path = postMergeOutputPath(cwd, retro);
 
+  let reconciled: WorktreePhaseReconcile[] = [];
   if (!opts.dryRun) {
     writePostMergeRetro(cwd, record);
-    updateSprintPhaseForSprint(cwd, retro.sprint, 'complete');
+    // Reconcile every checkout, not just this one — sibling worktrees otherwise
+    // keep reporting the merged sprint as in progress (GH #624).
+    reconciled = updateSprintPhaseForSprintAcrossWorktrees(cwd, retro.sprint, 'complete');
   }
 
   const payload = {
@@ -547,12 +552,40 @@ async function postMergeSubcommand(args: string[]): Promise<void> {
     console.log(`\n${target}: wrote ${path}`);
   }
   console.log(`  Outcome: ${retro.outcome}`);
-  if (!opts.dryRun) console.log('  Sprint state: reconciled to complete when local state matched this sprint');
+  if (!opts.dryRun) console.log(`  Sprint state: ${formatPhaseReconcile(reconciled, retro.sprint)}`);
   console.log(`  Memories: ${record.memory.added.length} added, ${record.memory.skipped} skipped, ${record.memory.planned} planned`);
   if (retro.followUps.length > 0) {
     console.log(`  Follow-ups: ${retro.followUps.length}`);
   }
   console.log('');
+}
+
+/**
+ * Describe what reconciliation actually did. The previous fixed message claimed
+ * a reconcile had happened even when no checkout matched the sprint, which is
+ * how a stale worktree could report the sprint still in progress right after a
+ * "successful" closeout (GH #624).
+ */
+function formatPhaseReconcile(results: WorktreePhaseReconcile[], sprint: number): string {
+  if (results.length === 0) return 'no sprint state found to reconcile';
+
+  const changed = results.filter(r => r.changed);
+  const matched = results.filter(r => r.matched);
+  const stale = results.filter(r => !r.matched);
+
+  const parts: string[] = [];
+  parts.push(changed.length > 0
+    ? `advanced to complete in ${changed.length} of ${results.length} checkout(s)`
+    : matched.length > 0
+      ? 'already complete'
+      : `no checkout holds state for ${formatSprintLabel(sprint)}`);
+
+  if (stale.length > 0) {
+    const names = stale.map(r => r.path).join(', ');
+    parts.push(`left unchanged (different sprint): ${names}`);
+  }
+
+  return parts.join('; ');
 }
 
 async function backfillSubcommand(args: string[]): Promise<void> {

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -6,6 +6,7 @@ import { checkConflicts } from '../../core/index.js';
 import type { SlopeSession } from '../../core/index.js';
 import { STALE_SESSION_THRESHOLD_MS } from '../../core/constants.js';
 import { resolveStore } from '../store.js';
+import { resolveSessionStoreCwd } from '../session-scope.js';
 
 /** A session may only be ended by default when its recorded identity does not
  *  contradict this checkout — in a same-checkout swarm, "the single active
@@ -108,7 +109,7 @@ Usage:
 }
 
 async function startSession(flags: Record<string, string>, cwd: string): Promise<void> {
-  const store = await resolveStore(cwd);
+  const store = await resolveStore(resolveSessionStoreCwd(cwd));
   try {
     const sessionId = flags['session-id'] || randomUUID();
     const role = (flags.role ?? 'primary') as 'primary' | 'secondary' | 'observer';
@@ -201,7 +202,7 @@ async function endSession(flags: Record<string, string>, cwd: string, rawArgs: s
     process.exit(1);
   }
 
-  const store = await resolveStore(cwd);
+  const store = await resolveStore(resolveSessionStoreCwd(cwd));
   try {
     // Prefer an explicit id, then the environment session (only when it is
     // actually active — a stale exported id must not defeat the fallback),
@@ -250,7 +251,7 @@ async function endSession(flags: Record<string, string>, cwd: string, rawArgs: s
 }
 
 async function heartbeat(flags: Record<string, string>, cwd: string): Promise<void> {
-  const store = await resolveStore(cwd);
+  const store = await resolveStore(resolveSessionStoreCwd(cwd));
   try {
     const sessionId = flags['session-id'];
     if (!sessionId) {
@@ -267,7 +268,7 @@ async function heartbeat(flags: Record<string, string>, cwd: string): Promise<vo
 
 async function pruneSessions(flags: Record<string, string>, cwd: string): Promise<void> {
   const maxAgeMs = parseMaxAgeMs(flags['max-age-ms']);
-  const store = await resolveStore(cwd);
+  const store = await resolveStore(resolveSessionStoreCwd(cwd));
   try {
     const removed = await store.cleanStaleSessions(maxAgeMs);
     console.log(`\nStale session cleanup:`);
@@ -291,7 +292,7 @@ function parseMaxAgeMs(raw: string | undefined): number {
 }
 
 async function listSessions(flags: Record<string, string>, cwd: string): Promise<void> {
-  const store = await resolveStore(cwd);
+  const store = await resolveStore(resolveSessionStoreCwd(cwd));
   try {
     const swarmId = flags.swarm;
     const sessions = swarmId
@@ -367,7 +368,7 @@ async function listSessions(flags: Record<string, string>, cwd: string): Promise
 // ── T4: Dashboard ────────────────────────────────────
 
 async function dashboardCommand(flags: Record<string, string>, cwd: string): Promise<void> {
-  const store = await resolveStore(cwd);
+  const store = await resolveStore(resolveSessionStoreCwd(cwd));
   try {
     await store.cleanStaleSessions(STALE_SESSION_THRESHOLD_MS);
     const sessions = await store.getActiveSessions();
@@ -474,7 +475,7 @@ async function handoffCommand(flags: Record<string, string>, cwd: string): Promi
     process.exit(1);
   }
 
-  const store = await resolveStore(cwd);
+  const store = await resolveStore(resolveSessionStoreCwd(cwd));
   try {
     const sessions = await store.getActiveSessions();
     const fromSession = sessions.find(s => s.session_id.startsWith(from));
@@ -510,7 +511,7 @@ async function assignCommand(flags: Record<string, string>, cwd: string): Promis
     process.exit(1);
   }
 
-  const store = await resolveStore(cwd);
+  const store = await resolveStore(resolveSessionStoreCwd(cwd));
   try {
     const sessions = await store.getActiveSessions();
     const target = sessions.find(s => s.session_id.startsWith(agent));
@@ -546,7 +547,7 @@ async function assignCommand(flags: Record<string, string>, cwd: string): Promis
 }
 
 async function planCommand(flags: Record<string, string>, cwd: string): Promise<void> {
-  const store = await resolveStore(cwd);
+  const store = await resolveStore(resolveSessionStoreCwd(cwd));
   try {
     const sessions = await store.getActiveSessions();
     if (sessions.length === 0) { console.log('\nNo active sessions.\n'); return; }

--- a/src/cli/guards/worktree-check.ts
+++ b/src/cli/guards/worktree-check.ts
@@ -8,6 +8,7 @@ import { STALE_SESSION_THRESHOLD_MS } from '../../core/constants.js';
 import { SlopeStoreError } from '../../core/store.js';
 import type { SlopeSession } from '../../core/store.js';
 import { resolveStore } from '../store.js';
+import { resolveSessionStoreCwd } from '../session-scope.js';
 
 const COMMAND_TEXT_KEYS = ['command', 'cmd', 'input'] as const;
 const FILE_PATH_KEYS = ['file_path', 'path'] as const;
@@ -78,7 +79,11 @@ export async function worktreeCheckGuard(input: HookInput, cwd: string): Promise
     branch = 'unknown';
   }
 
-  // Query store for concurrent sessions
+  // Query store for concurrent sessions. gitCommonDir === '.git' above already
+  // establishes that cwd is the primary checkout, so this is the repo-scoped
+  // session store that `slope session list|prune|end` now also resolves to via
+  // resolveSessionStoreCwd — the two agree, so the printed remediation can
+  // actually clear what the guard blocks on (GH #630, #631).
   let store;
   try {
     store = await resolveStore(cwd);
@@ -91,32 +96,23 @@ export async function worktreeCheckGuard(input: HookInput, cwd: string): Promise
     // Clean stale sessions first to reduce false positives
     await store.cleanStaleSessions(STALE_SESSION_THRESHOLD_MS);
 
-    // Auto-register the current session
-    let currentSwarmId: string | undefined;
-    let active: Awaited<ReturnType<typeof store.getActiveSessions>> | undefined;
-    try {
-      const registered = await store.registerSession({
-        session_id: sessionId,
-        role: 'primary',
-        ide: 'claude-code',
-        branch,
-      });
-      currentSwarmId = registered.swarm_id;
-    } catch (err) {
-      // SESSION_CONFLICT means this session is already registered — that's fine
-      if (err instanceof SlopeStoreError && err.code === 'SESSION_CONFLICT') {
-        // Fetch active sessions once — reuse for both swarm lookup and conflict check
-        active = await store.getActiveSessions();
-        const existing = active.find(s => s.session_id === sessionId);
-        currentSwarmId = existing?.swarm_id;
-      } else {
-        throw err;
-      }
+    // Inspect existing sessions BEFORE registering. Registering first meant a
+    // session that was about to be denied still got written as
+    // `role: primary` on the launch-dir branch, leaving a phantom primary that
+    // could then block the legitimate primary session (GH #631).
+    let active = await store.getActiveSessions();
+    const existing = active.find(s => s.session_id === sessionId);
+    const currentSwarmId = existing?.swarm_id;
+
+    // An already-registered worktree session is isolated by definition, even
+    // when the hook payload still reports the launch directory (GH #630, #631).
+    if (existing?.worktree_path) {
+      writeFileSync(sentinel, new Date().toISOString());
+      return {};
     }
 
     // Check for concurrent sessions in the same store (no worktree_path).
     // Swarm members are excluded — they coordinate via claims, not worktrees.
-    if (!active) active = await store.getActiveSessions();
     const others = active.filter(s => s.session_id !== sessionId);
     const now = Date.now();
     const conflicting = others.filter(s =>
@@ -126,10 +122,27 @@ export async function worktreeCheckGuard(input: HookInput, cwd: string): Promise
     );
 
     if (conflicting.length > 0) {
+      // The hook payload's cwd is the session's *launch* directory. A session
+      // moved into a worktree (WorktreeCreate at launch, or EnterWorktree
+      // mid-session) keeps reporting the launch dir, so the git-common-dir check
+      // above misses it and the session gets judged against the primary
+      // checkout's sessions. That was a permanent deadlock whose printed
+      // remediation could not help: there is nothing left to enter, and the
+      // session is already isolated. Trust where the work actually lands
+      // (GH #630, #631). Checked here rather than earlier so the common pass
+      // path spawns no extra git processes.
+      const worktrees = listGitWorktreeInfo(cwd);
+      const targetWorktree = resolveTargetWorktree(input, cwd, worktrees);
+      if (targetWorktree) {
+        await reconcileWorktreeSession(input, cwd, sessionId, targetWorktree);
+        writeFileSync(sentinel, new Date().toISOString());
+        return {};
+      }
+
       const sessionList = conflicting
         .map(s => `  - ${s.session_id} [${s.role}] ${s.ide} (branch: ${s.branch ?? '-'})`)
         .join('\n');
-      const existingWorktreeGuidance = formatExistingWorktreeGuidance(cwd, input, conflicting, branch);
+      const existingWorktreeGuidance = formatExistingWorktreeGuidance(cwd, input, conflicting, branch, worktrees);
       // Do NOT write sentinel — denied sessions should re-check next invocation
       return {
         decision: 'deny',
@@ -137,7 +150,21 @@ export async function worktreeCheckGuard(input: HookInput, cwd: string): Promise
       };
     }
 
-    // No conflict — write sentinel so we don't re-check this session
+    // No conflict — register this session so the next one can see it, then
+    // write the sentinel so we don't re-check.
+    if (!existing) {
+      try {
+        await store.registerSession({
+          session_id: sessionId,
+          role: 'primary',
+          ide: 'claude-code',
+          branch,
+        });
+      } catch (err) {
+        // Already registered by a concurrent invocation — harmless.
+        if (!(err instanceof SlopeStoreError && err.code === 'SESSION_CONFLICT')) throw err;
+      }
+    }
     writeFileSync(sentinel, new Date().toISOString());
     return {};
   } catch {
@@ -239,10 +266,15 @@ function isSlopeRecoveryCommand(words: string[]): boolean {
   if (args[0] === 'worktree' && args[1] === 'start') return true;
   if (args[0] !== 'session') return false;
 
+  // `start` and `heartbeat` must be exempt: registering is the one action that
+  // lets a legitimately isolated session prove itself, so denying it makes the
+  // block permanent (GH #631).
   return args[1] === 'end'
     || args[1] === 'list'
     || args[1] === 'prune'
-    || args[1] === 'dashboard';
+    || args[1] === 'dashboard'
+    || args[1] === 'start'
+    || args[1] === 'heartbeat';
 }
 
 function splitShellSegments(command: string): string[] {
@@ -346,9 +378,9 @@ function formatExistingWorktreeGuidance(
   input: HookInput,
   conflicting: SlopeSession[],
   currentBranch: string,
+  allWorktrees: GitWorktreeInfo[],
 ): string {
-  const worktrees = listGitWorktreeInfo(cwd)
-    .filter(wt => resolve(wt.path) !== resolve(cwd));
+  const worktrees = allWorktrees.filter(wt => resolve(wt.path) !== resolve(cwd));
   if (worktrees.length === 0) return '';
 
   const filePath = extractFilePath(input);
@@ -400,15 +432,44 @@ function pathContains(root: string, filePath: string): boolean {
   return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
 }
 
-async function reconcileWorktreeSession(input: HookInput, cwd: string, sessionId: string): Promise<void> {
+/**
+ * Resolve the worktree that a tool call's target path belongs to, if any.
+ *
+ * Only called from the primary-checkout branch, so `cwd` is the primary checkout
+ * and is excluded: an edit landing in the primary checkout is not isolated and
+ * must still be denied so the #499 "enter the existing worktree" guidance fires.
+ * A relative path is likewise not evidence — it resolves against the launch dir,
+ * which is exactly the value we cannot trust here (GH #630, #631).
+ */
+function resolveTargetWorktree(
+  input: HookInput,
+  cwd: string,
+  worktrees: GitWorktreeInfo[],
+): string | null {
+  const filePath = extractFilePath(input);
+  if (!filePath || !isAbsolute(filePath)) return null;
+
+  for (const worktree of worktrees) {
+    if (resolve(worktree.path) === resolve(cwd)) continue;
+    if (pathContains(worktree.path, filePath)) return worktree.path;
+  }
+  return null;
+}
+
+async function reconcileWorktreeSession(
+  input: HookInput,
+  cwd: string,
+  sessionId: string,
+  explicitWorktreePath?: string,
+): Promise<void> {
   let store;
   try {
-    const stateCwd = resolveSlopeStateCwd(cwd);
-    if (!stateCwd) return;
+    const stateCwd = resolveSessionStoreCwd(cwd);
     store = await resolveStore(stateCwd);
 
-    const worktreePath = gitRevParse(cwd, '--show-toplevel');
-    const branch = safeGitRevParse(cwd, '--abbrev-ref', 'HEAD') ?? 'unknown';
+    const worktreePath = explicitWorktreePath ?? gitRevParse(cwd, '--show-toplevel');
+    const branchCwd = explicitWorktreePath ?? cwd;
+    const branch = safeGitRevParse(branchCwd, '--abbrev-ref', 'HEAD') ?? 'unknown';
 
     try {
       await store.updateSession(sessionId, {
@@ -434,21 +495,6 @@ async function reconcileWorktreeSession(input: HookInput, cwd: string, sessionId
   } finally {
     try { store?.close(); } catch { /* ignore */ }
   }
-}
-
-function resolveSlopeStateCwd(cwd: string): string | undefined {
-  if (existsSync(join(cwd, '.slope', 'config.json'))) return cwd;
-
-  for (const worktree of listGitWorktrees(cwd)) {
-    if (resolve(worktree) === resolve(cwd)) continue;
-    if (existsSync(join(worktree, '.slope', 'config.json'))) return worktree;
-  }
-
-  return undefined;
-}
-
-function listGitWorktrees(cwd: string): string[] {
-  return listGitWorktreeInfo(cwd).map(wt => wt.path);
 }
 
 function listGitWorktreeInfo(cwd: string): GitWorktreeInfo[] {

--- a/src/cli/session-scope.ts
+++ b/src/cli/session-scope.ts
@@ -43,6 +43,27 @@ export function resolvePrimaryCheckout(cwd: string): string | null {
   return existsSync(root) ? root : null;
 }
 
+/**
+ * List every checkout of the repository containing `cwd` — the primary checkout
+ * and all linked worktrees — with `cwd` itself always included.
+ *
+ * Sprint lifecycle state is stored per checkout (`.slope/sprint-state.json`), so
+ * a closeout that only touches `cwd` leaves every sibling worktree reporting a
+ * stale sprint and contradictory next actions (GH #624).
+ */
+export function listRepoWorktrees(cwd: string): string[] {
+  const roots = new Set<string>([resolve(cwd)]);
+
+  const raw = safeGit(cwd, ['worktree', 'list', '--porcelain']);
+  for (const line of (raw ?? '').split('\n')) {
+    if (!line.startsWith('worktree ')) continue;
+    const path = line.slice('worktree '.length).trim();
+    if (path) roots.add(resolve(path));
+  }
+
+  return [...roots];
+}
+
 function safeGit(cwd: string, args: string[]): string | null {
   try {
     const out = execFileSync('git', args, {

--- a/src/cli/session-scope.ts
+++ b/src/cli/session-scope.ts
@@ -1,0 +1,58 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
+
+/**
+ * Resolve the working directory whose store owns *session* coordination state.
+ *
+ * Session records exist to coordinate concurrent agents across a repository, so
+ * they must live in one store per repository — not one per worktree. Secondary
+ * worktrees check out the committed `.slope/config.json`, so resolving the store
+ * from the local cwd gives every worktree its own empty database. That split is
+ * the root of GH #630 / #631: `worktree-check` reads the primary checkout's
+ * store (via the hook payload cwd) while `slope session list|prune|end` reads the
+ * worktree's own, so the guard's printed remediation can never clear the
+ * sessions the guard is blocking on.
+ *
+ * Returns the primary checkout when it owns SLOPE state, otherwise `cwd`
+ * unchanged (single-checkout repos, non-git directories, and repos whose
+ * primary checkout has no `.slope/config.json`).
+ */
+export function resolveSessionStoreCwd(cwd: string): string {
+  const primary = resolvePrimaryCheckout(cwd);
+  if (!primary) return cwd;
+  if (!existsSync(join(primary, '.slope', 'config.json'))) return cwd;
+  return primary;
+}
+
+/**
+ * Resolve the primary checkout of the repository containing `cwd`.
+ *
+ * `git rev-parse --git-common-dir` yields the shared `.git` directory: `.git`
+ * in the primary checkout, and a path to the primary's `.git` when run inside a
+ * linked worktree. The primary checkout is that directory's parent.
+ */
+export function resolvePrimaryCheckout(cwd: string): string | null {
+  const commonDir = safeGit(cwd, ['rev-parse', '--git-common-dir']);
+  if (!commonDir) return null;
+
+  const absolute = isAbsolute(commonDir) ? commonDir : resolve(cwd, commonDir);
+  if (basename(absolute) !== '.git') return null;
+
+  const root = dirname(absolute);
+  return existsSync(root) ? root : null;
+}
+
+function safeGit(cwd: string, args: string[]): string | null {
+  try {
+    const out = execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 3000,
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/sprint-state.ts
+++ b/src/cli/sprint-state.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync, unlinkSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import { atomicWriteFileSync, withFileLockSync } from './atomic-write.js';
+import { listRepoWorktrees } from './session-scope.js';
 
 /** Sprint lifecycle phases */
 export const SPRINT_PHASES = ['planning', 'reviewing', 'implementing', 'scoring', 'complete'] as const;
@@ -549,6 +550,43 @@ export function updateSprintPhaseForSprint(
     return true;
   });
   return { state, matched, changed };
+}
+
+export interface WorktreePhaseReconcile {
+  /** Checkout root whose sprint state was inspected. */
+  path: string;
+  /** True when that checkout's state was for the expected sprint. */
+  matched: boolean;
+  /** True when the phase actually changed. */
+  changed: boolean;
+}
+
+/**
+ * Apply a conditional phase update to every checkout of this repository.
+ *
+ * Sprint state is per checkout, so reconciling only `cwd` left sibling worktrees
+ * reporting an already-merged sprint as still in progress — agents then received
+ * contradictory next actions and could restart completed work (GH #624).
+ * Checkouts whose state is for a different sprint are reported as unmatched and
+ * left untouched, so unrelated in-flight work is never clobbered.
+ */
+export function updateSprintPhaseForSprintAcrossWorktrees(
+  cwd: string,
+  expectedSprint: number,
+  phase: SprintPhase,
+): WorktreePhaseReconcile[] {
+  const results: WorktreePhaseReconcile[] = [];
+  for (const root of listRepoWorktrees(cwd)) {
+    if (!existsSync(join(root, SPRINT_STATE_FILE))) continue;
+    try {
+      const { matched, changed } = updateSprintPhaseForSprint(root, expectedSprint, phase);
+      results.push({ path: root, matched, changed });
+    } catch {
+      // A locked or unreadable sibling checkout must not fail the closeout.
+      results.push({ path: root, matched: false, changed: false });
+    }
+  }
+  return results;
 }
 
 /** Check if all gates are true. */

--- a/tests/cli/atomic-write.test.ts
+++ b/tests/cli/atomic-write.test.ts
@@ -141,7 +141,8 @@ describe('withFileLockSync', () => {
   }, 15000);
 
   it('keeps representative sprint and session state writes valid under concurrent processes', async () => {
-    const moduleDir = compileCliModules(['atomic-write', 'sprint-state', 'session-state']);
+    // session-scope is a dependency of sprint-state (cross-worktree reconcile).
+    const moduleDir = compileCliModules(['atomic-write', 'sprint-state', 'session-state', 'session-scope']);
     const sprintUrl = pathToFileURL(join(moduleDir, 'sprint-state.js')).href;
     const sessionUrl = pathToFileURL(join(moduleDir, 'session-state.js')).href;
     const slopeDir = join(tmpDir, '.slope');

--- a/tests/cli/commands/guard.test.ts
+++ b/tests/cli/commands/guard.test.ts
@@ -180,6 +180,60 @@ describe('guardCommand dispatcher path', () => {
     expect(metrics).toContain('"decision":"ask"');
   });
 
+  it('ignores out-of-repo scratchpad writes instead of adopting them as the workspace (GH #625)', async () => {
+    const scratchpad = makeTmpPath('slope-scratchpad');
+    mkdirSync(scratchpad, { recursive: true });
+    try {
+      const output = await runGuardCommandWithInput(['claim-required'], makeHookInput(cwd, {
+        tool_input: { file_path: join(scratchpad, 'probe.config.ts'), content: 'x' },
+      }));
+
+      expect(output).toBe('');
+    } finally {
+      rmSync(scratchpad, { recursive: true, force: true });
+    }
+  });
+
+  it('does not cache a non-workspace cwd for later tool calls (GH #625)', async () => {
+    const scratchpad = makeTmpPath('slope-scratchpad');
+    mkdirSync(scratchpad, { recursive: true });
+    try {
+      await runGuardCommandWithInput(['claim-required'], makeHookInput(cwd, {
+        tool_input: { file_path: join(scratchpad, 'probe.ts'), content: 'x' },
+      }));
+
+      const store = join(cwd, '.slope', 'codex-workdirs');
+      const memos = existsSync(store) ? readdirSync(store) : [];
+      const remembered = memos.map(name => JSON.parse(readFileSync(join(store, name), 'utf8')).cwd);
+      expect(remembered).not.toContain(scratchpad);
+    } finally {
+      rmSync(scratchpad, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to replay a remembered cwd that is not a workspace (GH #625)', async () => {
+    const scratchpad = makeTmpPath('slope-scratchpad');
+    mkdirSync(scratchpad, { recursive: true });
+    const store = join(cwd, '.slope', 'codex-workdirs');
+    mkdirSync(store, { recursive: true });
+    // Simulate a memo written by an older version that pinned a non-workspace dir.
+    writeFileSync(
+      join(store, `${'0'.repeat(32)}.json`),
+      JSON.stringify({ session_id: 'test-session', cwd: scratchpad, source: 'tool-path' }),
+    );
+    try {
+      const output = await runGuardCommandWithInput(['claim-required'], makeHookInput(cwd, {
+        tool_input: { file_path: join(cwd, 'src/example.ts') },
+      }));
+
+      // Falls back to the real workspace, so the in-repo edit is still classified.
+      expect(output).toContain('src/example.ts');
+      expect(output).not.toContain('scratchpad');
+    } finally {
+      rmSync(scratchpad, { recursive: true, force: true });
+    }
+  });
+
   it('records suppressed metrics for adhoc workflow guards that do not run', async () => {
     const output = await runGuardCommandWithInput(['workflow-step-gate'], makeHookInput(cwd));
 

--- a/tests/cli/guards/worktree-check-integration.test.ts
+++ b/tests/cli/guards/worktree-check-integration.test.ts
@@ -10,6 +10,16 @@ import type { HookInput } from '../../../src/core/index.js';
 let cwd: string;
 let extraDirs: string[];
 
+const SESSION_IDS = [
+  'candidate-session',
+  'recovery-session',
+  'worktree-session',
+] as const;
+
+function resetSentinels(): void {
+  for (const id of SESSION_IDS) resetWorktreeCheckState(id);
+}
+
 function git(args: string[]): void {
   execFileSync('git', args, { cwd, stdio: 'ignore' });
 }
@@ -27,14 +37,17 @@ function makeHookInput(sessionId: string, command?: string, inputCwd = cwd): Hoo
 }
 
 async function seedPrimarySession(): Promise<void> {
+  await registerSession('orphan-primary', 'primary', 'main');
+}
+
+async function registerSession(
+  sessionId: string,
+  role: 'primary' | 'secondary',
+  branch: string,
+): Promise<void> {
   const store = new SqliteSlopeStore(join(cwd, '.slope/slope.db'));
   try {
-    await store.registerSession({
-      session_id: 'orphan-primary',
-      role: 'primary',
-      ide: 'codex',
-      branch: 'main',
-    });
+    await store.registerSession({ session_id: sessionId, role, ide: 'codex', branch });
   } finally {
     store.close();
   }
@@ -86,6 +99,10 @@ async function listClaims(): Promise<unknown[]> {
 
 describe('worktreeCheckGuard SQLite deadlock recovery', () => {
   beforeEach(() => {
+    // The pass-sentinel lives in the real tmpdir and outlives the process, so a
+    // leftover from an earlier run would short-circuit the guard before it can
+    // reconcile. Reset on entry as well as exit.
+    resetSentinels();
     cwd = mkdtempSync(join(tmpdir(), 'slope-worktree-check-'));
     extraDirs = [];
     git(['init', '-q']);
@@ -102,8 +119,7 @@ describe('worktreeCheckGuard SQLite deadlock recovery', () => {
   });
 
   afterEach(() => {
-    resetWorktreeCheckState('candidate-session');
-    resetWorktreeCheckState('recovery-session');
+    resetSentinels();
     for (const dir of extraDirs) rmSync(dir, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });
   });
@@ -130,10 +146,66 @@ describe('worktreeCheckGuard SQLite deadlock recovery', () => {
     expect(await listSessionIds()).toEqual(['orphan-primary']);
   });
 
+  it('allows a session whose edit lands in a worktree even when the payload reports the launch dir (GH #630, #631)', async () => {
+    await seedPrimarySession();
+
+    const worktreePath = join(tmpdir(), `slope-worktree-launchdir-${basename(cwd)}`);
+    extraDirs.push(worktreePath);
+    git(['worktree', 'add', '-q', worktreePath, '-b', 'launchdir-worktree']);
+
+    // Claude Code keeps reporting the launch directory after WorktreeCreate /
+    // EnterWorktree, so cwd is the primary checkout while the edit target is
+    // inside the worktree. This used to deadlock: denied on the primary
+    // checkout's sessions, with no remediation able to clear them.
+    const input: HookInput = {
+      session_id: 'worktree-session',
+      cwd,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Edit',
+      tool_input: { file_path: join(worktreePath, 'src/foo.ts'), old_string: 'a', new_string: 'b' },
+    };
+
+    const result = await worktreeCheckGuard(input, cwd);
+
+    expect(result).toEqual({});
+    const reconciled = await getSession('worktree-session');
+    expect(reconciled?.role).toBe('secondary');
+    expect(reconciled?.worktree_path ? realpathSync(reconciled.worktree_path) : '')
+      .toBe(realpathSync(worktreePath));
+  });
+
+  it('still denies an edit that lands in the primary checkout while a worktree exists', async () => {
+    await seedPrimarySession();
+
+    const worktreePath = join(tmpdir(), `slope-worktree-primaryedit-${basename(cwd)}`);
+    extraDirs.push(worktreePath);
+    git(['worktree', 'add', '-q', worktreePath, '-b', 'primaryedit-worktree']);
+
+    const result = await worktreeCheckGuard(makeHookInput('candidate-session'), cwd);
+
+    expect(result.decision).toBe('deny');
+    expect(result.blockReason).toContain('EnterWorktree');
+  });
+
+  it('does not register a denied session as a phantom primary (GH #631)', async () => {
+    await seedPrimarySession();
+
+    const result = await worktreeCheckGuard(makeHookInput('candidate-session'), cwd);
+
+    expect(result.decision).toBe('deny');
+    // A denied session used to be written as role:primary on the launch-dir
+    // branch before the conflict check ran, leaving a phantom that could then
+    // block the legitimate primary session.
+    expect(await listSessionIds()).toEqual(['orphan-primary']);
+  });
+
   it('reconciles a denied main-checkout session after it enters a git worktree', async () => {
     await seedPrimarySession();
     const denied = await worktreeCheckGuard(makeHookInput('candidate-session'), cwd);
     expect(denied.decision).toBe('deny');
+    // The guard no longer auto-registers a denied session, so register the way a
+    // real recovery does (`slope session start`) before claiming work.
+    await registerSession('candidate-session', 'primary', 'main');
     await claimForSession('candidate-session');
 
     const worktreePath = join(tmpdir(), `slope-worktree-child-${basename(cwd)}`);

--- a/tests/cli/guards/worktree-check.test.ts
+++ b/tests/cli/guards/worktree-check.test.ts
@@ -408,9 +408,14 @@ describe('worktreeCheckGuard', () => {
   });
 
   it('reconciles current session metadata when already in a worktree', async () => {
+    // The primary checkout owns SLOPE state; the worktree also has a committed
+    // config, which is what used to send the write to a worktree-local store.
+    sentinelFiles.add('/repo');
+    sentinelFiles.add(join('/repo', '.slope', 'config.json'));
     sentinelFiles.add(join('/tmp/test', '.slope', 'config.json'));
     mockExecFileSync
       .mockReturnValueOnce('../../.git' as never) // git-common-dir != '.git'
+      .mockReturnValueOnce('/repo/.git' as never) // session-scope: --git-common-dir
       .mockReturnValueOnce('/tmp/test' as never) // git rev-parse --show-toplevel
       .mockReturnValueOnce('fix/deadlock' as never); // branch
 
@@ -422,6 +427,9 @@ describe('worktreeCheckGuard', () => {
       branch: 'fix/deadlock',
       worktree_path: '/tmp/test',
     });
+    // Repo-scoped: written to the primary checkout's store, not the worktree's,
+    // so `slope session list|prune|end` sees the same record (GH #630, #631).
+    expect(mockResolveStore).toHaveBeenCalledWith('/repo');
   });
 
   it('silently passes on store resolve error (#263)', async () => {
@@ -640,9 +648,9 @@ describe('worktreeCheckGuard', () => {
 
   it('auto-registers current session with correct params', async () => {
     mockGitMainRepo('feat/my-branch');
-    (mockStore.getActiveSessions as ReturnType<typeof vi.fn>).mockResolvedValue([
-      makeSession({ session_id: 'test-session' }),
-    ]);
+    // No existing record — registration closes the detection gap for the *next*
+    // session. An already-registered session is not re-registered (GH #631).
+    (mockStore.getActiveSessions as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
     await worktreeCheckGuard(makeInput('test-session'), '/tmp/test');
     expect(mockStore.registerSession).toHaveBeenCalledWith({
@@ -736,9 +744,7 @@ describe('worktreeCheckGuard', () => {
       .mockReturnValueOnce('.git' as never)                              // git-common-dir
       .mockImplementationOnce(() => { throw new Error('detached'); });    // branch fails
 
-    (mockStore.getActiveSessions as ReturnType<typeof vi.fn>).mockResolvedValue([
-      makeSession({ session_id: 'test-session' }),
-    ]);
+    (mockStore.getActiveSessions as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
     await worktreeCheckGuard(makeInput(), '/tmp/test');
     const call = (mockStore.registerSession as ReturnType<typeof vi.fn>).mock.calls[0][0];

--- a/tests/cli/sprint-state-worktrees.test.ts
+++ b/tests/cli/sprint-state-worktrees.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  createSprintState,
+  loadSprintState,
+  saveSprintState,
+  updateSprintPhaseForSprintAcrossWorktrees,
+} from '../../src/cli/sprint-state.js';
+
+let primary: string;
+let extraDirs: string[];
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+function seedSprintState(cwd: string, sprint: number, phase: 'implementing' | 'complete'): void {
+  mkdirSync(join(cwd, '.slope'), { recursive: true });
+  const state = createSprintState(sprint);
+  state.phase = phase;
+  saveSprintState(cwd, state);
+}
+
+describe('updateSprintPhaseForSprintAcrossWorktrees (GH #624)', () => {
+  beforeEach(() => {
+    primary = mkdtempSync(join(tmpdir(), 'slope-sprint-wt-'));
+    extraDirs = [];
+    git(primary, ['init', '-q']);
+    git(primary, ['checkout', '-q', '-b', 'main']);
+    git(primary, ['config', 'user.email', 'test@example.com']);
+    git(primary, ['config', 'user.name', 'Test User']);
+    git(primary, ['commit', '--allow-empty', '-m', 'init']);
+  });
+
+  afterEach(() => {
+    for (const dir of extraDirs) rmSync(dir, { recursive: true, force: true });
+    rmSync(primary, { recursive: true, force: true });
+  });
+
+  function addWorktree(name: string): string {
+    const path = join(tmpdir(), `slope-sprint-wt-${name}-${basename(primary)}`);
+    extraDirs.push(path);
+    git(primary, ['worktree', 'add', '-q', path, '-b', name]);
+    return path;
+  }
+
+  it('advances the sprint phase in a sibling worktree, not just the cwd', () => {
+    const feature = addWorktree('feature');
+    seedSprintState(primary, 246, 'implementing');
+    seedSprintState(feature, 246, 'implementing');
+
+    const results = updateSprintPhaseForSprintAcrossWorktrees(primary, 246, 'complete');
+
+    expect(loadSprintState(feature)?.phase).toBe('complete');
+    expect(loadSprintState(primary)?.phase).toBe('complete');
+    expect(results.filter(r => r.changed)).toHaveLength(2);
+  });
+
+  it('leaves a worktree holding a different sprint untouched and reports it', () => {
+    const other = addWorktree('other');
+    seedSprintState(primary, 246, 'implementing');
+    seedSprintState(other, 247, 'implementing');
+
+    const results = updateSprintPhaseForSprintAcrossWorktrees(primary, 246, 'complete');
+
+    // Unrelated in-flight work must never be clobbered.
+    expect(loadSprintState(other)?.phase).toBe('implementing');
+    expect(loadSprintState(primary)?.phase).toBe('complete');
+    const unmatched = results.filter(r => !r.matched);
+    expect(unmatched).toHaveLength(1);
+    expect(unmatched[0].changed).toBe(false);
+  });
+
+  it('reports no results when no checkout holds sprint state', () => {
+    addWorktree('empty');
+
+    const results = updateSprintPhaseForSprintAcrossWorktrees(primary, 246, 'complete');
+
+    expect(results).toEqual([]);
+  });
+
+  it('works when invoked from the worktree rather than the primary checkout', () => {
+    const feature = addWorktree('from-worktree');
+    seedSprintState(primary, 246, 'implementing');
+    seedSprintState(feature, 246, 'implementing');
+
+    updateSprintPhaseForSprintAcrossWorktrees(feature, 246, 'complete');
+
+    expect(loadSprintState(primary)?.phase).toBe('complete');
+    expect(loadSprintState(feature)?.phase).toBe('complete');
+  });
+});


### PR DESCRIPTION
S246 of Phase 55 (late-July issue recovery). **First of three stacked PRs — merge this one first.**

## What this fixes

A session launched in the primary checkout and then moved into a worktree (WorktreeCreate at launch, or EnterWorktree mid-session) had **every** Bash, Read, Edit and Write call denied for as long as any primary-checkout session was live — with no reachable remediation. Three independent defects combined:

1. **`worktree-check` judged location by the hook payload's `cwd`**, which Claude Code keeps reporting as the *launch* directory. `--git-common-dir` therefore returned `.git`, the guard took the primary-checkout branch, saw the other live session and denied — even though every edit target was inside the worktree. It now checks, on the path where it would otherwise deny, whether the tool call's target lands in a non-primary worktree. Checked lazily so the common pass path spawns no extra git processes; the worktree list is computed once and shared with the guidance formatter. An edit landing in the primary checkout still denies, so the #499 "enter the existing worktree" guidance is unaffected.

2. **Guard and CLI resolved different session stores.** Secondary worktrees check out the committed `.slope/config.json`, so `slope session list|prune|end` opened a fresh worktree-local database while the guard read the primary checkout's — `prune` removed 0, `end` said "not found", and the printed remediation could never clear the block. New `src/cli/session-scope.ts` resolves the primary checkout via `--git-common-dir`; all nine session CLI call sites and worktree reconciliation now share it.

3. **The guard registered the session as `role: primary` before the conflict check**, so a session it was about to deny was left behind as a phantom primary that could then block the legitimate primary session. Registration now happens only on the pass path, and only when no record exists. `slope session start` and `session heartbeat` join the recovery exemptions — registering is the one action that lets an isolated session prove itself, so denying it made the block permanent.

Plus two more:

- **#625** — the issue's stated cause was wrong. `findImplementationWritePath` already scoped to the repo; the defect was upstream in `resolveEffectiveHookCwd`, which derives `cwd` from the tool's target path. `canonicalHookCwd` fell back to the raw path, so a write to a harness scratchpad made that directory the guard's workspace root — discarding the real sprint state *and* defeating the repo-scope check. Fixed there, so it fixes every guard at once with no temp-dir denylist. The Codex workdir memo is now guarded on both write and read, since one out-of-repo call previously pinned the whole session and stale caches kept doing so after the fix.
- **#624** — `updateSprintPhaseForSprint` only mutated the state file in `cwd`, so sibling worktrees kept stale state. Worse, the caller discarded the returned `matched`/`changed` and printed "reconciled to complete" unconditionally, so a closeout that reconciled nothing still reported success. Now reconciles every checkout (leaving those holding a different sprint untouched and reported) and says what actually happened.

## Verification

`pnpm build`, `pnpm typecheck`, `pnpm test` all clean — 249 files, 4099 tests. Each fix was reproduced against this repo before and after. New coverage: both directions of the worktree deadlock, the phantom-primary regression, out-of-repo scratchpad handling including a stale memo, and cross-worktree phase reconcile.

## Review status

⚠️ Both required review gates carry an explicit `independent_review_waived` — no independent reviewer or PR review was run, because the operator directed that no subagents be spawned. Sprint state reads `ready_for_pr_with_review_waiver` so the downgrade is visible. **An independent review here is recommended before merge.**

Closes #630. Closes #631. Closes #625. Closes #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
