### PR TITLE
docs: never write file content through a shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,18 @@ This repo uses SLOPE to score its own sprints:
 - Plans: `docs/backlog/sprint-N-plan.md`
 - Post-Hole: validate scorecard, generate review, update common-issues
 
+## Editing files — never through a shell
+
+Use the **Write** tool for new files and **Edit** for changes. Both take literal content with no escaping layer.
+
+When a change genuinely needs scripting (many mechanical call sites, generated JSON), **Write the script to a file, then run it** — `python scripts/foo.py`. Never inline it:
+
+- ❌ `python -c "..."` — backticks and `$` are live inside double quotes and get substituted by bash, silently deleting content.
+- ❌ `python - <<'EOF'` — you end up reasoning about escape levels across shell → Python → target file, and writing `\n` when the Python string needs `\\n` produces a real newline instead of the literal.
+- ✅ Write tool → script file → run it. One escaping layer, and the script is reviewable.
+
+**Always read back anything a script wrote.** All three failures of this kind wrote successfully with wrong content: two only surfaced when esbuild failed to parse, and one produced valid markdown with every code span silently deleted. A successful exit code proves nothing about correctness here.
+
 ## Conventions
 - `workspace:*` protocol for intra-monorepo deps
 - Conventional commits (feat/fix/chore)


### PR DESCRIPTION
Escaping in shell-inline scripts mangled a write **three times in one session** — the second and third after the first was already recorded in a scorecard, so the existing note demonstrably wasn't enough.

## The pattern

Every failure used shell-inline scripting; every success used the Write/Edit tools or a script file.

| Approach | Outcome |
|---|---|
| `python -c "...backticks..."` | bash substituted the backticks, silently deleting every code span from a markdown rule |
| heredoc + inline python (×2) | emitted a real newline where a literal `\n` was wanted → unterminated TS string literals |
| Write tool → script file → run | worked, every time |
| Write / Edit directly | worked, every time |

## Why "be more careful" isn't the fix

The mistake each time was reasoning at the **wrong escape layer** — writing `\n` for the final file when the Python string needed `\n`. That's not carelessness, it's an inherent hazard of stacking shell → Python → target file. The fix is removing a layer, not counting better.

## The compounding hazard

All three **succeeded with exit 0 and wrong content.** Two surfaced only when esbuild failed to parse; one produced perfectly valid markdown with content silently missing. So the convention also requires reading back anything a script wrote — exit status proves nothing about correctness for generated content.

Docs-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)