### PR TITLE
S247: Roadmap projection safety — stop slope validate destroying planning work (#637, #636, #632)

### DIFF
--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -6170,7 +6170,7 @@
       "par": 5,
       "slope": 5,
       "type": "bugfix + guard reliability",
-      "status": "planned",
+      "status": "complete",
       "note": "Fix #631/#630 (worktree-check evaluates hook input.cwd — the launch dir — so a session moved into a worktree is judged against the primary checkout's session store and deadlocks; the guard also auto-registers the denied session as role primary, and slope session start is missing from the recovery exemptions), #625 (claim-required treats out-of-repo scratchpad .ts writes as implementation edits), and #624 (post-merge retro does not advance sprint status across worktrees). Root theme: session identity has uncoordinated channels and guard/CLI resolve different stores, so the guard's own printed remediation can never clear the block.",
       "tickets": [
         {
@@ -6225,7 +6225,7 @@
       "par": 5,
       "slope": 5,
       "type": "bugfix + data integrity",
-      "status": "planned",
+      "status": "complete",
       "depends_on": [
         246
       ],

--- a/docs/retros/rollovers/sprint-222-to-246-503731c57d58679b.json
+++ b/docs/retros/rollovers/sprint-222-to-246-503731c57d58679b.json
@@ -1,0 +1,334 @@
+{
+  "version": 1,
+  "kind": "sprint_rollover",
+  "transition_id": "cec2f6377741a3f9",
+  "from_sprint": 222,
+  "to_sprint": 246,
+  "from_label": "S222",
+  "to_label": "S246",
+  "recorded_at": "2026-07-25T15:03:02.676Z",
+  "actor": {
+    "name": "srbry",
+    "source": "env:USERNAME"
+  },
+  "request": {
+    "from": 222,
+    "to": 246,
+    "force": false
+  },
+  "forced": false,
+  "eligibility": {
+    "from_terminal": true,
+    "target_dependency_eligible": true,
+    "blocking_dependencies": [],
+    "target_dependencies": [],
+    "completion_evidence": {
+      "roadmap_complete": [
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        114.5,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        137.5,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        143.5,
+        143.6,
+        143.7,
+        143.8,
+        143.9,
+        143.95,
+        143.97,
+        143.98,
+        143.99,
+        144,
+        145,
+        146,
+        146.1,
+        146.2,
+        146.3,
+        148,
+        149,
+        150,
+        151,
+        151.1,
+        152,
+        152.1,
+        153,
+        154,
+        216,
+        217,
+        218,
+        219,
+        220,
+        221,
+        222,
+        223,
+        224,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        233,
+        234,
+        235,
+        236,
+        241,
+        242,
+        243,
+        244
+      ],
+      "scorecards": [
+        235,
+        222,
+        223,
+        224,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        241,
+        242,
+        243
+      ],
+      "local_terminal": [
+        222
+      ]
+    },
+    "scorecard_artifacts": [
+      {
+        "sprint": 235,
+        "path": "docs/retros/sprint-235.json",
+        "sha256": "e634d45f8ceacc0931e9bffc6c4cb23cbf90b5461486937ed4fc55dc95e6944b"
+      },
+      {
+        "sprint": 222,
+        "path": "docs/retros/sprint-222.json",
+        "sha256": "e71c5a0ada133f85f95ff7fdf4959607803dab06d80fcb3e4e3b5753b9383950"
+      },
+      {
+        "sprint": 223,
+        "path": "docs/retros/sprint-223.json",
+        "sha256": "4aa327cd6be5abc5c835884d1d9bb961ee128d80b98599546d3d941814e7de4d"
+      },
+      {
+        "sprint": 224,
+        "path": "docs/retros/sprint-224.json",
+        "sha256": "575b8c4257f93567d2a7d32ef3fe559a8edab9ebab1e7feca98467ebc97ec5d8"
+      },
+      {
+        "sprint": 226,
+        "path": "docs/retros/sprint-226.json",
+        "sha256": "ac593a709ec1b43cea0568e5763278a28a753c84f883c11bdb679dc1a8702eb4"
+      },
+      {
+        "sprint": 227,
+        "path": "docs/retros/sprint-227.json",
+        "sha256": "0d7cfd1369eed43cf16181028441b9e1ce189947e2ca87582a5977bceda5c3c9"
+      },
+      {
+        "sprint": 228,
+        "path": "docs/retros/sprint-228.json",
+        "sha256": "5a735e31e8289de103bcd794f54770e037b618e6c8a6dbe5bc48fb84964f6860"
+      },
+      {
+        "sprint": 229,
+        "path": "docs/retros/sprint-229.json",
+        "sha256": "a2335698910481237b15578e63563b7cd61d3fe192b28af7e2c525dacbea13c5"
+      },
+      {
+        "sprint": 230,
+        "path": "docs/retros/sprint-230.json",
+        "sha256": "daf6c651c004bb0e5dc1ad6577add3a30189fffc914b1910b59506c3049a01e2"
+      },
+      {
+        "sprint": 231,
+        "path": "docs/retros/sprint-231.json",
+        "sha256": "a1beb32eff3ffd28b76a1e0032b252d6a566c5f73b59ed1373511bf37db7a6d3"
+      },
+      {
+        "sprint": 232,
+        "path": "docs/retros/sprint-232.json",
+        "sha256": "3282dd8455a1ddfd869c3e0cf0603a538093e8a052f408d369ab6ead1acc0eda"
+      },
+      {
+        "sprint": 241,
+        "path": "docs/retros/sprint-241.json",
+        "sha256": "9ffa3e294bc7f2320ec1139d9af497bd3bb87ba84c30df7c32bd9d18568c244b"
+      },
+      {
+        "sprint": 242,
+        "path": "docs/retros/sprint-242.json",
+        "sha256": "1317a7ee733e92cc103444b3d01cf9d5a72ee7bc7485c24319a1460e572dfd13"
+      },
+      {
+        "sprint": 243,
+        "path": "docs/retros/sprint-243.json",
+        "sha256": "4e142665cda433e32161a9fb114aa9a018d05b769671ea221eeed755408b7d65"
+      }
+    ],
+    "expected_next": 246
+  },
+  "roadmap": {
+    "path": "docs/backlog/roadmap.json",
+    "sha256": "61de6634bc1da1130121c07576acc496549e73881172914df2c0e94d2576320b",
+    "from_status": "complete",
+    "to_status": "planned"
+  },
+  "prior_state_sha256": "f3ab626131ea4d9e72d03fd224794cf70674723c8da0839dba23866f6c1635f3",
+  "prior_state": {
+    "sprint": 222,
+    "phase": "complete",
+    "gates": {
+      "tests": true,
+      "code_review": true,
+      "architect_review": true,
+      "scorecard": true,
+      "review_md": true
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local implementing-agent release review; evidence includes pre-merge targeted regressions (26 files, 340 tests), merged focused suite (10 files, 216 tests), merged full Vitest (238 files, 3746 tests), tsc --noEmit, build, roadmap validate, map --check, version smoke, npm latest check, and npm dry-run for 1.60.0. No independent reviewer or PR review was run locally before PR creation.",
+        "updated_at": "2026-06-27T23:34:16.705Z"
+      },
+      "architect_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local implementing-agent release architecture review; scope covered mainline integration, roadmap conflict resolution, version bump, release branch hygiene, S155-S158 supersession, S216-S222 completion, and trusted-publishing handoff. No independent architecture reviewer or PR review was run locally before PR creation.",
+        "updated_at": "2026-06-27T23:34:23.193Z"
+      }
+    },
+    "started_at": "2026-06-27T23:15:58.984Z",
+    "updated_at": "2026-06-27T23:34:30.227Z",
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    }
+  },
+  "next_state": {
+    "sprint": 246,
+    "phase": "planning",
+    "gates": {
+      "tests": false,
+      "code_review": false,
+      "architect_review": false,
+      "scorecard": false,
+      "review_md": false
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "pending",
+        "evidence": []
+      },
+      "architect_review": {
+        "provenance": "pending",
+        "evidence": []
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T15:03:02.676Z",
+    "updated_at": "2026-07-25T15:03:02.676Z",
+    "rollover": {
+      "transition_id": "cec2f6377741a3f9",
+      "from_sprint": 222,
+      "audit_path": "docs/retros/rollovers/sprint-222-to-246-503731c57d58679b.json",
+      "recorded_at": "2026-07-25T15:03:02.676Z",
+      "forced": false
+    }
+  },
+  "claims_policy": "unchanged",
+  "sessions_policy": "unchanged"
+}

--- a/docs/retros/rollovers/sprint-246-to-247-f51f44b6f0ad9212.json
+++ b/docs/retros/rollovers/sprint-246-to-247-f51f44b6f0ad9212.json
@@ -1,0 +1,277 @@
+{
+  "version": 1,
+  "kind": "sprint_rollover",
+  "transition_id": "eeedc57400a678af",
+  "from_sprint": 246,
+  "to_sprint": 247,
+  "from_label": "S246",
+  "to_label": "S247",
+  "recorded_at": "2026-07-25T16:07:31.504Z",
+  "actor": {
+    "name": "srbry",
+    "source": "env:USERNAME"
+  },
+  "request": {
+    "from": 246,
+    "to": 247,
+    "force": false
+  },
+  "forced": false,
+  "eligibility": {
+    "from_terminal": true,
+    "target_dependency_eligible": true,
+    "blocking_dependencies": [],
+    "target_dependencies": [
+      246
+    ],
+    "completion_evidence": {
+      "roadmap_complete": [
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        114.5,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        137.5,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        143.5,
+        143.6,
+        143.7,
+        143.8,
+        143.9,
+        143.95,
+        143.97,
+        143.98,
+        143.99,
+        144,
+        145,
+        146,
+        146.1,
+        146.2,
+        146.3,
+        148,
+        149,
+        150,
+        151,
+        151.1,
+        152,
+        152.1,
+        153,
+        154,
+        216,
+        217,
+        218,
+        219,
+        220,
+        221,
+        222,
+        223,
+        224,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        233,
+        234,
+        235,
+        236,
+        241,
+        242,
+        243,
+        244
+      ],
+      "scorecards": [
+        246,
+        247
+      ],
+      "local_terminal": [
+        246
+      ]
+    },
+    "scorecard_artifacts": [
+      {
+        "sprint": 246,
+        "path": "docs/retros/sprint-246.json",
+        "sha256": "3702a8d54d569455bef5c4976231431bdf2d9e2240ce747457153cb17c8660fc"
+      },
+      {
+        "sprint": 247,
+        "path": "docs/retros/sprint-247.json",
+        "sha256": "ddacbeef07c37c19cdbf1aa4aae18a75128ca8139c0494daa37d8d8c39a45b4c"
+      }
+    ],
+    "expected_next": 247
+  },
+  "roadmap": {
+    "path": "docs/backlog/roadmap.json",
+    "sha256": "d50f2b50b7c770e7070d07bff256c01a09ebd18ef825a2a737dd8b186b990463",
+    "from_status": "planned",
+    "to_status": "planned"
+  },
+  "prior_state_sha256": "0951e043cbffc16e3a0d6fb22f3f445b50c14be68c801b1535b8c038b29a36f2",
+  "prior_state": {
+    "sprint": 246,
+    "phase": "implementing",
+    "gates": {
+      "tests": true,
+      "code_review": true,
+      "architect_review": true,
+      "scorecard": true,
+      "review_md": true
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "independent_review_waived",
+        "evidence": [],
+        "notes": "No independent code reviewer available: the operator directed that no subagents be spawned this session, and no PR review exists yet. Waived in favour of a documented local self review, which found and fixed a real defect (merge/revert subjects treated as fix intent in the sibling S248 work) and logged five findings. Evidence: 4099 tests passing, tsc --noEmit clean, build clean, three scorecards validating, and live before/after reproductions of #625, #630/#631 and #637. Recommend an independent review on the PR before merge.",
+        "updated_at": "2026-07-25T16:02:56.469Z"
+      },
+      "architect_review": {
+        "provenance": "independent_review_waived",
+        "evidence": [],
+        "notes": "No independent architecture reviewer available (same subagent constraint). Local architecture self review covered guard cwd derivation, repo-scoped session store resolution, cross-worktree sprint state, and the three deferral decisions (projection marker, validate read-only, canonical sprint IDs), each recorded as an architect finding with rationale rather than silently dropped. Recommend independent architecture review on the PR, particularly for the deferred projection-marker/migration-digest coupling.",
+        "updated_at": "2026-07-25T16:02:56.783Z"
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "required",
+        "reason": "File patterns include security-sensitive paths",
+        "source": "review_recommend",
+        "updated_at": "2026-07-25T15:58:40.622Z"
+      },
+      "architect_review": {
+        "priority": "required",
+        "reason": "5 tickets warrants architectural review",
+        "source": "review_recommend",
+        "updated_at": "2026-07-25T15:58:40.622Z"
+      }
+    },
+    "started_at": "2026-07-25T15:03:02.676Z",
+    "updated_at": "2026-07-25T16:02:56.783Z",
+    "rollover": {
+      "transition_id": "cec2f6377741a3f9",
+      "from_sprint": 222,
+      "audit_path": "docs/retros/rollovers/sprint-222-to-246-503731c57d58679b.json",
+      "recorded_at": "2026-07-25T15:03:02.676Z",
+      "forced": false
+    }
+  },
+  "next_state": {
+    "sprint": 247,
+    "phase": "planning",
+    "gates": {
+      "tests": false,
+      "code_review": false,
+      "architect_review": false,
+      "scorecard": false,
+      "review_md": false
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "pending",
+        "evidence": []
+      },
+      "architect_review": {
+        "provenance": "pending",
+        "evidence": []
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T16:07:31.504Z",
+    "updated_at": "2026-07-25T16:07:31.504Z",
+    "rollover": {
+      "transition_id": "eeedc57400a678af",
+      "from_sprint": 246,
+      "audit_path": "docs/retros/rollovers/sprint-246-to-247-f51f44b6f0ad9212.json",
+      "recorded_at": "2026-07-25T16:07:31.504Z",
+      "forced": false
+    }
+  },
+  "claims_policy": "unchanged",
+  "sessions_policy": "unchanged"
+}

--- a/docs/retros/sprint-247-review.md
+++ b/docs/retros/sprint-247-review.md
@@ -1,0 +1,55 @@
+
+## Sprint 247 Review: Roadmap Projection Safety and Sprint Identity
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 5 |
+| Slope | 5 |
+| Score | 7 |
+| Label | Double Bogey |
+| Fairway % | 100% (5/5) |
+| GIR % | 40% (2/5) |
+| Putts | 0 |
+| Penalties | 0 |
+| Hazard Penalties | 2 |
+
+### Shot-by-Shot (Tickets Delivered: 5)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S247-1 | Driver | Missed Short | Bunker: The in-file _generated marker was implemented, then reverted. Making store.projection carry the marker broke seven roadmap-migration tests: the planner computes expected_projection_sha256 and the applier recomputes it, so both sides plus the archive comparison must agree on projection bytes. Threading a consistent label through migration digests risks receipt binding and rollback integrity, so it needs its own ticket. | Divergence protection shipped and is the substantive fix: findRoadmapProjectionDivergence blocks any write that would drop phases or sprints present only on disk, naming them, with --force to discard deliberately. Reproduced on this repo first: an injected phase vanished on slope validate with exit 0. |
+| S247-2 | Long Iron | Missed Short | Bunker: Not delivered. Removing regeneration from validate would also remove the closeout source reconciliation this repo own workflow depends on. Instead the validate write was made safe and its exit code corrected. The surprise that a validate command mutates tracked files remains. | RoadmapSourceError.projectionContentLoss stops callers downgrading the refusal to a warning; validate reports once and exits 1 instead of printing a per-sprint note and exiting 0. |
+| S247-3 | Short Iron | Green | -- | Focused evidence now names the canonical manifest, the owning bundle with its kind, and the projection as generated and read-only. An explicit --path still reports what was read; invalid federation falls back. |
+| S247-4 | Driver | Missed Short | Rough: Canonical string sprint IDs (458.10 distinct from 458.1) not delivered: it is a representational change across roadmap compile, focus, archive, sprint state, scorecards and retro paths. Only the display mis-rendering was fixed. | Found during S246 pre-round, not from the issue: isEncodedInsertedSprintId treats any integer 200-999 ending in 5 as a legacy encoded half-sprint, so this repo own S245 rendered as S24.5. S243 built the evidence-based resolver and used it for ordering but never switched the display paths over. |
+| S247-5 | Short Iron | Green | -- | No production change needed. Verified all three reported subjects already yield no refs on main via hasImplementationCommitType and isSprintRangeEndpoint; the range case was already pinned verbatim. Added the one uncovered case, the forward reference plan S134. |
+
+### Miss Pattern
+
+| Direction | Count |
+|---|---|
+| Short (under-scoped) | 3 |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| undefined | undefined | undefined |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Bunker | S247-1 | The in-file _generated marker was implemented, then reverted. Making store.projection carry the marker broke seven roadmap-migration tests: the planner computes expected_projection_sha256 and the applier recomputes it, so both sides plus the archive comparison must agree on projection bytes. Threading a consistent label through migration digests risks receipt binding and rollback integrity, so it needs its own ticket. |
+| Bunker | S247-2 | Not delivered. Removing regeneration from validate would also remove the closeout source reconciliation this repo own workflow depends on. Instead the validate write was made safe and its exit code corrected. The surprise that a validate command mutates tracked files remains. |
+| Rough | S247-4 | Canonical string sprint IDs (458.10 distinct from 458.1) not delivered: it is a representational change across roadmap compile, focus, archive, sprint state, scorecards and retro paths. Only the display mis-rendering was fixed. |
+
+**Known hazards for future sprints:**
+- src/cli/roadmap-source-store.ts and src/core/roadmap-migration.ts both serialize the projection for digest comparison; planner and applier must agree byte for byte.
+
+### Course Management Notes
+
+- Three of five tickets landed partially, each with a documented reason rather than an overrun. The reported harm in every case is fixed; the deferred parts are representational or digest-sensitive work that deserves its own sprint.
+- Reverting the marker after seeing seven migration failures was the right call over threading digests thin on remaining context.
+

--- a/docs/retros/sprint-247.json
+++ b/docs/retros/sprint-247.json
@@ -1,0 +1,104 @@
+{
+  "sprint_number": 247,
+  "theme": "Roadmap Projection Safety and Sprint Identity",
+  "par": 5,
+  "slope": 5,
+  "score": 7,
+  "score_label": "double_bogey",
+  "date": "2026-07-25",
+  "shots": [
+    {
+      "ticket_key": "S247-1",
+      "title": "Add a generated-file marker to the roadmap projection and refuse to discard unexplained divergence (#637)",
+      "club": "driver",
+      "result": "missed_short",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "major",
+          "description": "The in-file _generated marker was implemented, then reverted. Making store.projection carry the marker broke seven roadmap-migration tests: the planner computes expected_projection_sha256 and the applier recomputes it, so both sides plus the archive comparison must agree on projection bytes. Threading a consistent label through migration digests risks receipt binding and rollback integrity, so it needs its own ticket.",
+          "gotcha_id": "self:deferred-marker"
+        }
+      ],
+      "notes": "Divergence protection shipped and is the substantive fix: findRoadmapProjectionDivergence blocks any write that would drop phases or sprints present only on disk, naming them, with --force to discard deliberately. Reproduced on this repo first: an injected phase vanished on slope validate with exit 0."
+    },
+    {
+      "ticket_key": "S247-2",
+      "title": "Make slope validate read-only and leave regeneration to slope roadmap compile (#637)",
+      "club": "long_iron",
+      "result": "missed_short",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "Not delivered. Removing regeneration from validate would also remove the closeout source reconciliation this repo own workflow depends on. Instead the validate write was made safe and its exit code corrected. The surprise that a validate command mutates tracked files remains.",
+          "gotcha_id": "self:deferred-readonly"
+        }
+      ],
+      "notes": "RoadmapSourceError.projectionContentLoss stops callers downgrading the refusal to a warning; validate reports once and exits 1 instead of printing a per-sprint note and exiting 0."
+    },
+    {
+      "ticket_key": "S247-3",
+      "title": "Label canonical source, owning bundle, and generated projection distinctly in focused evidence (#636)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Focused evidence now names the canonical manifest, the owning bundle with its kind, and the projection as generated and read-only. An explicit --path still reports what was read; invalid federation falls back."
+    },
+    {
+      "ticket_key": "S247-4",
+      "title": "Preserve sprint IDs canonically and stop mis-rendering integer IDs ending in 5 (#635)",
+      "club": "driver",
+      "result": "missed_short",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "Canonical string sprint IDs (458.10 distinct from 458.1) not delivered: it is a representational change across roadmap compile, focus, archive, sprint state, scorecards and retro paths. Only the display mis-rendering was fixed.",
+          "gotcha_id": "self:deferred-canonical-ids"
+        }
+      ],
+      "notes": "Found during S246 pre-round, not from the issue: isEncodedInsertedSprintId treats any integer 200-999 ending in 5 as a legacy encoded half-sprint, so this repo own S245 rendered as S24.5. S243 built the evidence-based resolver and used it for ordering but never switched the display paths over."
+    },
+    {
+      "ticket_key": "S247-5",
+      "title": "Exclude docs-only and range-mention commits from shipped-commit detection (#632)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "No production change needed. Verified all three reported subjects already yield no refs on main via hasImplementationCommitType and isSprintRangeEndpoint; the range case was already pinned verbatim. Added the one uncovered case, the forward reference plan S134."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 5,
+    "fairways_total": 5,
+    "greens_in_regulation": 2,
+    "greens_total": 5,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 3,
+    "hazard_penalties": 2,
+    "miss_directions": {
+      "long": 0,
+      "short": 3,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Sprint executed on a branch cut from the S246 branch, so its history stacks."
+  ],
+  "special_plays": [],
+  "bunker_locations": [
+    "src/cli/roadmap-source-store.ts and src/core/roadmap-migration.ts both serialize the projection for digest comparison; planner and applier must agree byte for byte."
+  ],
+  "yardage_book_updates": [
+    "docs/backlog/roadmap.json is generated from docs/roadmap/project.yaml. Author phases in docs/roadmap/phases/ and run slope roadmap compile.",
+    "slope validate mutates tracked files as a side effect: it reconciles scorecard indexes into phase YAML and regenerates the projection.",
+    "Projection bytes are compared in four places: compile write, closeout reconcile, archive plan, and migration receipt digest. Changing the serialized shape touches all of them."
+  ],
+  "course_management_notes": [
+    "Three of five tickets landed partially, each with a documented reason rather than an overrun. The reported harm in every case is fixed; the deferred parts are representational or digest-sensitive work that deserves its own sprint.",
+    "Reverting the marker after seeing seven migration failures was the right call over threading digests thin on remaining context."
+  ]
+}

--- a/docs/roadmap/phases/phase-52.yaml
+++ b/docs/roadmap/phases/phase-52.yaml
@@ -199,3 +199,4 @@ scorecards:
   "229": docs/retros/sprint-229.json
   "230": docs/retros/sprint-230.json
   "231": docs/retros/sprint-231.json
+  "232": docs/retros/sprint-232.json

--- a/docs/roadmap/phases/phase-53.yaml
+++ b/docs/roadmap/phases/phase-53.yaml
@@ -147,3 +147,8 @@ sprints:
         github_issue: 589
         depends_on:
           - S236-3
+scorecards:
+  "235": docs/retros/sprint-235.json
+  "233": docs/retros/sprint-233.json
+  "234": docs/retros/sprint-234.json
+  "236": docs/retros/sprint-236.json

--- a/docs/roadmap/phases/phase-55.yaml
+++ b/docs/roadmap/phases/phase-55.yaml
@@ -14,7 +14,7 @@ sprints:
     par: 5
     slope: 5
     type: bugfix + guard reliability
-    status: planned
+    status: complete
     note: "Fix #631/#630 (worktree-check evaluates hook input.cwd — the launch dir — so a session moved into a worktree is judged against the primary checkout's session store and deadlocks; the guard also auto-registers the denied session as role primary, and slope session start is missing from the recovery exemptions), #625 (claim-required treats out-of-repo scratchpad .ts writes as implementation edits), and #624 (post-merge retro does not advance sprint status across worktrees). Root theme: session identity has uncoordinated channels and guard/CLI resolve different stores, so the guard's own printed remediation can never clear the block."
     tickets:
       - key: S246-1
@@ -53,7 +53,7 @@ sprints:
     par: 5
     slope: 5
     type: bugfix + data integrity
-    status: planned
+    status: complete
     depends_on:
       - 246
     note: "Fix #637 (slope validate regenerates the docs/backlog/roadmap.json projection as a side effect, silently discarding committed edits and exiting success — cost a whole phase of planning work in the Fathoms repo, and reproduced across operators), #636 (focused evidence labels the generated projection as 'Roadmap source'), #635 (sprint IDs are stored as JSON numbers so 458.10 aliases 458.1), and #632 (docs-only commits mentioning a sprint key count as shipped implementation). Also fixes a defect found during S246 pre-round: isEncodedInsertedSprintId treats any integer 200-999 ending in 5 as a legacy encoded half-sprint, so this repo's own S245 renders as S24.5 in slope now and roadmap status."
@@ -110,3 +110,6 @@ sprints:
         club: long_iron
         complexity: moderate
         github_issue: 623
+scorecards:
+  "246": docs/retros/sprint-246.json
+  "247": docs/retros/sprint-247.json

--- a/src/cli/commands/now.ts
+++ b/src/cli/commands/now.ts
@@ -1,4 +1,4 @@
-import { formatSprintLabel, formatSprintNumber, isRoadmapSprintPending, loadScorecards, parseSprintNumber } from '../../core/index.js';
+import { formatSprintLabel, formatRoadmapSprintLabel, formatSprintNumber, isRoadmapSprintPending, loadScorecards, parseSprintNumber } from '../../core/index.js';
 import type { RoadmapDefinition, RoadmapSprint, RoadmapTicket, SprintClaim } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { inferSprintContext, loadRoadmapForInference } from '../sprint-inference.js';
@@ -98,8 +98,11 @@ async function buildNowSnapshot(cwd: string, flags: Record<string, string>): Pro
     throw new Error(`Invalid sprint number: ${flags.sprint}`);
   }
   const sprint = parsedSprint;
-  const sprintLabel = formatSprintLabel(sprint);
   const roadmap = loadRoadmapForInference(cwd, config) ?? undefined;
+  // Without roadmap evidence, an integer like 245 is ambiguous: it could be a
+  // real S245 or the legacy encoding of S24.5. Prefer roadmap-aware labelling so
+  // this repo's own S245 stops rendering as "S24.5" (GH #635).
+  const sprintLabel = roadmap ? formatRoadmapSprintLabel(roadmap, sprint) : formatSprintLabel(sprint);
   const scorecards = loadScorecards(config, cwd);
   const completed = new Set(scorecards.map(card => card.sprint_number));
   const current = roadmap?.sprints.find(s => s.id === sprint);

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -528,7 +528,7 @@ function compileSourcesSubcommand(flags: Record<string, string>, cwd: string): v
       return;
     }
 
-    const result = writeRoadmapSourceProjection(store);
+    const result = writeRoadmapSourceProjection(store, { force: flags.force === 'true' });
     console.log(`\nRoadmap projection ${result}: ${output}`);
     console.log(`  Sources: ${store.sources.length}; phases: ${store.roadmap.phases.length}; sprints: ${store.roadmap.sprints.length}\n`);
   } catch (error) {
@@ -1190,7 +1190,7 @@ Usage:
   slope roadmap focus --sprint=N [--path=<file>] [--json]     Bounded sprint context
   slope roadmap migrate [--path=<file>] [--source=<file>] [--mapping=<file>] [--dry-run]
                                                 Plan or apply single-file federation migration
-  slope roadmap compile [--source=<file>] [--dry-run|--check] Compile modular YAML sources
+  slope roadmap compile [--source=<file>] [--dry-run|--check] [--force] Compile modular YAML sources
   slope roadmap complete --sprint=N [--source=<file>] [--scorecard=<path>] [--dry-run]
                                                 Mark a modular source sprint complete and compile projection
   slope roadmap validate-sources [--source=<file>]            Validate sources and projection drift

--- a/src/cli/commands/roadmap.ts
+++ b/src/cli/commands/roadmap.ts
@@ -8,7 +8,6 @@ import {
   compareSprintIds,
   computeCriticalPath,
   findParallelOpportunities,
-  formatSprintLabel,
   formatSprintNumber,
   formatRoadmapSummary,
   formatStrategicContext,
@@ -107,7 +106,7 @@ function statusLabelForSprint(
   if (isSuperseded) return '\u21B7 superseded';
   if (isCompleted) return '\u2713 completed';
   if (isCurrent) return '\u25B6 active';
-  if (blockedBy.length > 0) return `\u2718 blocked by ${blockedBy.map(formatSprintLabel).join(', ')}`;
+  if (blockedBy.length > 0) return `\u2718 blocked by ${blockedBy.map(dep => formatRoadmapSprintLabel(roadmap, dep)).join(', ')}`;
   return '\u25CB pending';
 }
 
@@ -763,7 +762,7 @@ function printFullRoadmapStatus(
 ): void {
   console.log(`\n# Roadmap Status — ${roadmap.name}`);
   console.log('\u2550'.repeat(40));
-  console.log(`\nCurrent sprint: ${formatSprintLabel(currentSprint)}`);
+  console.log(`\nCurrent sprint: ${formatRoadmapSprintLabel(roadmap, currentSprint)}`);
   console.log('');
 
   for (const phase of roadmap.phases || []) {
@@ -799,13 +798,13 @@ function printFullRoadmapStatus(
       } else if (isCurrent) {
         status = '\u25B6 active';
       } else if (isBlocked) {
-        status = `\u2718 blocked by ${blockedBy.map(formatSprintLabel).join(', ')}`;
+        status = `\u2718 blocked by ${blockedBy.map(dep => formatRoadmapSprintLabel(roadmap, dep)).join(', ')}`;
       } else {
         status = '\u25CB pending';
       }
 
       const theme = sprint.theme || 'Untitled Sprint';
-      console.log(`  ${formatSprintLabel(sprint.id)} ${theme.padEnd(30)} ${status}`);
+      console.log(`  ${formatRoadmapSprintLabel(roadmap, sprint.id)} ${theme.padEnd(30)} ${status}`);
     }
     console.log('');
   }
@@ -827,8 +826,8 @@ function printCompactRoadmapStatus(
 ): void {
   const current = roadmap.sprints.find(s => s.id === currentSprint);
   const currentLabel = current
-    ? `${formatSprintLabel(current.id)} ${current.theme || 'Untitled Sprint'}`
-    : `${formatSprintLabel(currentSprint)} (not found in roadmap)`;
+    ? `${formatRoadmapSprintLabel(roadmap, current.id)} ${current.theme || 'Untitled Sprint'}`
+    : `${formatRoadmapSprintLabel(roadmap, currentSprint)} (not found in roadmap)`;
   const currentIsPending = current ? isRoadmapSprintPending(current) : false;
   const currentPhase = phaseForSprint(roadmap, currentSprint);
   const pendingAfterCurrent = sortedRoadmapSprints(roadmap)
@@ -851,14 +850,14 @@ function printCompactRoadmapStatus(
 
   console.log('\nActive sprint:');
   if (!current) {
-    console.log(`  ${formatSprintLabel(currentSprint)} is not defined in the roadmap.`);
+    console.log(`  ${formatRoadmapSprintLabel(roadmap, currentSprint)} is not defined in the roadmap.`);
   } else {
-    console.log(`  ${formatSprintLabel(current.id)} ${current.theme || 'Untitled Sprint'} - ${statusLabelForSprint(roadmap, current, currentSprint, completedSprints)}`);
+    console.log(`  ${formatRoadmapSprintLabel(roadmap, current.id)} ${current.theme || 'Untitled Sprint'} - ${statusLabelForSprint(roadmap, current, currentSprint, completedSprints)}`);
     if ((current.depends_on ?? []).length > 0) {
       const deps = current.depends_on!.map(dep => {
         const sprint = roadmap.sprints.find(s => s.id === dep);
-        if (!sprint) return `${formatSprintLabel(dep)} missing`;
-        return `${formatSprintLabel(dep)} ${statusLabelForSprint(roadmap, sprint, currentSprint, completedSprints).replace(/^[^\w]+ /, '')}`;
+        if (!sprint) return `${formatRoadmapSprintLabel(roadmap, dep)} missing`;
+        return `${formatRoadmapSprintLabel(roadmap, dep)} ${statusLabelForSprint(roadmap, sprint, currentSprint, completedSprints).replace(/^[^\w]+ /, '')}`;
       });
       console.log(`  Dependencies: ${deps.join(', ')}`);
     }
@@ -869,7 +868,7 @@ function printCompactRoadmapStatus(
 
   console.log('\nNext ready:');
   if (nextReady) {
-    console.log(`  ${formatSprintLabel(nextReady.id)} ${nextReady.theme || 'Untitled Sprint'} - ${statusLabelForSprint(roadmap, nextReady, currentSprint, completedSprints)}`);
+    console.log(`  ${formatRoadmapSprintLabel(roadmap, nextReady.id)} ${nextReady.theme || 'Untitled Sprint'} - ${statusLabelForSprint(roadmap, nextReady, currentSprint, completedSprints)}`);
   } else {
     console.log('  None yet');
   }
@@ -879,7 +878,7 @@ function printCompactRoadmapStatus(
     console.log('  None');
   } else {
     for (const sprint of upcoming) {
-      console.log(`  ${formatSprintLabel(sprint.id)} ${sprint.theme || 'Untitled Sprint'} - ${statusLabelForSprint(roadmap, sprint, currentSprint, completedSprints)}`);
+      console.log(`  ${formatRoadmapSprintLabel(roadmap, sprint.id)} ${sprint.theme || 'Untitled Sprint'} - ${statusLabelForSprint(roadmap, sprint, currentSprint, completedSprints)}`);
     }
   }
 
@@ -890,7 +889,7 @@ function printCompactRoadmapStatus(
     const first = current.tickets[0];
     console.log(`  Work ${first.key}: ${first.title}`);
   } else if (nextReady) {
-    console.log(`  Start ${formatSprintLabel(nextReady.id)}: ${nextReady.theme || 'Untitled Sprint'}`);
+    console.log(`  Start ${formatRoadmapSprintLabel(roadmap, nextReady.id)}: ${nextReady.theme || 'Untitled Sprint'}`);
   } else {
     console.log('  No roadmap action is currently ready.');
   }

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -12,6 +12,7 @@ import {
 import { loadConfig } from '../config.js';
 import { updateGate } from '../sprint-state.js';
 import { completeRoadmapSourceSprint } from '../roadmap-source-store.js';
+import type { RoadmapSourceError } from '../../core/index.js';
 
 export function validateCommand(input?: string | string[]): void {
   const args = Array.isArray(input) ? input : input ? [input] : [];
@@ -100,16 +101,28 @@ export function validateCommand(input?: string | string[]): void {
   console.log('');
 
   // Mark scorecard gate complete on successful validation
+  let reconciled = true;
   if (allValid && registryAvailable) {
     updateGate(cwd, 'scorecard', true);
-    reconcileModularRoadmapSources(cwd, validScorecards);
+    reconciled = reconcileModularRoadmapSources(cwd, validScorecards);
   }
 
-  process.exit(allValid && registryAvailable ? 0 : 1);
+  process.exit(allValid && registryAvailable && reconciled ? 0 : 1);
 }
 
-function reconcileModularRoadmapSources(cwd: string, scorecards: Array<{ sprint: number; path: string }>): void {
-  if (!existsSync(join(cwd, 'docs', 'roadmap', 'project.yaml'))) return;
+/**
+ * Reconcile closeout status into the modular sources.
+ *
+ * Returns false when reconciliation was blocked by a refusal to discard authored
+ * projection content. That must fail the command: exiting 0 while planning work
+ * is silently destroyed is the defect itself (GH #637).
+ */
+function reconcileModularRoadmapSources(
+  cwd: string,
+  scorecards: Array<{ sprint: number; path: string }>,
+): boolean {
+  if (!existsSync(join(cwd, 'docs', 'roadmap', 'project.yaml'))) return true;
+  let ok = true;
   for (const scorecard of scorecards) {
     try {
       const result = completeRoadmapSourceSprint(cwd, scorecard.sprint, {
@@ -120,10 +133,17 @@ function reconcileModularRoadmapSources(cwd: string, scorecards: Array<{ sprint:
         console.log(`  ⚠ ${result.source} could not be patched surgically and was rewritten in canonical YAML style.`);
       }
     } catch (error) {
+      if ((error as RoadmapSourceError).projectionContentLoss) {
+        // Report once, not per scorecard \u2014 the cause is the projection, not the sprint.
+        if (ok) console.error(`\n\u2717 ${(error as Error).message}\n`);
+        ok = false;
+        continue;
+      }
       console.log(`  \u26A0 Roadmap source not reconciled for S${scorecard.sprint}: ${(error as Error).message}`);
       console.log(`    Run: slope roadmap complete --sprint=${scorecard.sprint}`);
     }
   }
+  return ok;
 }
 
 function parseRequestedSprint(args: string[], sprintArgIndex: number): number | null {

--- a/src/cli/roadmap-source-store.ts
+++ b/src/cli/roadmap-source-store.ts
@@ -12,6 +12,7 @@ import {
   roadmapSprintOrderValue,
   RoadmapSourceError,
   serializeRoadmapProjection,
+  findRoadmapProjectionDivergence,
   validateRoadmapSourceFederation,
   type LoadedRoadmapSource,
   type RoadmapDefinition,
@@ -116,7 +117,15 @@ export function loadRoadmapSourceStore(cwd: string, sourceFlag?: string): Roadma
   return { cwd, manifestPath, sourceRoot, outputPath, project, sources, roadmap, projection };
 }
 
-export function writeRoadmapSourceProjection(store: RoadmapSourceStore): 'written' | 'unchanged' {
+export interface WriteRoadmapProjectionOptions {
+  /** Overwrite even when the on-disk projection holds content no source produces. */
+  force?: boolean;
+}
+
+export function writeRoadmapSourceProjection(
+  store: RoadmapSourceStore,
+  options: WriteRoadmapProjectionOptions = {},
+): 'written' | 'unchanged' {
   const federationLock = join(store.sourceRoot, '.federation');
   return withFileLockSync(federationLock, () => {
     const fresh = loadRoadmapSourceStore(store.cwd, relative(store.cwd, store.manifestPath));
@@ -129,9 +138,44 @@ export function writeRoadmapSourceProjection(store: RoadmapSourceStore): 'writte
     }
     const existing = existsSync(fresh.outputPath) ? readFileSync(fresh.outputPath, 'utf8') : null;
     if (existing != null && roadmapProjectionMatches(existing, fresh.projection)) return 'unchanged';
+    if (existing != null && !options.force) assertNoProjectionContentLoss(fresh, existing);
     atomicWriteFileSync(fresh.outputPath, fresh.projection);
     return 'written';
   });
+}
+
+/**
+ * Refuse to silently discard authored content that exists only in the projection.
+ *
+ * `slope validate` regenerated the projection as a side effect and reported
+ * success, so a phase, six sprints and 26 tickets edited into the generated file
+ * vanished with no error, no warning and no diff — and it reproduced across
+ * operators, because nothing in the file said it was generated (GH #637).
+ */
+export function assertNoProjectionContentLoss(store: RoadmapSourceStore, existing: string): void {
+  const divergence = findRoadmapProjectionDivergence(existing, store.roadmap);
+  if (!divergence) return;
+
+  const target = normalizeDiagnosticPath(relative(store.cwd, store.outputPath));
+  const manifest = normalizeDiagnosticPath(relative(store.cwd, store.manifestPath));
+  const lines = [
+    `Refusing to overwrite ${target}: it contains planning work that no roadmap source produces.`,
+    `${target} is a GENERATED projection of ${manifest}. Rewriting it would discard:`,
+  ];
+  if (divergence.phases.length > 0) {
+    lines.push(`  phases: ${divergence.phases.join(', ')}`);
+  }
+  if (divergence.sprints.length > 0) {
+    lines.push(`  sprints: ${divergence.sprints.map(id => `S${id}`).join(', ')}`);
+  }
+  lines.push(
+    '',
+    'Move this work into the modular sources under docs/roadmap/, then re-run',
+    '`slope roadmap compile`. To discard it deliberately, re-run with --force.',
+  );
+  const error = new RoadmapSourceError(lines.join('\n'));
+  error.projectionContentLoss = true;
+  throw error;
 }
 
 export interface CompleteRoadmapSourceSprintResult {
@@ -286,6 +330,9 @@ export function completeRoadmapSourceSprint(
     const projection = existing != null && roadmapProjectionMatches(existing, reloaded.projection)
       ? 'unchanged'
       : 'written';
+    // Closeout reconciliation runs from `slope validate`, which is where the
+    // silent projection rewrite destroyed authored planning work (GH #637).
+    if (projection === 'written' && existing != null) assertNoProjectionContentLoss(reloaded, existing);
     if (projection === 'written') atomicWriteFileSync(reloaded.outputPath, reloaded.projection);
     return { source: sourceLabel, projection, changed: true, reformatted };
   });

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -229,6 +229,7 @@ export {
   sourceProjectToRoadmap,
   compileRoadmapSources,
   serializeRoadmapProjection,
+  findRoadmapProjectionDivergence,
   validateRoadmapSourceFederation,
 } from './roadmap-sources.js';
 export type {

--- a/src/core/roadmap-sources.ts
+++ b/src/core/roadmap-sources.ts
@@ -48,6 +48,14 @@ export interface RoadmapSourceValidationResult {
 }
 
 export class RoadmapSourceError extends Error {
+  /**
+   * True when the failure is a refusal to discard authored content that exists
+   * only in the generated projection. Callers must treat this as fatal rather
+   * than downgrading it to a warning — reporting success while planning work is
+   * destroyed is the whole defect (GH #637).
+   */
+  projectionContentLoss?: boolean;
+
   constructor(
     message: string,
     readonly sourcePath?: string,
@@ -398,6 +406,57 @@ export function compileRoadmapSources(
 
 export function serializeRoadmapProjection(roadmap: RoadmapDefinition): string {
   return `${JSON.stringify(roadmap, null, 2)}\n`;
+}
+
+export interface RoadmapProjectionDivergence {
+  /** Sprint ids present in the on-disk projection but produced by no source. */
+  sprints: string[];
+  /** Phase names present in the on-disk projection but produced by no source. */
+  phases: string[];
+}
+
+/**
+ * Find content that exists only in the checked-out projection.
+ *
+ * A projection that merely lags its sources contains nothing the sources do not
+ * produce, so it is safe to overwrite. Content present *only* on disk is
+ * authored planning work that a blind rewrite would destroy — which is exactly
+ * how a phase, six sprints and 26 tickets were lost on a success exit (GH #637).
+ *
+ * Returns null when nothing would be lost.
+ */
+export function findRoadmapProjectionDivergence(
+  existing: string,
+  compiled: RoadmapDefinition,
+): RoadmapProjectionDivergence | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(existing);
+  } catch {
+    // Unparseable projections carry no recoverable authored content.
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const disk = parsed as { phases?: unknown; sprints?: unknown };
+
+  const compiledSprints = new Set((compiled.sprints ?? []).map(sprint => String(sprint.id)));
+  const diskSprints = Array.isArray(disk.sprints) ? disk.sprints : [];
+  const sprints = diskSprints
+    .map(sprint => (sprint && typeof sprint === 'object' ? (sprint as { id?: unknown }).id : undefined))
+    .filter(id => id != null)
+    .map(id => String(id))
+    .filter(id => !compiledSprints.has(id));
+
+  const compiledPhases = new Set((compiled.phases ?? []).map(phase => phase.name));
+  const diskPhases = Array.isArray(disk.phases) ? disk.phases : [];
+  const phases = diskPhases
+    .map(phase => (phase && typeof phase === 'object' ? (phase as { name?: unknown }).name : undefined))
+    .filter((name): name is string => typeof name === 'string')
+    .filter(name => !compiledPhases.has(name));
+
+  if (sprints.length === 0 && phases.length === 0) return null;
+  return { sprints: [...new Set(sprints)], phases: [...new Set(phases)] };
 }
 
 function sourceLabel(source: LoadedRoadmapSource): string {

--- a/tests/cli/roadmap-sources.test.ts
+++ b/tests/cli/roadmap-sources.test.ts
@@ -9,7 +9,9 @@ import {
   loadRoadmapSourceStore,
   planRoadmapSourceArchive,
   roadmapProjectionMatches,
+  writeRoadmapSourceProjection,
 } from '../../src/cli/roadmap-source-store.js';
+import { findRoadmapProjectionDivergence } from '../../src/core/index.js';
 
 let cwd: string;
 let originalCwd: string;
@@ -724,5 +726,76 @@ sprints:
     expect(() => completeRoadmapSourceSprint(cwd, 9, {}))
       .toThrow(/ambiguous identity/);
     expect(readFileSync(join(root, 'phases', 'phase-01.yaml'), 'utf8')).toBe(before);
+  });
+});
+
+describe('projection content-loss protection (GH #637)', () => {
+  function projectionWithExtra(output: string, mutate: (data: Record<string, unknown>) => void): void {
+    const data = JSON.parse(readFileSync(output, 'utf8')) as Record<string, unknown>;
+    mutate(data);
+    writeFileSync(output, `${JSON.stringify(data, null, 2)}
+`);
+  }
+
+  it('refuses to discard a phase that exists only in the projection', () => {
+    const output = writeFixture();
+    let store = loadRoadmapSourceStore(cwd, 'docs/roadmap/project.yaml');
+    writeRoadmapSourceProjection(store);
+
+    projectionWithExtra(output, data => {
+      (data.phases as unknown[]).push({ name: 'Phase 99 — Authored', sprints: [9001], status: 'in_progress' });
+      (data.sprints as unknown[]).push({ id: 9001, theme: 'Authored', par: 3, slope: 1, status: 'planned', tickets: [] });
+    });
+    const before = readFileSync(output, 'utf8');
+
+    store = loadRoadmapSourceStore(cwd, 'docs/roadmap/project.yaml');
+    expect(() => writeRoadmapSourceProjection(store)).toThrow(/Phase 99 — Authored/);
+    // The authored work must survive the refusal.
+    expect(readFileSync(output, 'utf8')).toBe(before);
+  });
+
+  it('names the projection-only sprints in the refusal', () => {
+    const output = writeFixture();
+    let store = loadRoadmapSourceStore(cwd, 'docs/roadmap/project.yaml');
+    writeRoadmapSourceProjection(store);
+    projectionWithExtra(output, data => {
+      (data.sprints as unknown[]).push({ id: 9002, theme: 'Only here', par: 3, slope: 1, status: 'planned', tickets: [] });
+    });
+
+    store = loadRoadmapSourceStore(cwd, 'docs/roadmap/project.yaml');
+    expect(() => writeRoadmapSourceProjection(store)).toThrow(/S9002/);
+  });
+
+  it('overwrites projection-only content when --force is passed', () => {
+    const output = writeFixture();
+    let store = loadRoadmapSourceStore(cwd, 'docs/roadmap/project.yaml');
+    writeRoadmapSourceProjection(store);
+    projectionWithExtra(output, data => {
+      (data.sprints as unknown[]).push({ id: 9003, theme: 'Discard me', par: 3, slope: 1, status: 'planned', tickets: [] });
+    });
+
+    store = loadRoadmapSourceStore(cwd, 'docs/roadmap/project.yaml');
+    expect(writeRoadmapSourceProjection(store, { force: true })).toBe('written');
+    expect(readFileSync(output, 'utf8')).not.toContain('9003');
+  });
+
+  it('still rewrites a merely stale projection without --force', () => {
+    const output = writeFixture();
+    let store = loadRoadmapSourceStore(cwd, 'docs/roadmap/project.yaml');
+    writeRoadmapSourceProjection(store);
+    // Staleness in the safe direction: the projection lags its sources, holding
+    // nothing the sources do not produce.
+    projectionWithExtra(output, data => {
+      (data.sprints as unknown[]).pop();
+      (data.phases as unknown[]).pop();
+    });
+
+    store = loadRoadmapSourceStore(cwd, 'docs/roadmap/project.yaml');
+    expect(writeRoadmapSourceProjection(store)).toBe('written');
+    expect(roadmapProjectionMatches(readFileSync(output, 'utf8'), store.projection)).toBe(true);
+  });
+
+  it('reports no divergence for an unparseable projection', () => {
+    expect(findRoadmapProjectionDivergence('not json', { name: 'x', phases: [], sprints: [] })).toBeNull();
   });
 });

--- a/tests/core/analyzers/git.test.ts
+++ b/tests/core/analyzers/git.test.ts
@@ -217,6 +217,14 @@ describe('extractSprintReferences', () => {
     ])).toEqual(new Set());
   });
 
+  it('does not treat a forward-planning mention as a shipped sprint ref (GH #632)', () => {
+    // "plan S134" announces future work; S134 was never implemented. Counting it
+    // made `slope roadmap validate` demand status "complete" and exit 1.
+    expect(extractSprintReferences([
+      'docs: close S133 (reverted) + verified UCP findings + plan S134 (#339)',
+    ])).toEqual(new Set());
+  });
+
   it('does not match S75 inside S75.5', () => {
     expect(extractSprintReferences(['feat(S75.5): The Bug Clearing'])).toEqual(new Set());
   });

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -8,6 +8,7 @@ import {
   formatRoadmapSummary,
   formatStrategicContext,
   formatSprintLabel,
+  formatRoadmapSprintLabel,
   nextCanonicalSprintId,
   parseSprintNumber,
   sprintOrderValue,
@@ -882,5 +883,37 @@ describe('formatStrategicContext next-sprint output', () => {
     });
     const context = formatStrategicContext(roadmap, 9);
     expect(context).not.toContain('Next:');
+  });
+});
+
+describe('roadmap-aware sprint labelling (GH #635)', () => {
+  function roadmapWith(id: number, ticketKey: string) {
+    return {
+      name: 'r',
+      phases: [{ name: 'P', sprints: [id] }],
+      sprints: [{
+        id,
+        theme: 'T',
+        par: 3,
+        slope: 1,
+        tickets: [{ key: ticketKey, title: 'x', club: 'wedge' as const, complexity: 'small' as const }],
+      }],
+    };
+  }
+
+  it('renders a real three-digit sprint ending in 5 as itself, not a decimal', () => {
+    // Bare formatSprintLabel cannot disambiguate: any integer 200-999 ending in 5
+    // looks like the legacy encoding, so this repo's own S245 rendered "S24.5".
+    expect(formatSprintLabel(245)).toBe('S24.5');
+    // With roadmap evidence (ticket keys prove the canonical identity) it is correct.
+    expect(formatRoadmapSprintLabel(roadmapWith(245, 'S245-1'), 245)).toBe('S245');
+  });
+
+  it.each([205, 215, 225, 235, 245, 255])('resolves S%i from roadmap evidence', id => {
+    expect(formatRoadmapSprintLabel(roadmapWith(id, `S${id}-1`), id)).toBe(`S${id}`);
+  });
+
+  it('still renders a genuinely encoded inserted sprint as a decimal', () => {
+    expect(formatRoadmapSprintLabel(roadmapWith(435, 'S43.5-1'), 435)).toBe('S43.5');
   });
 });


### PR DESCRIPTION
S247 of Phase 55. **Second of three stacked PRs — based on `feat/S246-session-worktree-isolation`; merge that one first.**

## What this fixes

### #637 — `slope validate` silently destroyed planning work (the serious one)

With federated sources, `docs/backlog/roadmap.json` is a generated projection that `slope validate` regenerated as a side effect. Edits were discarded with **no error, no warning, no diff — and exit 0**. One run cost a phase, six sprints with 26 tickets, three deferrals and two status changes, and it reproduced across operators because nothing in the file said it was generated.

Reproduced on this repo before fixing: an injected phase + sprint vanished on `slope validate`, exit 0.

- `findRoadmapProjectionDivergence` reports phases and sprint ids present on disk but produced by no source. A projection that merely *lags* its sources contains nothing the sources don't produce, so the safe direction still rewrites silently — only content existing **only** on disk blocks the write.
- Both write paths (`roadmap compile`, and closeout reconciliation reached from `slope validate`) refuse such a write, naming the exact phases and sprints at risk. `--force` discards deliberately.
- `RoadmapSourceError.projectionContentLoss` stops callers downgrading the refusal to a warning. `validate` previously caught the error, printed a per-sprint note and still exited 0 — reporting success while destroying planning work is the defect itself. It now reports once and **exits 1**.

### #636 — projection mislabeled as source

Focused evidence labelled the generated file flatly "Roadmap source". Agents read that as authority and edit it — which #637 then destroys. Evidence now reports the canonical manifest, the owning bundle with its kind, and the projection as *generated, read-only*.

### #635 — partially fixed

Found during the S246 pre-round, not from the issue: `isEncodedInsertedSprintId` treats **any** integer 200–999 ending in 5 as a legacy encoded half-sprint, so this repo's own S245 rendered as **"S24.5"** (also S205/S215/S225/S235/S255). S243 built the evidence-based resolver and used it for ordering but never switched the display paths over — the same fix-one-consumer pattern this repo records as a recurring hazard. 13 call sites now use it.

### #632 — already fixed; verified

All three reported subjects already yield no refs on main (`hasImplementationCommitType` + `isSprintRangeEndpoint`), and the range case was already pinned verbatim. Added the one uncovered case: the forward reference `plan S134`. No production change.

## Deliberately deferred — please read

Three items are **not** in this PR, each recorded as an architect finding with rationale rather than silently dropped:

1. **The in-file `_generated` marker** (#637 fix 1). Implemented, then reverted: making `store.projection` carry it broke seven roadmap-migration tests, because the planner computes `expected_projection_sha256` and the applier recomputes it, so both sides plus the archive comparison must agree byte-for-byte. Threading a marker through migration digests risks receipt binding and rollback integrity. Needs its own ticket. **The data loss is prevented regardless**, and the refusal message states plainly that the file is generated.
2. **Making `validate` wholly read-only** (#637 fix 3). Removing regeneration would also remove the closeout source reconciliation this repo's own workflow depends on. The write is now safe and exits 1; a `validate` that mutates tracked files remains surprising.
3. **Canonical string sprint IDs** — #635's actual request, that `458.10` stay distinct from `458.1`. That's a representational change across roadmap compile/focus/archive, sprint state, scorecards and retro paths, and needs round-trip tests. **#635 is therefore referenced, not closed.**

## Verification

Build, typecheck and the full suite clean — 4099 tests. New coverage for divergence refusal, `--force`, the safe stale direction, unparseable projections, federated evidence labelling, and roadmap-aware labels across S205–S255.

## Review status

⚠️ Required review gates carry an explicit `independent_review_waived` (no subagents per operator direction). **Independent architecture review recommended, particularly on the deferred marker/migration-digest coupling.**

Closes #637. Closes #636. Closes #632.

Refs #635 — display mis-rendering fixed; canonical ID representation still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
