### PR TITLE
Phase 57: sprint identity safety and diagnosability (#635, #646, #648, #649, #651)

### DIFF
--- a/.claude/rules/branch-discipline.md
+++ b/.claude/rules/branch-discipline.md
@@ -19,6 +19,31 @@ Branch names: lowercase, hyphen-separated. Sprint number prefix is optional.
 3. **Check current branch BEFORE first commit** — if on main, create a branch first
 4. **Unrelated fixes get their own branch** — don't bundle
 
+## Multiple sprints in flight (stacked PRs)
+
+Sequential sprints naturally produce a stack — PR 2 based on PR 1's branch. GitHub and
+squash-merging fight this, so prefer **one phase branch** with per-sprint commits reviewed as a
+single PR. That keeps sprint granularity in history and avoids everything below.
+
+If you do stack PRs, all three rules apply or you will lose work:
+
+1. **Merge the base with a merge commit, never squash.** Squashing rewrites history, so every
+   dependent PR immediately conflicts against `main` even when it is a strict superset of what
+   just merged.
+2. **Never `--delete-branch` a base that has dependents.** Deleting it *closes* the dependent PR, and
+   a closed PR cannot be retargeted (`Cannot change the base branch of a closed pull request`).
+   Its `Closes #N` trailers never fire, so fixed issues stay open with their code already on `main`.
+3. **Merge strictly in order**, retargeting each dependent to `main` before merging it.
+
+Also: `sprint-completion` infers the sprint from the branch name, so a branch carrying several
+sprints is refused once state advances past the first — `State: Sprint 250; branch suggests Sprint 249`.
+Name multi-sprint branches after the phase (`chore/phase-56-...`), not a sprint.
+
+Each PR also needs its own scorecard **and** its rollover lineage audit present on the branch
+being PR'd, not merely somewhere in the stack.
+
+Landing Phase 55-56 as four stacked PRs cost three recoveries to exactly these. See #648.
+
 ## Recovery
 
 If you realize you're on main after making changes:

--- a/.claude/rules/sprint-checklist.md
+++ b/.claude/rules/sprint-checklist.md
@@ -27,6 +27,26 @@ Before writing any code in a new sprint:
 6. **Gap analysis** (if touching API or schema) — Read relevant docs and compare against implementation before writing code
 7. **Set par and slope** — Par from ticket count (1-2=3, 3-4=4, 5+=5), slope from complexity factors
 
+## Sprint State Gate (Before ANY Implementation Write)
+
+Before the first Edit/Write of a work session **and again after every PR merge**, confirm sprint state is `implementing` for the sprint you are about to work on:
+
+```
+slope sprint status
+```
+
+If the phase is anything else — `complete`, `scoring`, `planning`, or a different sprint — transition first:
+
+```
+slope sprint rollover --from=<current> --to=<next>
+slope sprint start --number=<next> --phase=implementing
+slope claim --target=<area> --ticket=<key> --scope=area
+```
+
+**Why:** `claim-required` returns `ask` on every implementation write when state is absent or in a non-implementing phase, so the operator gets a host permission prompt per edit. `slope pr` sets the phase to `scoring` automatically the moment a PR merges, so starting the next sprint's work always trips this unless state is advanced first. The remedy is entirely agent-actionable — never make the operator answer for it.
+
+Observed twice in one session: at session start (state left at a long-completed sprint) and immediately after a merge.
+
 ## Pre-Shot Routine (Per-Ticket, Before Code)
 
 Before starting each ticket:

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -480,6 +480,16 @@
       ],
       "status": "in_progress",
       "note": "Issue-driven recovery for #641, #642, #643, #644, #645 — all self-reported from the Phase 55 run. #645 makes a clean checkout fail to install on pnpm 8 with an error that names the wrong cause, and lets CI float to whatever latest pnpm means; #643 raises a host permission prompt on every implementation write in the mode that advertises guards are silenced; #641/#642 are lifecycle and claim-state safety, where a plausible command silently does the opposite of what was asked; #644 completes the two #637 fixes deferred from S247."
+    },
+    {
+      "name": "Phase 57 — Identity Safety and Diagnosability",
+      "description": "The tail of the July issue batch: the two items deliberately left open after Phase 56, plus the stacked-PR workflow gap that landing Phase 55-56 exposed. Identity safety first because silent aliasing corrupts data; diagnosability second because opaque refusals cost a source read each.",
+      "sprints": [
+        252,
+        253
+      ],
+      "status": "in_progress",
+      "note": "Closes out #635, #646 and #648. #635 cannot be fully fixed without canonical string sprint ids — a representational change across roadmap compile/focus/archive, sprint state, scorecards, retro paths and the store schema — so S252 removes the silent-corruption path and defers the representation. #646 and #648 are both about failures that are reachable in normal use but not diagnosable without reading source."
     }
   ],
   "sprints": [
@@ -6457,6 +6467,82 @@
           "club": "wedge",
           "complexity": "small",
           "github_issue": 644
+        }
+      ]
+    },
+    {
+      "id": 252,
+      "theme": "Sprint Identity Safety",
+      "par": 4,
+      "slope": 3,
+      "type": "bugfix + data integrity",
+      "status": "planned",
+      "note": "Fix the harmful half of #635: sprint ids are stored as JSON numbers, so a decimal whose fraction ends in zero silently aliases another sprint (458.10 reads back as 458.1; 458.0 as 458). Reject those at every entry point with a message that says how to renumber, rather than corrupting dependencies, focused context, evidence lookup and scorecard identity. The canonical-string representation stays deferred and #635 stays open for it.",
+      "tickets": [
+        {
+          "key": "S252-1",
+          "title": "Reject decimal sprint ids whose fraction ends in zero, with a renumbering message (#635)",
+          "club": "long_iron",
+          "complexity": "moderate",
+          "github_issue": 635
+        },
+        {
+          "key": "S252-2",
+          "title": "Fail roadmap source authoring on an ambiguous sprint id instead of compiling it (#635)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 635,
+          "depends_on": [
+            "S252-1"
+          ]
+        },
+        {
+          "key": "S252-3",
+          "title": "Add round-trip coverage for 458.1, 458.9, 458.10, 458.11 and 459 (#635)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 635,
+          "depends_on": [
+            "S252-1"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 253,
+      "theme": "Diagnosability and Branch Workflow",
+      "par": 4,
+      "slope": 2,
+      "type": "bugfix + agent ergonomics",
+      "status": "planned",
+      "depends_on": [
+        252
+      ],
+      "note": "Fix #646 (rollover audit validation reports a blanket 'invalid shape' naming no field, so diagnosing it required reading the validator — it was a field absent rather than malformed) and #648 (stacked sprint PRs are unsupported: squash-merging the base makes every dependent conflict, --delete-branch closes them outright so their Closes trailers never fire, and until Phase 56 they ran no CI). Landing Phase 55-56 cost three recoveries to this.",
+      "tickets": [
+        {
+          "key": "S253-1",
+          "title": "Name the failing field when refusing a rollover audit instead of reporting invalid shape (#646)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 646
+        },
+        {
+          "key": "S253-2",
+          "title": "Document stacked-PR rules in branch discipline — merge order, no squash on a base, no branch delete (#648)",
+          "club": "wedge",
+          "complexity": "small",
+          "github_issue": 648
+        },
+        {
+          "key": "S253-3",
+          "title": "Warn at PR creation when the base is not main so the stack rules are seen before they bite (#648)",
+          "club": "short_iron",
+          "complexity": "standard",
+          "github_issue": 648,
+          "depends_on": [
+            "S253-2"
+          ]
         }
       ]
     }

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -6476,7 +6476,7 @@
       "par": 4,
       "slope": 3,
       "type": "bugfix + data integrity",
-      "status": "planned",
+      "status": "complete",
       "note": "Fix the harmful half of #635: sprint ids are stored as JSON numbers, so a decimal whose fraction ends in zero silently aliases another sprint (458.10 reads back as 458.1; 458.0 as 458). Reject those at every entry point with a message that says how to renumber, rather than corrupting dependencies, focused context, evidence lookup and scorecard identity. The canonical-string representation stays deferred and #635 stays open for it.",
       "tickets": [
         {
@@ -6514,7 +6514,7 @@
       "par": 4,
       "slope": 2,
       "type": "bugfix + agent ergonomics",
-      "status": "planned",
+      "status": "complete",
       "depends_on": [
         252
       ],

--- a/docs/retros/rollovers/sprint-251-to-252-f3b3e6125b7896a1.json
+++ b/docs/retros/rollovers/sprint-251-to-252-f3b3e6125b7896a1.json
@@ -1,0 +1,261 @@
+{
+  "version": 1,
+  "kind": "sprint_rollover",
+  "transition_id": "d6be4a9bb2bc441b",
+  "from_sprint": 251,
+  "to_sprint": 252,
+  "from_label": "S251",
+  "to_label": "S252",
+  "recorded_at": "2026-07-25T17:18:32.631Z",
+  "actor": {
+    "name": "srbry",
+    "source": "env:USERNAME"
+  },
+  "request": {
+    "from": 251,
+    "to": 252,
+    "force": false
+  },
+  "forced": false,
+  "eligibility": {
+    "from_terminal": true,
+    "target_dependency_eligible": true,
+    "blocking_dependencies": [],
+    "target_dependencies": [],
+    "completion_evidence": {
+      "roadmap_complete": [
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        114.5,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        137.5,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        143.5,
+        143.6,
+        143.7,
+        143.8,
+        143.9,
+        143.95,
+        143.97,
+        143.98,
+        143.99,
+        144,
+        145,
+        146,
+        146.1,
+        146.2,
+        146.3,
+        148,
+        149,
+        150,
+        151,
+        151.1,
+        152,
+        152.1,
+        153,
+        154,
+        216,
+        217,
+        218,
+        219,
+        220,
+        221,
+        222,
+        223,
+        224,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        233,
+        234,
+        235,
+        236,
+        241,
+        242,
+        243,
+        244,
+        246,
+        247,
+        248,
+        249,
+        250,
+        251
+      ],
+      "scorecards": [],
+      "local_terminal": [
+        251
+      ]
+    },
+    "scorecard_artifacts": [],
+    "expected_next": 252
+  },
+  "roadmap": {
+    "path": "docs/backlog/roadmap.json",
+    "sha256": "2f6912f4228158ea018b750144084fc7b1f147079b3e537b5ee691dc4188a9c1",
+    "from_status": "complete",
+    "to_status": "planned"
+  },
+  "prior_state_sha256": "abbb6aaedec19fad6ffc27a3f1c2098b00c89d411d5705fb36e33c73e192cb77",
+  "prior_state": {
+    "sprint": 251,
+    "phase": "scoring",
+    "gates": {
+      "tests": true,
+      "code_review": true,
+      "architect_review": true,
+      "scorecard": true,
+      "review_md": true
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local self review; no subagents per operator direction. This review found a regression I introduced: making expectedNext legitimately undefined produced audits that the audit validator rejected as invalid shape.",
+        "updated_at": "2026-07-25T16:51:43.785Z"
+      },
+      "architect_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local architecture self review of the projection marker write boundary and the rollover audit schema.",
+        "updated_at": "2026-07-25T16:51:44.110Z"
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T16:50:49.856Z",
+    "updated_at": "2026-07-25T16:57:23.176Z",
+    "rollover": {
+      "transition_id": "11431b80bc5e145a",
+      "from_sprint": 250,
+      "audit_path": "docs/retros/rollovers/sprint-250-to-251-9cc9094304e85294.json",
+      "recorded_at": "2026-07-25T16:50:49.856Z",
+      "forced": false
+    }
+  },
+  "next_state": {
+    "sprint": 252,
+    "phase": "planning",
+    "gates": {
+      "tests": false,
+      "code_review": false,
+      "architect_review": false,
+      "scorecard": false,
+      "review_md": false
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "pending",
+        "evidence": []
+      },
+      "architect_review": {
+        "provenance": "pending",
+        "evidence": []
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T17:18:32.631Z",
+    "updated_at": "2026-07-25T17:18:32.631Z",
+    "rollover": {
+      "transition_id": "d6be4a9bb2bc441b",
+      "from_sprint": 251,
+      "audit_path": "docs/retros/rollovers/sprint-251-to-252-f3b3e6125b7896a1.json",
+      "recorded_at": "2026-07-25T17:18:32.631Z",
+      "forced": false
+    }
+  },
+  "claims_policy": "unchanged",
+  "sessions_policy": "unchanged"
+}

--- a/docs/retros/rollovers/sprint-252-to-253-49b40f8d28b50c91.json
+++ b/docs/retros/rollovers/sprint-252-to-253-49b40f8d28b50c91.json
@@ -1,0 +1,272 @@
+{
+  "version": 1,
+  "kind": "sprint_rollover",
+  "transition_id": "cdbe5058a5c646e0",
+  "from_sprint": 252,
+  "to_sprint": 253,
+  "from_label": "S252",
+  "to_label": "S253",
+  "recorded_at": "2026-07-25T17:48:41.244Z",
+  "actor": {
+    "name": "srbry",
+    "source": "env:USERNAME"
+  },
+  "request": {
+    "from": 252,
+    "to": 253,
+    "force": false
+  },
+  "forced": false,
+  "eligibility": {
+    "from_terminal": true,
+    "target_dependency_eligible": true,
+    "blocking_dependencies": [],
+    "target_dependencies": [
+      252
+    ],
+    "completion_evidence": {
+      "roadmap_complete": [
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        114.5,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        137.5,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        143.5,
+        143.6,
+        143.7,
+        143.8,
+        143.9,
+        143.95,
+        143.97,
+        143.98,
+        143.99,
+        144,
+        145,
+        146,
+        146.1,
+        146.2,
+        146.3,
+        148,
+        149,
+        150,
+        151,
+        151.1,
+        152,
+        152.1,
+        153,
+        154,
+        216,
+        217,
+        218,
+        219,
+        220,
+        221,
+        222,
+        223,
+        224,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        233,
+        234,
+        235,
+        236,
+        241,
+        242,
+        243,
+        244,
+        246,
+        247,
+        248,
+        249,
+        250,
+        251,
+        252,
+        253
+      ],
+      "scorecards": [
+        252
+      ],
+      "local_terminal": [
+        252
+      ]
+    },
+    "scorecard_artifacts": [
+      {
+        "sprint": 252,
+        "path": "docs/retros/sprint-252.json",
+        "sha256": "186279c3c4a576ec5f049f7b8daaaa65c8578e0efcc1575a8fbdcb25920744b1"
+      }
+    ]
+  },
+  "roadmap": {
+    "path": "docs/backlog/roadmap.json",
+    "sha256": "57a3e93f225c68f2103e68b11fbdb229d02601ab42371aaa163b6fc1da3a08c1",
+    "from_status": "complete",
+    "to_status": "complete"
+  },
+  "prior_state_sha256": "1df18f1320fd1da7081574c3b3158f0fe20253aaed0b53bdf8ca1ffbc0107726",
+  "prior_state": {
+    "sprint": 252,
+    "phase": "implementing",
+    "gates": {
+      "tests": true,
+      "code_review": true,
+      "architect_review": true,
+      "scorecard": true,
+      "review_md": true
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local self review; no subagents per operator direction. This review caught that the planned S252 approach was impossible (YAML collapses the id before validation) and that a reverted claim-required change had no deny coverage. Evidence: 4145 tests, tsc clean, per-field audit refusals verified against a real audit, both #635 enforcement points probed.",
+        "updated_at": "2026-07-25T17:48:39.808Z"
+      },
+      "architect_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local architecture self review of where sprint-id ambiguity is detectable (text, not parsed value), tracked-content hashing, and duplicated claim-area matching across two guards.",
+        "updated_at": "2026-07-25T17:48:40.132Z"
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T17:18:32.631Z",
+    "updated_at": "2026-07-25T17:48:40.458Z",
+    "rollover": {
+      "transition_id": "d6be4a9bb2bc441b",
+      "from_sprint": 251,
+      "audit_path": "docs/retros/rollovers/sprint-251-to-252-f3b3e6125b7896a1.json",
+      "recorded_at": "2026-07-25T17:18:32.631Z",
+      "forced": false
+    }
+  },
+  "next_state": {
+    "sprint": 253,
+    "phase": "planning",
+    "gates": {
+      "tests": false,
+      "code_review": false,
+      "architect_review": false,
+      "scorecard": false,
+      "review_md": false
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "pending",
+        "evidence": []
+      },
+      "architect_review": {
+        "provenance": "pending",
+        "evidence": []
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T17:48:41.244Z",
+    "updated_at": "2026-07-25T17:48:41.244Z",
+    "rollover": {
+      "transition_id": "cdbe5058a5c646e0",
+      "from_sprint": 252,
+      "audit_path": "docs/retros/rollovers/sprint-252-to-253-49b40f8d28b50c91.json",
+      "recorded_at": "2026-07-25T17:48:41.244Z",
+      "forced": false
+    }
+  },
+  "claims_policy": "unchanged",
+  "sessions_policy": "unchanged"
+}

--- a/docs/retros/sprint-252-review.md
+++ b/docs/retros/sprint-252-review.md
@@ -1,0 +1,49 @@
+
+## Sprint 252 Review: Sprint Identity Safety
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 5 |
+| Slope | 4 |
+| Score | 5 |
+| Label | Par |
+| Fairway % | 100% (5/5) |
+| GIR % | 100% (5/5) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 5)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S252-1 | Long Iron | Green | Bunker: The planned approach was impossible: YAML collapses 458.10 to the number 458.1 before any validator sees the document, so the ambiguity is unrecoverable from the parsed value. describeSprintIdAmbiguity had to take a string, and authored sources needed a raw-text scan rather than an object check. A first attempt that inspected the parsed id would have silently done nothing. | Trailing zero is the discriminator: .10 aliases .1 and .0 aliases the whole sprint, while .11 and .01 round-trip. The message names what the id collapses to and suggests a renumbering. |
+| S252-2 | Short Iron | Green | -- | Raw-YAML scan in parseRoadmapSourceDocument reporting the offending line. Inspects only the two positions a sprint id is written (a phase.sprints list item and an id: key), so par, slope and version decimals are untouched. This repo's 48 sources compile unchanged. |
+| S252-3 | Wedge | Green | -- | Covers both enforcement points plus the case that only text can detect: describeSprintIdAmbiguity(String(458.10)) is correctly null, because by then the zero is already gone. |
+| S252-4 | Driver | In the Hole | Water: Found while transitioning into this phase. Rollover audits hashed raw bytes, so on Windows with core.autocrlf any checkout renormalized tracked text and permanently invalidated every audit — proven by the recorded digest matching the git blob (LF, 4446 bytes) while the working tree hashed CRLF at 4547. Because sprint-completion requires lineage verification before PR creation, this blocked the entire lifecycle, and was the fourth distinct block on the same closeout path after #641 twice and #646. | hashTrackedContent normalizes CRLF to LF, matching what git stores; trackedContentMatches also accepts legacy raw-byte digests so existing audits keep verifying. |
+| S252-5 | Wedge | Green | Rough: The product-side fix was attempted and reverted. Keying claim-required's advisory flag off the policy rather than the session mode stopped both prompt triggers but broke deny mode, returning no decision where it must block. loadConfig resolved the policy correctly, so the fault is at the guard/CLI output boundary. The suite has no test asserting deny blocks, which is why the regression was invisible — recorded on #650 so a retry starts with that test. | The operator was asked to approve host permission prompts three times because claim-required returns ask whenever sprint state is absent or non-implementing, and every remedy it prints is agent-actionable. Agent-side stop landed in sprint-checklist.md; the guard fix stays open. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| undefined | undefined | undefined |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Bunker | S252-1 | The planned approach was impossible: YAML collapses 458.10 to the number 458.1 before any validator sees the document, so the ambiguity is unrecoverable from the parsed value. describeSprintIdAmbiguity had to take a string, and authored sources needed a raw-text scan rather than an object check. A first attempt that inspected the parsed id would have silently done nothing. |
+| Water | S252-4 | Found while transitioning into this phase. Rollover audits hashed raw bytes, so on Windows with core.autocrlf any checkout renormalized tracked text and permanently invalidated every audit — proven by the recorded digest matching the git blob (LF, 4446 bytes) while the working tree hashed CRLF at 4547. Because sprint-completion requires lineage verification before PR creation, this blocked the entire lifecycle, and was the fourth distinct block on the same closeout path after #641 twice and #646. |
+| Rough | S252-5 | The product-side fix was attempted and reverted. Keying claim-required's advisory flag off the policy rather than the session mode stopped both prompt triggers but broke deny mode, returning no decision where it must block. loadConfig resolved the policy correctly, so the fault is at the guard/CLI output boundary. The suite has no test asserting deny blocks, which is why the regression was invisible — recorded on #650 so a retry starts with that test. |
+
+**Known hazards for future sprints:**
+- Sprint id ambiguity is only visible in source text; any check that inspects a parsed number is a no-op.
+- Rollover audits hash file contents — normalize line endings or Windows checkouts invalidate them.
+
+### Course Management Notes
+
+- The plan assumed the ambiguity could be validated after parsing. It could not. Checking the constraint before writing the ticket would have saved a wrong first approach.
+- #635 stays open deliberately: this removes the silent-corruption path, but canonical string ids remain the durable fix.
+

--- a/docs/retros/sprint-252.json
+++ b/docs/retros/sprint-252.json
@@ -1,0 +1,105 @@
+{
+  "sprint_number": 252,
+  "theme": "Sprint Identity Safety",
+  "par": 5,
+  "slope": 4,
+  "score": 5,
+  "score_label": "par",
+  "date": "2026-07-25",
+  "shots": [
+    {
+      "ticket_key": "S252-1",
+      "title": "Reject decimal sprint ids whose fraction ends in zero, with a renumbering message (#635)",
+      "club": "long_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "major",
+          "description": "The planned approach was impossible: YAML collapses 458.10 to the number 458.1 before any validator sees the document, so the ambiguity is unrecoverable from the parsed value. describeSprintIdAmbiguity had to take a string, and authored sources needed a raw-text scan rather than an object check. A first attempt that inspected the parsed id would have silently done nothing.",
+          "gotcha_id": "self:parse-loses-evidence"
+        }
+      ],
+      "notes": "Trailing zero is the discriminator: .10 aliases .1 and .0 aliases the whole sprint, while .11 and .01 round-trip. The message names what the id collapses to and suggests a renumbering."
+    },
+    {
+      "ticket_key": "S252-2",
+      "title": "Fail roadmap source authoring on an ambiguous sprint id instead of compiling it (#635)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "Raw-YAML scan in parseRoadmapSourceDocument reporting the offending line. Inspects only the two positions a sprint id is written (a phase.sprints list item and an id: key), so par, slope and version decimals are untouched. This repo's 48 sources compile unchanged."
+    },
+    {
+      "ticket_key": "S252-3",
+      "title": "Add round-trip coverage for 458.1, 458.9, 458.10, 458.11 and 459 (#635)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [],
+      "notes": "Covers both enforcement points plus the case that only text can detect: describeSprintIdAmbiguity(String(458.10)) is correctly null, because by then the zero is already gone."
+    },
+    {
+      "ticket_key": "S252-4",
+      "title": "Unplanned: hash rollover evidence with normalized line endings (#649)",
+      "club": "driver",
+      "result": "in_the_hole",
+      "hazards": [
+        {
+          "type": "water",
+          "severity": "critical",
+          "description": "Found while transitioning into this phase. Rollover audits hashed raw bytes, so on Windows with core.autocrlf any checkout renormalized tracked text and permanently invalidated every audit \u2014 proven by the recorded digest matching the git blob (LF, 4446 bytes) while the working tree hashed CRLF at 4547. Because sprint-completion requires lineage verification before PR creation, this blocked the entire lifecycle, and was the fourth distinct block on the same closeout path after #641 twice and #646.",
+          "gotcha_id": "self:raw-byte-hash"
+        }
+      ],
+      "notes": "hashTrackedContent normalizes CRLF to LF, matching what git stores; trackedContentMatches also accepts legacy raw-byte digests so existing audits keep verifying."
+    },
+    {
+      "ticket_key": "S252-5",
+      "title": "Unplanned: add a sprint state gate before implementation writes (#650)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "The product-side fix was attempted and reverted. Keying claim-required's advisory flag off the policy rather than the session mode stopped both prompt triggers but broke deny mode, returning no decision where it must block. loadConfig resolved the policy correctly, so the fault is at the guard/CLI output boundary. The suite has no test asserting deny blocks, which is why the regression was invisible \u2014 recorded on #650 so a retry starts with that test.",
+          "gotcha_id": "self:no-deny-coverage"
+        }
+      ],
+      "notes": "The operator was asked to approve host permission prompts three times because claim-required returns ask whenever sprint state is absent or non-implementing, and every remedy it prints is agent-actionable. Agent-side stop landed in sprint-checklist.md; the guard fix stays open."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 5,
+    "fairways_total": 5,
+    "greens_in_regulation": 5,
+    "greens_total": 5,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 3,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Two of five shots were unplanned discoveries from running the tool on itself rather than roadmap tickets."
+  ],
+  "special_plays": [],
+  "bunker_locations": [
+    "Sprint id ambiguity is only visible in source text; any check that inspects a parsed number is a no-op.",
+    "Rollover audits hash file contents \u2014 normalize line endings or Windows checkouts invalidate them."
+  ],
+  "yardage_book_updates": [
+    "describeSprintIdAmbiguity takes a string by design. Never call it with a number.",
+    "parseRoadmapSourceDocument scans raw YAML before parsing; extend that scan for any id-shaped field.",
+    "hashTrackedContent for anything hashed from a tracked file, so digests survive checkout renormalization."
+  ],
+  "course_management_notes": [
+    "The plan assumed the ambiguity could be validated after parsing. It could not. Checking the constraint before writing the ticket would have saved a wrong first approach.",
+    "#635 stays open deliberately: this removes the silent-corruption path, but canonical string ids remain the durable fix."
+  ]
+}

--- a/docs/retros/sprint-253-review.md
+++ b/docs/retros/sprint-253-review.md
@@ -1,0 +1,47 @@
+
+## Sprint 253 Review: Diagnosability and Branch Workflow
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 5 |
+| Slope | 2 |
+| Score | 5 |
+| Label | Par |
+| Fairway % | 100% (5/5) |
+| GIR % | 100% (5/5) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 5)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S253-1 | Short Iron | In the Hole | -- | A 40-term boolean chain became describeAuditShapeProblem returning the first specific problem, with array indices. Verified by breaking each field in a real audit. The original message named no field, which is why the real cause — an absent rather than malformed field — took a source read to find. |
+| S253-2 | Wedge | Green | Rough: Backticks in a python -c string were command-substituted by bash, silently stripping every code span from the written rule. Second escaping incident this phase and third overall; the S248 scorecard already says to write scripts as files rather than inline. Rewrote from a file. | Recommends one phase branch with per-sprint commits, and states the three rules if stacking anyway: merge commit not squash, never --delete-branch a base with dependents, merge in order. Also records the per-branch scorecard and rollover-audit requirement. |
+| S253-3 | Short Iron | Green | -- | pr-review emits the stack rules when --base is neither main nor master, so they are seen at creation rather than at merge. Landing Phase 55-56 as four stacked PRs cost three recoveries to exactly these. |
+| S253-4 | Short Iron | Green | Bunker: Prompted by the operator asking whether the scope-drift guard was useful at all. A claim on '.' silenced nothing because both matchers built the prefix './', which no relative path starts with — so claiming the repo was impossible to express and every write was reported as drift. Two independent copies of the logic needed the same fix. | isWithinClaimedArea and claimOverlapsPath both handle root claims now, with tests; a narrow claim still scopes correctly. They should probably be one function. |
+| S253-5 | Wedge | Green | -- | dedupGuardContext substituted a note about the budget itself for every guard on every fire, naming no file and no action, spending context to announce there was none left. Now returns empty; writeGuardOutput already treats empty context as no output. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| undefined | undefined | undefined |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Rough | S253-2 | Backticks in a python -c string were command-substituted by bash, silently stripping every code span from the written rule. Second escaping incident this phase and third overall; the S248 scorecard already says to write scripts as files rather than inline. Rewrote from a file. |
+| Bunker | S253-4 | Prompted by the operator asking whether the scope-drift guard was useful at all. A claim on '.' silenced nothing because both matchers built the prefix './', which no relative path starts with — so claiming the repo was impossible to express and every write was reported as drift. Two independent copies of the logic needed the same fix. |
+
+**Known hazards for future sprints:**
+- Claim-area matching is duplicated in scope-drift and claim-required; changes must land in both.
+
+### Course Management Notes
+
+- scope-drift still has no value in a solo session — it exists for multi-agent claim coordination. Gating it on another live session or another actor's claim is left open on #651 as a design decision rather than patched.
+- Answering 'is this guard useful?' honestly surfaced two real bugs. Worth doing for other advisory guards.
+

--- a/docs/retros/sprint-253.json
+++ b/docs/retros/sprint-253.json
@@ -1,0 +1,96 @@
+{
+  "sprint_number": 253,
+  "theme": "Diagnosability and Branch Workflow",
+  "par": 5,
+  "slope": 2,
+  "score": 5,
+  "score_label": "par",
+  "date": "2026-07-25",
+  "shots": [
+    {
+      "ticket_key": "S253-1",
+      "title": "Name the failing field when refusing a rollover audit (#646)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": "A 40-term boolean chain became describeAuditShapeProblem returning the first specific problem, with array indices. Verified by breaking each field in a real audit. The original message named no field, which is why the real cause \u2014 an absent rather than malformed field \u2014 took a source read to find."
+    },
+    {
+      "ticket_key": "S253-2",
+      "title": "Document stacked-PR rules in branch discipline (#648)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Backticks in a python -c string were command-substituted by bash, silently stripping every code span from the written rule. Second escaping incident this phase and third overall; the S248 scorecard already says to write scripts as files rather than inline. Rewrote from a file.",
+          "gotcha_id": "self:inline-script-escaping"
+        }
+      ],
+      "notes": "Recommends one phase branch with per-sprint commits, and states the three rules if stacking anyway: merge commit not squash, never --delete-branch a base with dependents, merge in order. Also records the per-branch scorecard and rollover-audit requirement."
+    },
+    {
+      "ticket_key": "S253-3",
+      "title": "Warn at PR creation when the base is not the default branch (#648)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "pr-review emits the stack rules when --base is neither main nor master, so they are seen at creation rather than at merge. Landing Phase 55-56 as four stacked PRs cost three recoveries to exactly these."
+    },
+    {
+      "ticket_key": "S253-4",
+      "title": "Unplanned: make a whole-repo claim cover the repo (#651)",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "moderate",
+          "description": "Prompted by the operator asking whether the scope-drift guard was useful at all. A claim on '.' silenced nothing because both matchers built the prefix './', which no relative path starts with \u2014 so claiming the repo was impossible to express and every write was reported as drift. Two independent copies of the logic needed the same fix.",
+          "gotcha_id": "self:duplicated-matcher"
+        }
+      ],
+      "notes": "isWithinClaimedArea and claimOverlapsPath both handle root claims now, with tests; a narrow claim still scopes correctly. They should probably be one function."
+    },
+    {
+      "ticket_key": "S253-5",
+      "title": "Unplanned: stay silent when the guard context budget is exhausted (#651)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [],
+      "notes": "dedupGuardContext substituted a note about the budget itself for every guard on every fire, naming no file and no action, spending context to announce there was none left. Now returns empty; writeGuardOutput already treats empty context as no output."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 5,
+    "fairways_total": 5,
+    "greens_in_regulation": 5,
+    "greens_total": 5,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 2,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Two of five shots came from the operator questioning whether a guard was worth keeping, which is a better defect-finding signal than the backlog."
+  ],
+  "special_plays": [],
+  "bunker_locations": [
+    "Claim-area matching is duplicated in scope-drift and claim-required; changes must land in both."
+  ],
+  "yardage_book_updates": [
+    "A guard with nothing useful left to say should emit empty, not a note about its own limits.",
+    "Write helper scripts to files. Inline python -c with backticks gets command-substituted by bash and silently mangles output."
+  ],
+  "course_management_notes": [
+    "scope-drift still has no value in a solo session \u2014 it exists for multi-agent claim coordination. Gating it on another live session or another actor's claim is left open on #651 as a design decision rather than patched.",
+    "Answering 'is this guard useful?' honestly surfaced two real bugs. Worth doing for other advisory guards."
+  ]
+}

--- a/docs/roadmap/phases/phase-57.yaml
+++ b/docs/roadmap/phases/phase-57.yaml
@@ -1,0 +1,64 @@
+version: "1"
+phase:
+  name: Phase 57 — Identity Safety and Diagnosability
+  description: "The tail of the July issue batch: the two items deliberately left open after Phase 56, plus the stacked-PR workflow gap that landing Phase 55-56 exposed. Identity safety first because silent aliasing corrupts data; diagnosability second because opaque refusals cost a source read each."
+  sprints:
+    - 252
+    - 253
+  status: in_progress
+  note: "Closes out #635, #646 and #648. #635 cannot be fully fixed without canonical string sprint ids — a representational change across roadmap compile/focus/archive, sprint state, scorecards, retro paths and the store schema — so S252 removes the silent-corruption path and defers the representation. #646 and #648 are both about failures that are reachable in normal use but not diagnosable without reading source."
+sprints:
+  - id: 252
+    theme: Sprint Identity Safety
+    par: 4
+    slope: 3
+    type: bugfix + data integrity
+    status: planned
+    note: "Fix the harmful half of #635: sprint ids are stored as JSON numbers, so a decimal whose fraction ends in zero silently aliases another sprint (458.10 reads back as 458.1; 458.0 as 458). Reject those at every entry point with a message that says how to renumber, rather than corrupting dependencies, focused context, evidence lookup and scorecard identity. The canonical-string representation stays deferred and #635 stays open for it."
+    tickets:
+      - key: S252-1
+        title: "Reject decimal sprint ids whose fraction ends in zero, with a renumbering message (#635)"
+        club: long_iron
+        complexity: moderate
+        github_issue: 635
+      - key: S252-2
+        title: Fail roadmap source authoring on an ambiguous sprint id instead of compiling it (#635)
+        club: short_iron
+        complexity: standard
+        github_issue: 635
+        depends_on:
+          - S252-1
+      - key: S252-3
+        title: "Add round-trip coverage for 458.1, 458.9, 458.10, 458.11 and 459 (#635)"
+        club: wedge
+        complexity: small
+        github_issue: 635
+        depends_on:
+          - S252-1
+  - id: 253
+    theme: Diagnosability and Branch Workflow
+    par: 4
+    slope: 2
+    type: bugfix + agent ergonomics
+    status: planned
+    depends_on:
+      - 252
+    note: "Fix #646 (rollover audit validation reports a blanket 'invalid shape' naming no field, so diagnosing it required reading the validator — it was a field absent rather than malformed) and #648 (stacked sprint PRs are unsupported: squash-merging the base makes every dependent conflict, --delete-branch closes them outright so their Closes trailers never fire, and until Phase 56 they ran no CI). Landing Phase 55-56 cost three recoveries to this."
+    tickets:
+      - key: S253-1
+        title: Name the failing field when refusing a rollover audit instead of reporting invalid shape (#646)
+        club: short_iron
+        complexity: standard
+        github_issue: 646
+      - key: S253-2
+        title: Document stacked-PR rules in branch discipline — merge order, no squash on a base, no branch delete (#648)
+        club: wedge
+        complexity: small
+        github_issue: 648
+      - key: S253-3
+        title: Warn at PR creation when the base is not main so the stack rules are seen before they bite (#648)
+        club: short_iron
+        complexity: standard
+        github_issue: 648
+        depends_on:
+          - S253-2

--- a/docs/roadmap/phases/phase-57.yaml
+++ b/docs/roadmap/phases/phase-57.yaml
@@ -13,7 +13,7 @@ sprints:
     par: 4
     slope: 3
     type: bugfix + data integrity
-    status: planned
+    status: complete
     note: "Fix the harmful half of #635: sprint ids are stored as JSON numbers, so a decimal whose fraction ends in zero silently aliases another sprint (458.10 reads back as 458.1; 458.0 as 458). Reject those at every entry point with a message that says how to renumber, rather than corrupting dependencies, focused context, evidence lookup and scorecard identity. The canonical-string representation stays deferred and #635 stays open for it."
     tickets:
       - key: S252-1
@@ -40,7 +40,7 @@ sprints:
     par: 4
     slope: 2
     type: bugfix + agent ergonomics
-    status: planned
+    status: complete
     depends_on:
       - 252
     note: "Fix #646 (rollover audit validation reports a blanket 'invalid shape' naming no field, so diagnosing it required reading the validator — it was a field absent rather than malformed) and #648 (stacked sprint PRs are unsupported: squash-merging the base makes every dependent conflict, --delete-branch closes them outright so their Closes trailers never fire, and until Phase 56 they ran no CI). Landing Phase 55-56 cost three recoveries to this."
@@ -62,3 +62,6 @@ sprints:
         github_issue: 648
         depends_on:
           - S253-2
+scorecards:
+  "252": docs/retros/sprint-252.json
+  "253": docs/retros/sprint-253.json

--- a/docs/roadmap/project.yaml
+++ b/docs/roadmap/project.yaml
@@ -97,3 +97,5 @@ sources:
     kind: phase
   - path: phases/phase-56.yaml
     kind: phase
+  - path: phases/phase-57.yaml
+    kind: phase

--- a/src/cli/guards/claim-required.ts
+++ b/src/cli/guards/claim-required.ts
@@ -299,6 +299,7 @@ export function claimOverlapsPath(
 ): boolean {
   if (scope !== 'area') return relativePath === target;
   if (isWholeSprintClaim(target)) return true;
+  if (isWholeRepoClaim(target)) return true;
   const areaPrefix = target.endsWith('/') ? target : `${target}/`;
   return (
     relativePath === target || relativePath.startsWith(areaPrefix) ||
@@ -362,4 +363,17 @@ async function loadSprintClaims(cwd: string, sprintNumber: number): Promise<Spri
 
 function isWholeSprintClaim(target: string): boolean {
   return /^sprint:S\d+(?:\.\d+)?$/i.test(target);
+}
+
+/**
+ * True when an area claim covers the whole working tree.
+ *
+ * `slope claim --target=. --scope=area` is the natural way to say "I am working
+ * across this repo", but the prefix match built `./`, which no relative path
+ * starts with — so a root claim silenced nothing and every write was reported as
+ * scope drift (GH #651).
+ */
+function isWholeRepoClaim(target: string): boolean {
+  const normalized = target.replace(/\\/g, '/').replace(/\/+$/, '');
+  return normalized === '.' || normalized === '' || normalized === '/';
 }

--- a/src/cli/guards/pr-review.ts
+++ b/src/cli/guards/pr-review.ts
@@ -14,6 +14,35 @@ import { buildReviewerAgentSpecs, formatReviewerAgentSummary } from '../reviewer
  * As of S91-4 (#302) the suggestion includes recommended review types
  * computed from the PR's diff (file patterns) and current sprint metadata.
  */
+/**
+ * Return the base branch when a PR was opened against something other than the
+ * default branch, i.e. a stacked PR.
+ */
+function detectStackedPrBase(command: string): string | null {
+  const match = command.match(/--base[=\s]+("[^"]+"|'[^']+'|[^\s]+)/);
+  if (!match) return null;
+  const base = match[1].replace(/^["']|["']$/g, '');
+  if (base === 'main' || base === 'master') return null;
+  return base;
+}
+
+/**
+ * Stacked PRs are easy to open and hard to land: squashing the base rewrites
+ * history so every dependent conflicts, and deleting the base closes the
+ * dependent outright so its Closes trailers never fire. Landing Phase 55-56 as
+ * four stacked PRs cost three recoveries to exactly that, so surface the rules
+ * at creation rather than at merge (GH #648).
+ */
+function formatStackedPrWarning(base: string): string {
+  return [
+    'SLOPE stacked PR: this PR targets ' + base + ', not the default branch.',
+    'Merge the base with a merge commit (never squash — it rewrites history and every dependent conflicts),',
+    'do not pass --delete-branch on the base (it closes this PR, and a closed PR cannot be retargeted,',
+    'so its Closes #N trailers never fire), and merge strictly in order.',
+    'Consider one phase branch with per-sprint commits instead. See .claude/rules/branch-discipline.md.',
+  ].join(' ');
+}
+
 export async function prReviewGuard(input: HookInput, cwd: string): Promise<GuardResult> {
   const command = (input.tool_input?.command as string) ?? '';
   const response = (input.tool_response?.stdout as string) ?? (input.tool_response?.result as string) ?? '';
@@ -33,6 +62,8 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
 
   recordPendingReview(cwd, parseInt(prNumber, 10));
 
+  const stackedBase = detectStackedPrBase(command);
+
   const recommendationContext = computeRecommendationContext(cwd);
   const recs = recommendationContext.recommendations;
   const recLine = formatRecommendations(recs);
@@ -51,6 +82,7 @@ export async function prReviewGuard(input: HookInput, cwd: string): Promise<Guar
       `Then run \`slope pr status --pr=${prNumber}\` after checks and review threads settle before presenting the PR as ready.`,
       `After review, capture findings with \`slope review findings add\`, then \`slope review amend\` to apply them to the scorecard.`,
       'Tip: also run `slope pr finalize` to add Closes #N for any issues referenced in commits.',
+      ...(stackedBase ? [formatStackedPrWarning(stackedBase)] : []),
     ].join(' '),
   };
 }

--- a/src/cli/guards/scope-drift.ts
+++ b/src/cli/guards/scope-drift.ts
@@ -143,5 +143,10 @@ function resolveCurrentSprint(cwd: string, config: SlopeConfig): number | undefi
 function isWithinClaimedArea(relativePath: string, target: string): boolean {
   const normalizedTarget = target.replace(/\\/g, '/').replace(/\/$/, '');
   if (/^sprint:S\d+(?:\.\d+)?$/i.test(normalizedTarget)) return true;
+  // `slope claim --target=. --scope=area` is the natural way to say "working
+  // across this repo", but the prefix test built `./`, which no relative path
+  // starts with — so a root claim silenced nothing and every write was reported
+  // as drift (GH #651).
+  if (normalizedTarget === '.' || normalizedTarget === '' || normalizedTarget === '/') return true;
   return relativePath === normalizedTarget || relativePath.startsWith(`${normalizedTarget}/`);
 }

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -189,11 +189,14 @@ export function dedupGuardContext(
       return `SLOPE ${guardName}: (same as prior warning, shown ${existing.count}x)`;
     }
 
-    // Check token budget — if exceeded, return short message instead of full context
+    // Budget exhausted: stay silent. This previously substituted a note about the
+    // budget itself, which every guard then repeated on every fire — spending
+    // context to announce that there is no context left, naming no file and no
+    // action. A guard with nothing useful left to say should say nothing (GH #651).
     const budget = DEFAULT_CONTEXT_BUDGET_CHARS;
     if ((state.total_chars ?? 0) + context.length > budget) {
       saveDedupStateUnlocked(filePath, state);
-      return `SLOPE ${guardName}: context budget exhausted (${Math.round((state.total_chars ?? 0) / 4)}+ tokens injected). Run \`slope briefing --compact\` for status.`;
+      return '';
     }
 
     // New content — track chars and record

--- a/src/cli/sprint-rollover.ts
+++ b/src/cli/sprint-rollover.ts
@@ -151,6 +151,28 @@ interface LoadedCompletionEvidence {
   scorecards: SprintRolloverScorecardEvidence[];
 }
 
+/**
+ * Hash a tracked text file's content with line endings normalized to LF.
+ *
+ * Raw-byte hashing made every rollover audit single-use on Windows: with
+ * `core.autocrlf` any checkout, merge or branch switch renormalizes tracked text
+ * to CRLF, changing the bytes without changing the content, so verification
+ * reported "scorecard evidence changed" for a file nobody had touched — and the
+ * lifecycle could not advance (GH #649). Normalizing matches what git stores, so
+ * the digest is reproducible across platforms and checkouts.
+ */
+export function hashTrackedContent(content: Buffer | string): string {
+  const text = typeof content === 'string' ? content : content.toString('utf8');
+  return createHash('sha256').update(text.replace(/\r\n/g, '\n')).digest('hex');
+}
+
+/** True when a digest matches, accepting legacy raw-byte digests written before
+ *  normalization so existing audits keep verifying. */
+export function trackedContentMatches(content: Buffer, expected: string): boolean {
+  if (hashTrackedContent(content) === expected) return true;
+  return createHash('sha256').update(content).digest('hex') === expected;
+}
+
 function roadmapIdsEqual(roadmap: RoadmapDefinition, left: number, right: number): boolean {
   return roadmapSprintOrderValue(roadmap, left) === roadmapSprintOrderValue(roadmap, right);
 }
@@ -180,7 +202,7 @@ function loadRolloverRoadmap(cwd: string): { roadmap: RoadmapDefinition; path: s
     const detail = boundedMessages(parsed.validation.errors.map(issue => issue.message));
     throw new SprintRolloverError(`Roadmap is not safe for rollover${detail ? `: ${detail}` : '.'}`);
   }
-  return { roadmap, path, sha256: createHash('sha256').update(source).digest('hex') };
+  return { roadmap, path, sha256: hashTrackedContent(source) };
 }
 
 function loadCompletionEvidence(cwd: string): LoadedCompletionEvidence {
@@ -204,7 +226,7 @@ function loadCompletionEvidence(cwd: string): LoadedCompletionEvidence {
     scorecards.push({
       sprint: fileSprint,
       path: relative(cwd, absolutePath).replaceAll('\\', '/'),
-      sha256: createHash('sha256').update(source).digest('hex'),
+      sha256: hashTrackedContent(source),
     });
     recorded.add(fileSprint);
   }
@@ -597,9 +619,12 @@ function assertRecordedScorecardEvidenceAvailable(
     if (!existsSync(path)) {
       throw new SprintRolloverError(`Existing rollover audit references missing scorecard evidence: ${artifact.path}.`);
     }
-    const digest = createHash('sha256').update(readFileSync(path)).digest('hex');
-    if (digest !== artifact.sha256) {
-      throw new SprintRolloverError(`Existing rollover audit scorecard evidence changed: ${artifact.path}.`);
+    if (!trackedContentMatches(readFileSync(path), artifact.sha256)) {
+      throw new SprintRolloverError(
+        `Existing rollover audit scorecard evidence changed: ${artifact.path}.`
+        + ' Content differs from what the audit recorded (line endings are normalized before hashing,'
+        + ' so this is a real content change).',
+      );
     }
   }
 }

--- a/src/cli/sprint-rollover.ts
+++ b/src/cli/sprint-rollover.ts
@@ -535,41 +535,11 @@ function readAudit(cwd: string, path: string): SprintRolloverAuditRecord {
     throw new SprintRolloverError(`Existing rollover audit is unreadable: ${(error as Error).message}`);
   }
   const record = raw as Partial<SprintRolloverAuditRecord>;
-  if (record.version !== 1 || record.kind !== 'sprint_rollover'
-    || typeof record.transition_id !== 'string'
-    || typeof record.from_sprint !== 'number' || typeof record.to_sprint !== 'number'
-    || typeof record.from_label !== 'string' || typeof record.to_label !== 'string'
-    || typeof record.recorded_at !== 'string'
-    || !Number.isFinite(Date.parse(record.recorded_at))
-    || !record.actor || typeof record.actor.name !== 'string' || record.actor.name.trim().length === 0
-    || typeof record.actor.source !== 'string' || record.actor.source.trim().length === 0
-    || !record.request || typeof record.request.from !== 'number' || typeof record.request.to !== 'number'
-    || typeof record.request.force !== 'boolean'
-    || (record.request.reason !== undefined && typeof record.request.reason !== 'string')
-    || typeof record.forced !== 'boolean'
-    || (record.reason !== undefined && typeof record.reason !== 'string')
-    || !record.eligibility
-    // expected_next is legitimately absent when no pending successor exists; a
-    // required-number check rejected audits this tool itself writes (GH #646).
-    || (record.eligibility.expected_next !== undefined
-      && typeof record.eligibility.expected_next !== 'number')
-    || typeof record.eligibility.from_terminal !== 'boolean'
-    || typeof record.eligibility.target_dependency_eligible !== 'boolean'
-    || !Array.isArray(record.eligibility.blocking_dependencies)
-    || !Array.isArray(record.eligibility.target_dependencies)
-    || !record.eligibility.completion_evidence
-    || !Array.isArray(record.eligibility.completion_evidence.roadmap_complete)
-    || !Array.isArray(record.eligibility.completion_evidence.scorecards)
-    || !Array.isArray(record.eligibility.completion_evidence.local_terminal)
-    || !Array.isArray(record.eligibility.scorecard_artifacts)
-    || !record.eligibility.scorecard_artifacts.every(validScorecardArtifact)
-    || !record.roadmap || typeof record.roadmap.path !== 'string' || typeof record.roadmap.sha256 !== 'string'
-    || typeof record.prior_state_sha256 !== 'string'
-    || !isValidSprintStateEvidence(record.prior_state)
-    || !isValidSprintStateEvidence(record.next_state)
-    || record.claims_policy !== 'unchanged'
-    || record.sessions_policy !== 'unchanged') {
-    throw new SprintRolloverError('Existing rollover audit has an invalid shape; refusing to replace it.');
+  const shapeProblem = describeAuditShapeProblem(record);
+  if (shapeProblem) {
+    throw new SprintRolloverError(
+      `Existing rollover audit is not valid: ${shapeProblem}. Refusing to replace it.`,
+    );
   }
   const complete = record as SprintRolloverAuditRecord;
   ensureTrackedPath(cwd, resolve(cwd, complete.roadmap.path));
@@ -684,6 +654,95 @@ function buildAuditRecord(
 }
 
 /** Verify that a rollover-linked state still has exact tracked audit evidence. */
+/**
+ * Return the first structural problem with a persisted audit, or null when it is
+ * valid.
+ *
+ * Replaces a single 40-term boolean chain that threw "invalid shape" naming no
+ * field. Diagnosing a refusal meant reading this function — and the actual cause
+ * turned out to be a field that was *absent* rather than malformed, which the
+ * message gave no way to guess (GH #646).
+ */
+function describeAuditShapeProblem(record: Partial<SprintRolloverAuditRecord>): string | null {
+  const nonEmptyString = (value: unknown): boolean => typeof value === 'string' && value.trim().length > 0;
+
+  if (record.version !== 1) return 'version must be 1';
+  if (record.kind !== 'sprint_rollover') return "kind must be 'sprint_rollover'";
+  if (typeof record.transition_id !== 'string') return 'transition_id must be a string';
+  if (typeof record.from_sprint !== 'number') return 'from_sprint must be a number';
+  if (typeof record.to_sprint !== 'number') return 'to_sprint must be a number';
+  if (typeof record.from_label !== 'string') return 'from_label must be a string';
+  if (typeof record.to_label !== 'string') return 'to_label must be a string';
+  if (typeof record.recorded_at !== 'string') return 'recorded_at must be a string';
+  if (!Number.isFinite(Date.parse(record.recorded_at))) return 'recorded_at must be a parseable timestamp';
+
+  if (!record.actor) return 'actor is missing';
+  if (!nonEmptyString(record.actor.name)) return 'actor.name must be a non-empty string';
+  if (!nonEmptyString(record.actor.source)) return 'actor.source must be a non-empty string';
+
+  if (!record.request) return 'request is missing';
+  if (typeof record.request.from !== 'number') return 'request.from must be a number';
+  if (typeof record.request.to !== 'number') return 'request.to must be a number';
+  if (typeof record.request.force !== 'boolean') return 'request.force must be a boolean';
+  if (record.request.reason !== undefined && typeof record.request.reason !== 'string') {
+    return 'request.reason must be a string when present';
+  }
+
+  if (typeof record.forced !== 'boolean') return 'forced must be a boolean';
+  if (record.reason !== undefined && typeof record.reason !== 'string') {
+    return 'reason must be a string when present';
+  }
+
+  const eligibility = record.eligibility;
+  if (!eligibility) return 'eligibility is missing';
+  // Absent is valid: no pending successor exists once a phase is fully complete.
+  if (eligibility.expected_next !== undefined && typeof eligibility.expected_next !== 'number') {
+    return 'eligibility.expected_next must be a number when present';
+  }
+  if (typeof eligibility.from_terminal !== 'boolean') return 'eligibility.from_terminal must be a boolean';
+  if (typeof eligibility.target_dependency_eligible !== 'boolean') {
+    return 'eligibility.target_dependency_eligible must be a boolean';
+  }
+  if (!Array.isArray(eligibility.blocking_dependencies)) {
+    return 'eligibility.blocking_dependencies must be an array';
+  }
+  if (!Array.isArray(eligibility.target_dependencies)) {
+    return 'eligibility.target_dependencies must be an array';
+  }
+
+  const evidence = eligibility.completion_evidence;
+  if (!evidence) return 'eligibility.completion_evidence is missing';
+  if (!Array.isArray(evidence.roadmap_complete)) {
+    return 'eligibility.completion_evidence.roadmap_complete must be an array';
+  }
+  if (!Array.isArray(evidence.scorecards)) {
+    return 'eligibility.completion_evidence.scorecards must be an array';
+  }
+  if (!Array.isArray(evidence.local_terminal)) {
+    return 'eligibility.completion_evidence.local_terminal must be an array';
+  }
+
+  if (!Array.isArray(eligibility.scorecard_artifacts)) {
+    return 'eligibility.scorecard_artifacts must be an array';
+  }
+  const badArtifact = eligibility.scorecard_artifacts.findIndex(artifact => !validScorecardArtifact(artifact));
+  if (badArtifact >= 0) {
+    return `eligibility.scorecard_artifacts[${badArtifact}] must have sprint, path and sha256`;
+  }
+
+  if (!record.roadmap) return 'roadmap is missing';
+  if (typeof record.roadmap.path !== 'string') return 'roadmap.path must be a string';
+  if (typeof record.roadmap.sha256 !== 'string') return 'roadmap.sha256 must be a string';
+
+  if (typeof record.prior_state_sha256 !== 'string') return 'prior_state_sha256 must be a string';
+  if (!isValidSprintStateEvidence(record.prior_state)) return 'prior_state is not valid sprint state';
+  if (!isValidSprintStateEvidence(record.next_state)) return 'next_state is not valid sprint state';
+  if (record.claims_policy !== 'unchanged') return "claims_policy must be 'unchanged'";
+  if (record.sessions_policy !== 'unchanged') return "sessions_policy must be 'unchanged'";
+
+  return null;
+}
+
 export function verifySprintRolloverLineage(cwd: string, state: SprintState): SprintRolloverAuditRecord | null {
   const lineage = state.rollover;
   if (!lineage) return null;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -197,6 +197,7 @@ export {
   formatSprintNumber,
   nextCanonicalSprintId,
   parseSprintNumber,
+  describeSprintIdAmbiguity,
   findNextPlannedSprint,
   isEncodedInsertedSprintId,
   isEncodedInsertedSprintInRoadmap,

--- a/src/core/roadmap-sources.ts
+++ b/src/core/roadmap-sources.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, posix } from 'node:path';
 import { parseDocument } from 'yaml';
 import { castRoadmapStructure, getRoadmapTicketKey, validateRoadmap } from './roadmap.js';
-import { compareRoadmapSprintIds, roadmapSprintOrderValue } from './roadmap.js';
+import { compareRoadmapSprintIds, describeSprintIdAmbiguity, roadmapSprintOrderValue } from './roadmap.js';
 import type { RoadmapDefinition, RoadmapPhase, RoadmapSprint } from './roadmap.js';
 
 export type RoadmapSourceKind = 'phase' | 'backlog' | 'archive';
@@ -184,10 +184,52 @@ export function parseRoadmapSourceProject(
   };
 }
 
+/**
+ * Reject sprint ids written with a trailing zero in the fraction before YAML
+ * parsing collapses them.
+ *
+ * `458.10` parses to the number 458.1, so by the time any validator sees the
+ * document the id has already silently become an existing sprint — the text is the
+ * only place the ambiguity is still visible (GH #635).
+ *
+ * Scans only the two positions a sprint id is written: a `- <number>` item under
+ * `phase.sprints`, and an `id: <number>` key on a sprint mapping. Other decimals in
+ * the file (par, slope, version) are left alone.
+ */
+function assertNoAmbiguousWrittenSprintIds(yaml: string, sourcePath: string): void {
+  const lines = yaml.split(/\r?\n/);
+  let inPhaseSprints = false;
+
+  for (const [index, line] of lines.entries()) {
+    if (/^\s*sprints:\s*$/.test(line)) {
+      // `phase.sprints` is indented; the top-level `sprints:` list is not.
+      inPhaseSprints = /^\s+sprints:\s*$/.test(line);
+      continue;
+    }
+
+    const idMatch = line.match(/^\s*-?\s*id:\s*([0-9]+\.[0-9]+)\s*(?:#.*)?$/);
+    const itemMatch = inPhaseSprints
+      ? line.match(/^\s*-\s*([0-9]+\.[0-9]+)\s*(?:#.*)?$/)
+      : null;
+    const written = idMatch?.[1] ?? itemMatch?.[1];
+    if (!written) {
+      // Any non-list, non-blank line ends the phase.sprints block.
+      if (inPhaseSprints && line.trim() && !/^\s*-/.test(line)) inPhaseSprints = false;
+      continue;
+    }
+
+    const problem = describeSprintIdAmbiguity(written);
+    if (problem) {
+      throw new RoadmapSourceError(`line ${index + 1}: ${problem}`, sourcePath);
+    }
+  }
+}
+
 export function parseRoadmapSourceDocument(
   yaml: string,
   sourcePath: string,
 ): RoadmapSourceDocument {
+  assertNoAmbiguousWrittenSprintIds(yaml, sourcePath);
   const raw = parseYamlMapping(yaml, sourcePath);
   const version = parseVersion(raw.version, sourcePath);
   if (!raw.phase || typeof raw.phase !== 'object' || Array.isArray(raw.phase)) {

--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -119,6 +119,35 @@ export function formatSprintLabel(id: number): string {
   return `S${formatSprintNumber(id)}`;
 }
 
+/**
+ * Describe why a sprint id cannot be represented unambiguously, or null when it
+ * is fine.
+ *
+ * Sprint ids are stored as JSON numbers, so a decimal whose fraction ends in a
+ * zero loses that zero and silently becomes a different, usually existing,
+ * sprint: `458.10` reads back as `458.1`, and `458.0` as `458`. That corrupts
+ * dependencies, focused context, evidence lookup and scorecard identity, and it
+ * is why a phase had to be renumbered to whole sprints (GH #635).
+ *
+ * Rejecting these is a stopgap. The durable fix is canonical string ids, which
+ * spans roadmap compile/focus/archive, sprint state, scorecards, retro paths and
+ * the store schema.
+ */
+export function describeSprintIdAmbiguity(value: string | number): string | null {
+  const raw = typeof value === 'number' ? String(value) : value.trim();
+  const body = raw[0]?.toLowerCase() === 's' ? raw.slice(1) : raw;
+  const dot = body.indexOf('.');
+  if (dot < 0) return null;
+
+  const fraction = body.slice(dot + 1);
+  if (!fraction.endsWith('0')) return null;
+
+  const collapsed = String(Number(body));
+  return `Sprint id "${body}" is ambiguous: it is stored as a number, so it reads back as ${collapsed}`
+    + ` and would alias that sprint. Renumber it — use a fraction with no trailing zero`
+    + ` (for example ${body.slice(0, dot)}.${fraction.replace(/0+$/, '') || '1'}1) or a whole sprint id.`;
+}
+
 /** Parse human-entered sprint ids such as "114", "114.5", or "S114.5". */
 export function parseSprintNumber(value: string | number): number | null {
   if (typeof value === 'number') {

--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -119,6 +119,37 @@ export function formatSprintLabel(id: number): string {
   return `S${formatSprintNumber(id)}`;
 }
 
+/**
+ * Describe why a written sprint id cannot round-trip, or null when it is fine.
+ *
+ * Sprint ids are stored as JSON/YAML numbers, so a decimal whose fraction ends in
+ * a zero loses that zero and silently becomes a different — usually existing —
+ * sprint: `458.10` reads back as `458.1`, and `458.0` as `458`. That corrupts
+ * dependencies, focused context, evidence lookup and scorecard identity, and it is
+ * why a phase had to be renumbered to whole sprints (GH #635).
+ *
+ * Takes a **string** deliberately. By the time such an id has been parsed into a
+ * number the trailing zero is already gone, so the ambiguity is only detectable in
+ * the text as written.
+ *
+ * Rejecting these is a stopgap; the durable fix is canonical string ids.
+ */
+export function describeSprintIdAmbiguity(written: string): string | null {
+  const trimmed = written.trim();
+  const body = trimmed[0]?.toLowerCase() === 's' ? trimmed.slice(1) : trimmed;
+  const dot = body.indexOf('.');
+  if (dot < 0) return null;
+
+  const fraction = body.slice(dot + 1);
+  if (!/^\d+$/.test(fraction) || !fraction.endsWith('0')) return null;
+
+  const collapsed = String(Number(body));
+  const suggestion = fraction.replace(/0+$/, '');
+  return `sprint id "${body}" cannot round-trip: ids are stored as numbers, so it reads back as `
+    + `${collapsed} and would alias that sprint. Renumber it — use a fraction with no trailing `
+    + `zero (for example ${body.slice(0, dot)}.${suggestion || '1'}1) or a whole sprint id.`;
+}
+
 /** Parse human-entered sprint ids such as "114", "114.5", or "S114.5". */
 export function parseSprintNumber(value: string | number): number | null {
   if (typeof value === 'number') {
@@ -139,6 +170,10 @@ export function parseSprintNumber(value: string | number): number | null {
     }
     return null;
   }
+
+  // A trailing zero in the fraction cannot round-trip through a number, so the id
+  // would silently alias an existing sprint. Reject rather than corrupt (GH #635).
+  if (typeof value === 'string' && describeSprintIdAmbiguity(body)) return null;
 
   const parsed = Number(body);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;

--- a/src/core/roadmap.ts
+++ b/src/core/roadmap.ts
@@ -119,35 +119,6 @@ export function formatSprintLabel(id: number): string {
   return `S${formatSprintNumber(id)}`;
 }
 
-/**
- * Describe why a sprint id cannot be represented unambiguously, or null when it
- * is fine.
- *
- * Sprint ids are stored as JSON numbers, so a decimal whose fraction ends in a
- * zero loses that zero and silently becomes a different, usually existing,
- * sprint: `458.10` reads back as `458.1`, and `458.0` as `458`. That corrupts
- * dependencies, focused context, evidence lookup and scorecard identity, and it
- * is why a phase had to be renumbered to whole sprints (GH #635).
- *
- * Rejecting these is a stopgap. The durable fix is canonical string ids, which
- * spans roadmap compile/focus/archive, sprint state, scorecards, retro paths and
- * the store schema.
- */
-export function describeSprintIdAmbiguity(value: string | number): string | null {
-  const raw = typeof value === 'number' ? String(value) : value.trim();
-  const body = raw[0]?.toLowerCase() === 's' ? raw.slice(1) : raw;
-  const dot = body.indexOf('.');
-  if (dot < 0) return null;
-
-  const fraction = body.slice(dot + 1);
-  if (!fraction.endsWith('0')) return null;
-
-  const collapsed = String(Number(body));
-  return `Sprint id "${body}" is ambiguous: it is stored as a number, so it reads back as ${collapsed}`
-    + ` and would alias that sprint. Renumber it — use a fraction with no trailing zero`
-    + ` (for example ${body.slice(0, dot)}.${fraction.replace(/0+$/, '') || '1'}1) or a whole sprint id.`;
-}
-
 /** Parse human-entered sprint ids such as "114", "114.5", or "S114.5". */
 export function parseSprintNumber(value: string | number): number | null {
   if (typeof value === 'number') {

--- a/tests/cli/guards/claim-required.test.ts
+++ b/tests/cli/guards/claim-required.test.ts
@@ -89,6 +89,21 @@ function writeSprintState(cwd: string, phase: string): void {
 }
 
 describe('claimOverlapsPath', () => {
+  describe('whole-repo area claim (GH #651)', () => {
+    it.each(['.', './', ''])('treats %j as covering every path', target => {
+      // `slope claim --target=. --scope=area` is how you say "working across this
+      // repo". The prefix test built `./`, which no relative path starts with, so a
+      // root claim silenced nothing and every write was reported as scope drift.
+      expect(claimOverlapsPath('area', target, 'src/core/roadmap.ts', 'src/core')).toBe(true);
+      expect(claimOverlapsPath('area', target, 'package.json', '.')).toBe(true);
+    });
+
+    it('still scopes a narrow area claim', () => {
+      expect(claimOverlapsPath('area', 'src/cli', 'src/core/roadmap.ts', 'src/core')).toBe(false);
+      expect(claimOverlapsPath('area', 'src/cli', 'src/cli/guards/x.ts', 'src/cli/guards')).toBe(true);
+    });
+  });
+
   describe('area scope', () => {
     it('matches exact path', () => {
       expect(claimOverlapsPath('area', 'src/core', 'src/core', 'src')).toBe(true);

--- a/tests/cli/guards/pr-review.test.ts
+++ b/tests/cli/guards/pr-review.test.ts
@@ -121,3 +121,41 @@ describe('prReviewGuard', () => {
     }
   });
 });
+
+describe('stacked PR base warning (GH #648)', () => {
+  function input(base: string) {
+    return {
+      session_id: 'stack-test',
+      cwd: process.cwd(),
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: `gh pr create --base ${base} --head feat/x` },
+      tool_response: { stdout: 'https://github.com/srbryers/slope/pull/999' },
+    } as unknown as HookInput;
+  }
+
+  it('warns when the base is another feature branch', async () => {
+    const result = await prReviewGuard(input('feat/S246-session'), process.cwd());
+    expect(result.context).toContain('stacked PR');
+    expect(result.context).toContain('never squash');
+    expect(result.context).toContain('--delete-branch');
+  });
+
+  it.each(['main', 'master'])('does not warn for the default branch %s', async base => {
+    const result = await prReviewGuard(input(base), process.cwd());
+    expect(result.context).not.toContain('stacked PR');
+  });
+
+  it('does not warn when no base is given', async () => {
+    const bare = {
+      session_id: 'stack-test',
+      cwd: process.cwd(),
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'gh pr create --fill' },
+      tool_response: { stdout: 'https://github.com/srbryers/slope/pull/999' },
+    } as unknown as HookInput;
+    const result = await prReviewGuard(bare, process.cwd());
+    expect(result.context).not.toContain('stacked PR');
+  });
+});

--- a/tests/cli/sprint-rollover.test.ts
+++ b/tests/cli/sprint-rollover.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -7,6 +8,8 @@ import type { ResolvedActor } from '../../src/cli/actor.js';
 import {
   assessSprintRollover,
   performSprintRollover,
+  hashTrackedContent,
+  trackedContentMatches,
   type SprintRolloverAuditRecord,
 } from '../../src/cli/sprint-rollover.js';
 import {
@@ -324,6 +327,37 @@ describe('assessSprintRollover', () => {
       const issue = assessment.issues.find(i => i.code === 'target_not_pending');
       expect(issue?.message).toContain('--force --reason');
     });
+  });
+});
+
+describe('tracked-content hashing is line-ending stable (GH #649)', () => {
+  const CR = String.fromCharCode(13);
+  const LF = String.fromCharCode(10);
+  const lfText = ['{', '  "sprint_number": 10', '}', ''].join(LF);
+  const crlfText = lfText.split(LF).join(CR + LF);
+
+  it('hashes CRLF and LF content identically', () => {
+    // git renormalizes tracked text on checkout when core.autocrlf is set, so a
+    // raw-byte digest changed without the content changing and permanently
+    // invalidated every rollover audit on Windows.
+    expect(hashTrackedContent(crlfText)).toBe(hashTrackedContent(lfText));
+  });
+
+  it('accepts CRLF bytes against a digest recorded from LF content', () => {
+    const recorded = hashTrackedContent(lfText);
+    expect(trackedContentMatches(Buffer.from(crlfText, 'utf8'), recorded)).toBe(true);
+  });
+
+  it('still accepts a legacy raw-byte digest so existing audits keep verifying', () => {
+    const legacy = createHash('sha256').update(Buffer.from(crlfText, 'utf8')).digest('hex');
+    expect(legacy).not.toBe(hashTrackedContent(crlfText));
+    expect(trackedContentMatches(Buffer.from(crlfText, 'utf8'), legacy)).toBe(true);
+  });
+
+  it('rejects a real content change', () => {
+    const recorded = hashTrackedContent(lfText);
+    const tampered = lfText.replace('10', '11');
+    expect(trackedContentMatches(Buffer.from(tampered, 'utf8'), recorded)).toBe(false);
   });
 });
 

--- a/tests/core/roadmap-sources.test.ts
+++ b/tests/core/roadmap-sources.test.ts
@@ -261,3 +261,46 @@ sprints:
     expect(result.errors).toContainEqual(expect.objectContaining({ code: 'logical_sprint_collision' }));
   });
 });
+
+function sourceWithSprintId(id: string): string {
+  return [
+    'version: "1"',
+    'phase:',
+    '  name: Phase 99',
+    '  sprints:',
+    `    - ${id}`,
+    'sprints:',
+    `  - id: ${id}`,
+    '    theme: T',
+    '    par: 3',
+    '    slope: 1',
+    '    type: feature',
+    '    status: planned',
+    '    tickets:',
+    `      - {key: S${id}-1, title: T1, club: wedge, complexity: small}`,
+    '',
+  ].join(String.fromCharCode(10));
+}
+
+describe('authored sprint id ambiguity (GH #635)', () => {
+  it.each(['458.1', '458.9', '458.11', '459'])('accepts %s', id => {
+    expect(() => parseRoadmapSourceDocument(sourceWithSprintId(id), 'phases/phase-99.yaml')).not.toThrow();
+  });
+
+  it.each(['458.10', '458.0'])('rejects %s before YAML collapses it', id => {
+    // The parser would silently yield 458.1 / 458, so the text is the only place
+    // this is still detectable.
+    expect(() => parseRoadmapSourceDocument(sourceWithSprintId(id), 'phases/phase-99.yaml'))
+      .toThrow(/cannot round-trip/);
+  });
+
+  it('reports the offending line number', () => {
+    expect(() => parseRoadmapSourceDocument(sourceWithSprintId('458.10'), 'phases/phase-99.yaml'))
+      .toThrow(/line 5/);
+  });
+
+  it('leaves other decimals alone', () => {
+    // par/slope/version are numbers too but are not sprint ids.
+    expect(() => parseRoadmapSourceDocument(sourceWithSprintId('459'), 'phases/phase-99.yaml')).not.toThrow();
+  });
+});

--- a/tests/core/roadmap.test.ts
+++ b/tests/core/roadmap.test.ts
@@ -9,6 +9,7 @@ import {
   formatStrategicContext,
   formatSprintLabel,
   formatRoadmapSprintLabel,
+  describeSprintIdAmbiguity,
   nextCanonicalSprintId,
   parseSprintNumber,
   sprintOrderValue,
@@ -915,5 +916,34 @@ describe('roadmap-aware sprint labelling (GH #635)', () => {
 
   it('still renders a genuinely encoded inserted sprint as a decimal', () => {
     expect(formatRoadmapSprintLabel(roadmapWith(435, 'S43.5-1'), 435)).toBe('S43.5');
+  });
+});
+
+describe('ambiguous sprint id rejection (GH #635)', () => {
+  it.each([
+    ['458.1', 458.1],
+    ['458.9', 458.9],
+    ['458.11', 458.11],
+    ['459', 459],
+  ])('round-trips %s', (written, expected) => {
+    expect(parseSprintNumber(written)).toBe(expected);
+    expect(describeSprintIdAmbiguity(written)).toBeNull();
+  });
+
+  it.each(['458.10', '458.0', '458.100', 'S458.10'])('rejects %s as unrepresentable', written => {
+    // Stored as a number, "458.10" reads back as 458.1 and silently aliases it.
+    expect(parseSprintNumber(written)).toBeNull();
+    expect(describeSprintIdAmbiguity(written)).toContain('cannot round-trip');
+  });
+
+  it('names what the id would collapse to and suggests a renumbering', () => {
+    const problem = describeSprintIdAmbiguity('458.10');
+    expect(problem).toContain('reads back as 458.1');
+    expect(problem).toContain('458.11');
+  });
+
+  it('only inspects text, since a parsed number has already lost the zero', () => {
+    // 458.10 and 458.1 are the same number; the ambiguity exists only as written.
+    expect(describeSprintIdAmbiguity(String(458.10))).toBeNull();
   });
 });


### PR DESCRIPTION
Phase 57 — the tail of the July issue batch, plus three defects found while landing it. **Targets `main` directly**, per the stacked-PR rule this PR adds.

## Planned work

**#635 — sprint ids that cannot round-trip.** Ids are stored as JSON/YAML numbers, so a decimal whose fraction ends in a zero loses it and silently becomes an existing sprint: `458.10` reads back as `458.1`, `458.0` as `458`.

The planned approach was impossible and the plan was wrong about it: **YAML collapses `458.10` to `458.1` before any validator sees the document**, so the ambiguity is unrecoverable from the parsed value. `describeSprintIdAmbiguity` therefore takes a *string*, and there are two enforcement points — `parseSprintNumber` for `--sprint` flags, and a raw-YAML scan in `parseRoadmapSourceDocument` that reports the offending line. The scan inspects only the two positions a sprint id is written, so par/slope/version decimals are untouched.

`458.1`, `458.9`, `458.11`, `459` still round-trip; this repo's 48 sources compile unchanged. **#635 stays open** — canonical string ids remain the durable fix; this removes the silent-corruption path.

**#646 — audit refusals named no field.** A 40-term boolean chain threw "invalid shape", so diagnosing it meant reading the validator — and the real cause was a field *absent* rather than malformed, which the message gave no way to guess. Now reports the first specific problem, with array indices:

```
claims_policy              -> claims_policy must be 'unchanged'
eligibility.from_terminal  -> eligibility.from_terminal must be a boolean
scorecard_artifacts[0]     -> eligibility.scorecard_artifacts[0] must have sprint, path and sha256
```

**#648 — stacked PRs.** `branch-discipline.md` now recommends one phase branch with per-sprint commits, and states the three rules if you stack anyway: merge commit not squash (squashing rewrites history so every dependent conflicts), never `--delete-branch` a base with dependents (it *closes* them, and a closed PR cannot be retargeted so its `Closes` trailers never fire), merge strictly in order. `pr-review` now emits those rules when a PR targets a non-default base, so they arrive at creation rather than at merge.

## Found while landing this — all three fixed

**#649 — rollover audits were single-use on Windows.** Audits hash file contents as raw bytes, so `core.autocrlf` renormalization on any checkout invalidated every one of them. Proven directly:

```
audit-recorded  b23e68e2...  == git blob (LF, 4446 bytes)
working tree    d5928b82...     (CRLF, 4547 bytes)
```

Because `sprint-completion` requires lineage verification before PR creation, this blocked the entire lifecycle — the **fourth** distinct block on the same closeout path after #641 (twice) and #646. Now hashes LF-normalized content, accepting legacy digests so existing audits keep verifying.

**#651 — `scope-drift` was ~all noise.** A claim on `.` (the whole repo) silenced nothing, because both matchers built the prefix `./` which no relative path starts with — so "I'm working across this repo" was inexpressible. And `dedupGuardContext` substituted a note about its own budget exhaustion for every guard on every fire, naming no file or action while spending context to say it had none. Both fixed; a narrow claim still scopes correctly.

**#650 — filed, not fixed.** `claim-required` returns `ask` whenever sprint state is absent or non-implementing — including the `scoring` phase `slope pr` sets on merge — so the operator is asked to approve a fix only the agent can apply. I fixed it, verified both triggers stopped, then **reverted**: keying the advisory flag off the policy broke `deny`, returning no decision where it must block. The suite has no test asserting `deny` blocks, which is why that was invisible. #650 records the exact failure and says to start a retry with that test. The agent-side stop — a Sprint State Gate in `sprint-checklist.md` — is included here.

## Verification

Build, typecheck and full suite clean — 249 files, **4145 tests** (up from 4119). `slope validate` passes both scorecards; roadmap validates with 0 errors across 48 sources. Each fix was probed before and after.

The rollover chain 251 → 252 → 253 ran with no manual intervention — the first time the closeout lifecycle worked end to end this session.

## Review status

⚠️ Gates are `self_review` (weaker) — no subagents per operator direction. Self review caught that S252's planned approach was impossible, and that the reverted `claim-required` change had no `deny` coverage.

Closes #646. Closes #648. Closes #649. Closes #651.

Refs #635 — silent aliasing fixed; canonical string ids still open.
Refs #650 — agent-side mitigation only; guard fix still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
