### PR TITLE
Phase 58: stop asking the operator, and enforce no-shell-inline-writes (#650)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -100,6 +100,12 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/slope-guard.sh phase-boundary",
             "timeout": 10,
             "statusMessage": "SLOPE: Block starting sprint in new phase if previous phase cleanup incomplete"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/slope-guard.sh shell-write",
+            "timeout": 10,
+            "statusMessage": "SLOPE: Warn when file content is written through a shell instead of Write/Edit"
           }
         ],
         "matcher": "Bash"

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -490,6 +490,15 @@
       ],
       "status": "in_progress",
       "note": "Closes out #635, #646 and #648. #635 cannot be fully fixed without canonical string sprint ids — a representational change across roadmap compile/focus/archive, sprint state, scorecards, retro paths and the store schema — so S252 removes the silent-corruption path and defers the representation. #646 and #648 are both about failures that are reachable in normal use but not diagnosable without reading source."
+    },
+    {
+      "name": "Phase 58 — Shell Write Enforcement",
+      "description": "Make the no-shell-inline-writes convention mechanical. It was recorded in an S248 scorecard and still recurred twice, so documentation alone is demonstrably insufficient for this hazard.",
+      "sprints": [
+        254
+      ],
+      "status": "in_progress",
+      "note": "Single-sprint phase. The convention landed in CLAUDE.md via #653; this adds the guard that enforces it. Scoped deliberately narrow: inline scripting that only reads or prints is correct and was used constantly and successfully, so the guard must key on a file-write call rather than on the interpreter alone."
     }
   ],
   "sprints": [
@@ -6542,6 +6551,41 @@
           "github_issue": 648,
           "depends_on": [
             "S253-2"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 254,
+      "theme": "Shell Write Enforcement",
+      "par": 3,
+      "slope": 2,
+      "type": "feature + agent ergonomics",
+      "status": "planned",
+      "note": "Escaping in shell-inline scripts mangled a write three times in one session: `python -c` with backticks had them substituted by bash (silently deleting every code span from a markdown rule), and a heredoc twice emitted a real newline where a literal \\n was wanted (unterminated TS string literals). All three exited 0 with wrong content. Every failure used shell-inline scripting; every success used the Write/Edit tools or a script file.",
+      "tickets": [
+        {
+          "key": "S254-1",
+          "title": "Add a shell-write guard that warns when an inline interpreter also writes a file",
+          "club": "short_iron",
+          "complexity": "standard"
+        },
+        {
+          "key": "S254-2",
+          "title": "Register the guard across the name union, handlers, relevance, docs and harness templates",
+          "club": "wedge",
+          "complexity": "small",
+          "depends_on": [
+            "S254-1"
+          ]
+        },
+        {
+          "key": "S254-3",
+          "title": "Cover the read-only-probe case so legitimate inline scripting stays silent",
+          "club": "wedge",
+          "complexity": "small",
+          "depends_on": [
+            "S254-1"
           ]
         }
       ]

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -492,13 +492,13 @@
       "note": "Closes out #635, #646 and #648. #635 cannot be fully fixed without canonical string sprint ids — a representational change across roadmap compile/focus/archive, sprint state, scorecards, retro paths and the store schema — so S252 removes the silent-corruption path and defers the representation. #646 and #648 are both about failures that are reachable in normal use but not diagnosable without reading source."
     },
     {
-      "name": "Phase 58 — Shell Write Enforcement",
-      "description": "Make the no-shell-inline-writes convention mechanical. It was recorded in an S248 scorecard and still recurred twice, so documentation alone is demonstrably insufficient for this hazard.",
+      "name": "Phase 58 — Stop Asking the Operator",
+      "description": "Two process failures that documentation demonstrably did not fix. Both were recorded in earlier scorecards and both recurred anyway, so each gets mechanical enforcement instead of another note.",
       "sprints": [
         254
       ],
       "status": "in_progress",
-      "note": "Single-sprint phase. The convention landed in CLAUDE.md via #653; this adds the guard that enforces it. Scoped deliberately narrow: inline scripting that only reads or prints is correct and was used constantly and successfully, so the guard must key on a file-write call rather than on the interpreter alone."
+      "note": "Re-planned mid-sprint. The phase began as a single shell-write guard ticket; the permission prompt then recurred a fourth time — immediately after the process rule for it was merged — which made clear that #650 was the priority and that process docs were not going to fix either hazard. #650 landed first."
     }
   ],
   "sprints": [
@@ -6557,35 +6557,43 @@
     },
     {
       "id": 254,
-      "theme": "Shell Write Enforcement",
-      "par": 3,
-      "slope": 2,
-      "type": "feature + agent ergonomics",
+      "theme": "Stop Asking the Operator",
+      "par": 4,
+      "slope": 3,
+      "type": "bugfix + agent ergonomics",
       "status": "planned",
-      "note": "Escaping in shell-inline scripts mangled a write three times in one session: `python -c` with backticks had them substituted by bash (silently deleting every code span from a markdown rule), and a heredoc twice emitted a real newline where a literal \\n was wanted (unterminated TS string literals). All three exited 0 with wrong content. Every failure used shell-inline scripting; every success used the Write/Edit tools or a script file.",
+      "note": "#650: claim-required returned ask on every implementation write whenever sprint state was absent or in a non-implementing phase — including the scoring phase slope pr sets the moment a PR merges — so beginning the next sprint's work always prompted. Every remedy it prints is agent-actionable, so the operator was being asked to approve a fix only the agent could apply. An earlier attempt was reverted for lack of deny coverage; this lands with it. Then the shell-write guard, making the no-shell-inline-writes convention mechanical.",
       "tickets": [
         {
           "key": "S254-1",
-          "title": "Add a shell-write guard that warns when an inline interpreter also writes a file",
+          "title": "Make claim-required advisory under the default ask policy, keeping deny blocking (#650)",
           "club": "short_iron",
-          "complexity": "standard"
+          "complexity": "standard",
+          "github_issue": 650
         },
         {
           "key": "S254-2",
-          "title": "Register the guard across the name union, handlers, relevance, docs and harness templates",
+          "title": "Add deny-policy coverage for both non-implementing branches (#650)",
           "club": "wedge",
           "complexity": "small",
+          "github_issue": 650,
           "depends_on": [
             "S254-1"
           ]
         },
         {
           "key": "S254-3",
-          "title": "Cover the read-only-probe case so legitimate inline scripting stays silent",
+          "title": "Add a shell-write guard that warns when an inline interpreter also writes a file",
+          "club": "short_iron",
+          "complexity": "standard"
+        },
+        {
+          "key": "S254-4",
+          "title": "Register the shell-write guard across the name union, handlers, relevance, docs and templates",
           "club": "wedge",
           "complexity": "small",
           "depends_on": [
-            "S254-1"
+            "S254-3"
           ]
         }
       ]

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -6561,7 +6561,7 @@
       "par": 4,
       "slope": 3,
       "type": "bugfix + agent ergonomics",
-      "status": "planned",
+      "status": "complete",
       "note": "#650: claim-required returned ask on every implementation write whenever sprint state was absent or in a non-implementing phase — including the scoring phase slope pr sets the moment a PR merges — so beginning the next sprint's work always prompted. Every remedy it prints is agent-actionable, so the operator was being asked to approve a fix only the agent could apply. An earlier attempt was reverted for lack of deny coverage; this lands with it. Then the shell-write guard, making the no-shell-inline-writes convention mechanical.",
       "tickets": [
         {

--- a/docs/retros/rollovers/sprint-253-to-254-2f4bbfce0adb77e1.json
+++ b/docs/retros/rollovers/sprint-253-to-254-2f4bbfce0adb77e1.json
@@ -1,0 +1,263 @@
+{
+  "version": 1,
+  "kind": "sprint_rollover",
+  "transition_id": "1fa3f2fc089b769d",
+  "from_sprint": 253,
+  "to_sprint": 254,
+  "from_label": "S253",
+  "to_label": "S254",
+  "recorded_at": "2026-07-25T18:11:11.038Z",
+  "actor": {
+    "name": "srbry",
+    "source": "env:USERNAME"
+  },
+  "request": {
+    "from": 253,
+    "to": 254,
+    "force": false
+  },
+  "forced": false,
+  "eligibility": {
+    "from_terminal": true,
+    "target_dependency_eligible": true,
+    "blocking_dependencies": [],
+    "target_dependencies": [],
+    "completion_evidence": {
+      "roadmap_complete": [
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        114.5,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        137.5,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        143.5,
+        143.6,
+        143.7,
+        143.8,
+        143.9,
+        143.95,
+        143.97,
+        143.98,
+        143.99,
+        144,
+        145,
+        146,
+        146.1,
+        146.2,
+        146.3,
+        148,
+        149,
+        150,
+        151,
+        151.1,
+        152,
+        152.1,
+        153,
+        154,
+        216,
+        217,
+        218,
+        219,
+        220,
+        221,
+        222,
+        223,
+        224,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        233,
+        234,
+        235,
+        236,
+        241,
+        242,
+        243,
+        244,
+        246,
+        247,
+        248,
+        249,
+        250,
+        251,
+        252,
+        253
+      ],
+      "scorecards": [],
+      "local_terminal": [
+        253
+      ]
+    },
+    "scorecard_artifacts": [],
+    "expected_next": 254
+  },
+  "roadmap": {
+    "path": "docs/backlog/roadmap.json",
+    "sha256": "bed302370095a09ebf96b2f62dd345189c3cfcc1be5da66b23501a40b446980f",
+    "from_status": "complete",
+    "to_status": "planned"
+  },
+  "prior_state_sha256": "ea96c3a2afd61d15dac699815ea7ef82f8b85d0a2870c6d6bb21a286107a9055",
+  "prior_state": {
+    "sprint": 253,
+    "phase": "scoring",
+    "gates": {
+      "tests": true,
+      "code_review": true,
+      "architect_review": true,
+      "scorecard": true,
+      "review_md": true
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local self review; no subagents per operator direction. Two of five shots in this sprint came from the operator asking whether scope-drift was worth keeping, which surfaced a root-claim matching bug and a self-referential budget message.",
+        "updated_at": "2026-07-25T17:49:35.718Z"
+      },
+      "architect_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local architecture self review of audit-shape diagnostics and the duplicated claim-area matchers; solo-session gating for scope-drift left open on #651 as a design decision.",
+        "updated_at": "2026-07-25T17:49:36.047Z"
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T17:48:41.244Z",
+    "updated_at": "2026-07-25T17:54:09.248Z",
+    "rollover": {
+      "transition_id": "cdbe5058a5c646e0",
+      "from_sprint": 252,
+      "audit_path": "docs/retros/rollovers/sprint-252-to-253-49b40f8d28b50c91.json",
+      "recorded_at": "2026-07-25T17:48:41.244Z",
+      "forced": false
+    }
+  },
+  "next_state": {
+    "sprint": 254,
+    "phase": "planning",
+    "gates": {
+      "tests": false,
+      "code_review": false,
+      "architect_review": false,
+      "scorecard": false,
+      "review_md": false
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "pending",
+        "evidence": []
+      },
+      "architect_review": {
+        "provenance": "pending",
+        "evidence": []
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T18:11:11.038Z",
+    "updated_at": "2026-07-25T18:11:11.038Z",
+    "rollover": {
+      "transition_id": "1fa3f2fc089b769d",
+      "from_sprint": 253,
+      "audit_path": "docs/retros/rollovers/sprint-253-to-254-2f4bbfce0adb77e1.json",
+      "recorded_at": "2026-07-25T18:11:11.038Z",
+      "forced": false
+    }
+  },
+  "claims_policy": "unchanged",
+  "sessions_policy": "unchanged"
+}

--- a/docs/retros/sprint-254-review.md
+++ b/docs/retros/sprint-254-review.md
@@ -1,0 +1,51 @@
+
+## Sprint 254 Review: Stop Asking the Operator
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 3 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (5/5) |
+| GIR % | 100% (5/5) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 5)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S254-1 | Short Iron | In the Hole | Bunker: This exact change was attempted in S252 and reverted because it appeared to break deny. It had not: the earlier check went through the CLI, and the failure was a probe artifact. Calling the guard directly shows deny blocking on both non-implementing branches. An hour was lost to an unverified revert that a direct-call harness would have settled immediately. | Keyed off the policy rather than the session mode: deny blocks, off returns early, default ask becomes advisory context addressed to the agent, once per session. Verified through the real hook path in this repo — no output reaches the operator. |
+| S254-2 | Wedge | Green | -- | The coverage whose absence made the S252 revert unresolvable. Five existing tests asserted the old ask contract, two of them added by me in S249 and S253; all updated to the intended behaviour. |
+| S254-3 | Short Iron | In the Hole | Rough: The guard caught its own author within a minute of being wired up, on an inline python file write — the fourth occurrence of a hazard first recorded in S248 and re-documented in #653 the same day. Confirms the mechanism was the right call over another note, and that the signal now reaches the agent rather than the operator. | Keyed on the file-write call, not the interpreter, so read-only inline scripting stays silent. 11/11 against three real failures and six legitimate patterns. |
+| S254-4 | Wedge | Green | Rough: Two registration assumptions were wrong and only typecheck caught them: toolCategories has no 'run_command' (it is 'execute_command'), and GuardHandler requires a Promise return. The docs entry shape was also different from what I assumed and had to be read first. Eight registration sites for one guard is a lot of coupling. | slope hook add generates hook config from the registry, so the registry entry covers new installs; this repo's .claude/settings.json was patched directly to take effect now. |
+| S254-5 | Short Iron | Green | Bunker: Re-planning this phase mid-sprint renamed it, which blocked slope roadmap compile: my own #637 divergence check matched phases by name, so a rename looked like authored content vanishing. A false positive in a data-protection check is expensive — it blocks legitimate work and trains operators to reach for --force, which is exactly what the check exists to prevent. | Divergence now requires an orphaned sprint, so a phase whose sprints still compile is treated as renamed. The original #637 case (a phase plus six sprints existing only in the projection) is still caught, as is a projection-only phase declaring no sprints. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| undefined | undefined | undefined |
+| undefined | undefined | undefined |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Bunker | S254-1 | This exact change was attempted in S252 and reverted because it appeared to break deny. It had not: the earlier check went through the CLI, and the failure was a probe artifact. Calling the guard directly shows deny blocking on both non-implementing branches. An hour was lost to an unverified revert that a direct-call harness would have settled immediately. |
+| Rough | S254-3 | The guard caught its own author within a minute of being wired up, on an inline python file write — the fourth occurrence of a hazard first recorded in S248 and re-documented in #653 the same day. Confirms the mechanism was the right call over another note, and that the signal now reaches the agent rather than the operator. |
+| Rough | S254-4 | Two registration assumptions were wrong and only typecheck caught them: toolCategories has no 'run_command' (it is 'execute_command'), and GuardHandler requires a Promise return. The docs entry shape was also different from what I assumed and had to be read first. Eight registration sites for one guard is a lot of coupling. |
+| Bunker | S254-5 | Re-planning this phase mid-sprint renamed it, which blocked slope roadmap compile: my own #637 divergence check matched phases by name, so a rename looked like authored content vanishing. A false positive in a data-protection check is expensive — it blocks legitimate work and trains operators to reach for --force, which is exactly what the check exists to prevent. |
+
+**Known hazards for future sprints:**
+- src/core/roadmap-sources.ts findRoadmapProjectionDivergence: a protective check with a false positive blocks real work and pushes operators toward --force.
+- Adding a guard touches eight registration sites; toolCategories and GuardHandler shapes are easy to get wrong and only typecheck catches them.
+
+### Course Management Notes
+
+- Two hazards this sprint were process failures documentation had already been written for. Both are now mechanical. Where a rule has failed twice, stop writing rules.
+- Never revert on an unverified failure. Build the direct harness first — the S252 revert cost real time and the regression was never there.
+

--- a/docs/retros/sprint-254.json
+++ b/docs/retros/sprint-254.json
@@ -1,0 +1,113 @@
+{
+  "sprint_number": 254,
+  "theme": "Stop Asking the Operator",
+  "par": 4,
+  "slope": 3,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-07-25",
+  "shots": [
+    {
+      "ticket_key": "S254-1",
+      "title": "Make claim-required advisory under the default ask policy, keeping deny blocking (#650)",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "major",
+          "description": "This exact change was attempted in S252 and reverted because it appeared to break deny. It had not: the earlier check went through the CLI, and the failure was a probe artifact. Calling the guard directly shows deny blocking on both non-implementing branches. An hour was lost to an unverified revert that a direct-call harness would have settled immediately.",
+          "gotcha_id": "self:probe-artifact"
+        }
+      ],
+      "notes": "Keyed off the policy rather than the session mode: deny blocks, off returns early, default ask becomes advisory context addressed to the agent, once per session. Verified through the real hook path in this repo \u2014 no output reaches the operator."
+    },
+    {
+      "ticket_key": "S254-2",
+      "title": "Add deny-policy coverage for both non-implementing branches (#650)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [],
+      "notes": "The coverage whose absence made the S252 revert unresolvable. Five existing tests asserted the old ask contract, two of them added by me in S249 and S253; all updated to the intended behaviour."
+    },
+    {
+      "ticket_key": "S254-3",
+      "title": "Add a shell-write guard that warns when an inline interpreter also writes a file",
+      "club": "short_iron",
+      "result": "in_the_hole",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "moderate",
+          "description": "The guard caught its own author within a minute of being wired up, on an inline python file write \u2014 the fourth occurrence of a hazard first recorded in S248 and re-documented in #653 the same day. Confirms the mechanism was the right call over another note, and that the signal now reaches the agent rather than the operator.",
+          "gotcha_id": "self:guard-caught-author"
+        }
+      ],
+      "notes": "Keyed on the file-write call, not the interpreter, so read-only inline scripting stays silent. 11/11 against three real failures and six legitimate patterns."
+    },
+    {
+      "ticket_key": "S254-4",
+      "title": "Register the shell-write guard across the name union, handlers, relevance, docs and templates",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "Two registration assumptions were wrong and only typecheck caught them: toolCategories has no 'run_command' (it is 'execute_command'), and GuardHandler requires a Promise return. The docs entry shape was also different from what I assumed and had to be read first. Eight registration sites for one guard is a lot of coupling.",
+          "gotcha_id": "self:registration-coupling"
+        }
+      ],
+      "notes": "slope hook add generates hook config from the registry, so the registry entry covers new installs; this repo's .claude/settings.json was patched directly to take effect now."
+    },
+    {
+      "ticket_key": "S254-5",
+      "title": "Unplanned: stop treating a phase rename as projection content loss",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "bunker",
+          "severity": "major",
+          "description": "Re-planning this phase mid-sprint renamed it, which blocked slope roadmap compile: my own #637 divergence check matched phases by name, so a rename looked like authored content vanishing. A false positive in a data-protection check is expensive \u2014 it blocks legitimate work and trains operators to reach for --force, which is exactly what the check exists to prevent.",
+          "gotcha_id": "self:false-positive-protection"
+        }
+      ],
+      "notes": "Divergence now requires an orphaned sprint, so a phase whose sprints still compile is treated as renamed. The original #637 case (a phase plus six sprints existing only in the projection) is still caught, as is a projection-only phase declaring no sprints."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 5,
+    "fairways_total": 5,
+    "greens_in_regulation": 5,
+    "greens_total": 5,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 4,
+    "hazard_penalties": 0,
+    "miss_directions": {
+      "long": 0,
+      "short": 0,
+      "left": 0,
+      "right": 0
+    }
+  },
+  "conditions": [
+    "Phase re-planned mid-sprint: it began as a single shell-write guard ticket, and the permission prompt recurring a fourth time made #650 the priority.",
+    "Committing was blocked by branch-before-commit because work had begun on main after a merge \u2014 the guard caught it, which is the pattern this sprint is about."
+  ],
+  "special_plays": [],
+  "bunker_locations": [
+    "src/core/roadmap-sources.ts findRoadmapProjectionDivergence: a protective check with a false positive blocks real work and pushes operators toward --force.",
+    "Adding a guard touches eight registration sites; toolCategories and GuardHandler shapes are easy to get wrong and only typecheck catches them."
+  ],
+  "yardage_book_updates": [
+    "Test guard behaviour by calling the guard function directly, not through the CLI \u2014 a CLI probe produced a false negative that caused a wrongful revert.",
+    "slope hook add generates hook config from GUARD_DEFINITIONS; a new guard needs the registry entry plus a manual patch to an already-installed .claude/settings.json.",
+    "Guards should only ask the operator when the operator has a decision. Anything an agent can resolve deterministically belongs in context."
+  ],
+  "course_management_notes": [
+    "Two hazards this sprint were process failures documentation had already been written for. Both are now mechanical. Where a rule has failed twice, stop writing rules.",
+    "Never revert on an unverified failure. Build the direct harness first \u2014 the S252 revert cost real time and the regression was never there."
+  ]
+}

--- a/docs/roadmap/phases/phase-58.yaml
+++ b/docs/roadmap/phases/phase-58.yaml
@@ -1,0 +1,39 @@
+version: "1"
+phase:
+  name: Phase 58 — Stop Asking the Operator
+  description: "Two process failures that documentation demonstrably did not fix. Both were recorded in earlier scorecards and both recurred anyway, so each gets mechanical enforcement instead of another note."
+  sprints:
+    - 254
+  status: in_progress
+  note: "Re-planned mid-sprint. The phase began as a single shell-write guard ticket; the permission prompt then recurred a fourth time — immediately after the process rule for it was merged — which made clear that #650 was the priority and that process docs were not going to fix either hazard. #650 landed first."
+sprints:
+  - id: 254
+    theme: Stop Asking the Operator
+    par: 4
+    slope: 3
+    type: bugfix + agent ergonomics
+    status: planned
+    note: "#650: claim-required returned ask on every implementation write whenever sprint state was absent or in a non-implementing phase — including the scoring phase slope pr sets the moment a PR merges — so beginning the next sprint's work always prompted. Every remedy it prints is agent-actionable, so the operator was being asked to approve a fix only the agent could apply. An earlier attempt was reverted for lack of deny coverage; this lands with it. Then the shell-write guard, making the no-shell-inline-writes convention mechanical."
+    tickets:
+      - key: S254-1
+        title: "Make claim-required advisory under the default ask policy, keeping deny blocking (#650)"
+        club: short_iron
+        complexity: standard
+        github_issue: 650
+      - key: S254-2
+        title: "Add deny-policy coverage for both non-implementing branches (#650)"
+        club: wedge
+        complexity: small
+        github_issue: 650
+        depends_on:
+          - S254-1
+      - key: S254-3
+        title: Add a shell-write guard that warns when an inline interpreter also writes a file
+        club: short_iron
+        complexity: standard
+      - key: S254-4
+        title: Register the shell-write guard across the name union, handlers, relevance, docs and templates
+        club: wedge
+        complexity: small
+        depends_on:
+          - S254-3

--- a/docs/roadmap/phases/phase-58.yaml
+++ b/docs/roadmap/phases/phase-58.yaml
@@ -12,7 +12,7 @@ sprints:
     par: 4
     slope: 3
     type: bugfix + agent ergonomics
-    status: planned
+    status: complete
     note: "#650: claim-required returned ask on every implementation write whenever sprint state was absent or in a non-implementing phase — including the scoring phase slope pr sets the moment a PR merges — so beginning the next sprint's work always prompted. Every remedy it prints is agent-actionable, so the operator was being asked to approve a fix only the agent could apply. An earlier attempt was reverted for lack of deny coverage; this lands with it. Then the shell-write guard, making the no-shell-inline-writes convention mechanical."
     tickets:
       - key: S254-1
@@ -37,3 +37,5 @@ sprints:
         complexity: small
         depends_on:
           - S254-3
+scorecards:
+  "254": docs/retros/sprint-254.json

--- a/docs/roadmap/project.yaml
+++ b/docs/roadmap/project.yaml
@@ -99,3 +99,5 @@ sources:
     kind: phase
   - path: phases/phase-57.yaml
     kind: phase
+  - path: phases/phase-58.yaml
+    kind: phase

--- a/src/cli/commands/guard.ts
+++ b/src/cli/commands/guard.ts
@@ -11,6 +11,7 @@ import { exploreGuard } from '../guards/explore.js';
 import { hazardGuard } from '../guards/hazard.js';
 import { commitNudgeGuard } from '../guards/commit-nudge.js';
 import { scopeDriftGuard } from '../guards/scope-drift.js';
+import { shellWriteGuard } from '../guards/shell-write.js';
 import { compactionGuard } from '../guards/compaction.js';
 import { stopCheckGuard } from '../guards/stop-check.js';
 import { subagentGateGuard } from '../guards/subagent-gate.js';
@@ -85,6 +86,7 @@ const handlers: Partial<Record<GuardName, GuardHandler>> = {
   hazard: hazardGuard,
   'commit-nudge': commitNudgeGuard,
   'scope-drift': scopeDriftGuard,
+  'shell-write': shellWriteGuard,
   compaction: compactionGuard,
   'stop-check': stopCheckGuard,
   'subagent-gate': subagentGateGuard,
@@ -965,6 +967,7 @@ const GUARD_RELEVANCE: Record<string, GuardRelevance> = {
   'worktree-merge': { when: 'multi-session', why: 'Prevents gh pr merge failures in worktrees' },
   'worktree-self-remove': { when: 'multi-session', why: 'Prevents shell breakage from self-removing worktree' },
   'scope-drift': { when: 'sprint-workflow', why: 'Keeps work focused on claimed tickets' },
+  'shell-write': { when: 'always', why: 'Shell escaping silently corrupts written file content' },
   'sprint-completion': { when: 'sprint-workflow', why: 'Blocks PR until tests pass and scorecard exists' },
   'review-tier': { when: 'sprint-workflow', why: 'Prompts for plan review after writing plan files' },
   'workflow-gate': { when: 'sprint-workflow', why: 'Blocks plan exit until review rounds complete' },

--- a/src/cli/guards/claim-required.ts
+++ b/src/cli/guards/claim-required.ts
@@ -5,7 +5,7 @@ import type { HookInput, GuardResult, SprintClaim } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import { inferSprintContext } from '../sprint-inference.js';
 import { loadSprintState } from '../sprint-state.js';
-import { isAdhocSession, loadSessionState, updateSessionState } from '../session-state.js';
+import { loadSessionState, updateSessionState } from '../session-state.js';
 import { resolveStore } from '../store.js';
 import { normalizeTouchedPath, resolveTouchedPaths, toAbsoluteTouchedPath } from './hook-input.js';
 
@@ -90,12 +90,18 @@ export async function claimRequiredGuard(input: HookInput, cwd: string): Promise
 
   const policy = getImplementationWritePolicy(cwd);
 
-  // Adhoc mode advertises "sprint-workflow guards silenced", so this guard must
-  // not gate the host there. It still runs — the missing-claim signal is useful —
-  // but it emits advisory context instead of ask/deny, and only once per session.
-  // Previously every implementation write in an adhoc session raised a host
-  // permission prompt (GH #643).
-  const advisoryOnly = isAdhocSession(cwd, sessionId);
+  // Never raise a host permission prompt for something the agent can fix itself.
+  // Every remedy this guard prints — `slope sprint start`, `slope claim` — is
+  // deterministic and needs no human judgement, so asking interrupts the operator
+  // for a decision that is not theirs. It fired on every implementation write
+  // whenever sprint state was absent or in a non-implementing phase, including the
+  // `scoring` phase that `slope pr` sets the moment a PR merges, so beginning the
+  // next sprint's work always prompted (GH #643, #650).
+  //
+  // Keyed off the policy, not the session mode: "deny" still blocks, "off" already
+  // returns early, and the default "ask" becomes advisory context addressed to the
+  // agent, recorded once per session.
+  const advisoryOnly = policy !== 'deny';
 
   // Check if there's an active sprint with claims
   const sprintState = loadSprintState(cwd);
@@ -229,9 +235,9 @@ function implementationWritePolicyResult(
     updateSessionState(ctx.cwd, 'claim_warned_session_id', ctx.sessionId);
     return {
       context: [
-        'SLOPE advisory (non-blocking) — adhoc session, so sprint-workflow gating is off.',
+        'SLOPE advisory (non-blocking) — addressed to the agent, not a permission request.',
         ...lines,
-        'Run `slope sprint start` to re-enter the sprint workflow if this is sprint work.',
+        'Run the suggested command, then continue. Set guidance.requireSprintForImplementationWrites to "deny" to block instead.',
       ].join('\n'),
     };
   }

--- a/src/cli/guards/docs.ts
+++ b/src/cli/guards/docs.ts
@@ -35,6 +35,13 @@ export const GUARD_DOCS: Record<string, GuardDoc> = {
     configuration: 'guidance.commitInterval (default: 15 minutes) controls the nudge threshold. Disable: add "commit-nudge" to guidance.disabled.',
     level: 'full',
   },
+  'shell-write': {
+    purpose: 'Warns when file content is written through a shell instead of the Write/Edit tools. Shell escaping silently corrupts written content, and the write still exits 0.',
+    triggers: 'PreToolUse on Bash. Fires when an inline interpreter (python -c, node -e, a piped heredoc) also contains a file-write call, or when a heredoc is redirected straight into a file.',
+    behavior: 'Advisory — injects guidance to use the Write/Edit tools, or to write the script to a file and run it. Does not block. Once per session. Inline scripting that only reads, computes or prints is not flagged.',
+    configuration: 'Advisory only. Disable: add "shell-write" to guidance.disabled.',
+    level: 'full',
+  },
   'scope-drift': {
     purpose: 'Warns when the agent edits files outside the claimed ticket scope. Keeps work focused and prevents unintended changes.',
     triggers: 'PreToolUse on Edit, Write. Fires when a file modification is attempted.',

--- a/src/cli/guards/shell-write.ts
+++ b/src/cli/guards/shell-write.ts
@@ -1,0 +1,87 @@
+import type { HookInput, GuardResult } from '../../core/index.js';
+import { dedupGuardContext } from '../session-state.js';
+
+/**
+ * Inline interpreter invocations — a script passed on the command line or piped in
+ * from a heredoc, rather than run from a file.
+ */
+const INLINE_INTERPRETER = [
+  /\b(?:python|python3|py)\s+(?:-\S+\s+)*-c\b/,
+  /\bnode\s+(?:--\S+\s+)*(?:-e|--eval|--print)\b/,
+  /\b(?:perl|ruby)\s+-e\b/,
+  /\b(?:python|python3|py|node|perl|ruby)\s+-\s*<</,
+  /\b(?:python|python3|py|node|perl|ruby)\s+<</,
+];
+
+/**
+ * Calls that write a file. The interpreter alone is not the hazard — reading,
+ * computing and printing inline is correct and common. Writing file content
+ * through a shell is what stacks escaping layers.
+ */
+const FILE_WRITE_CALL = [
+  /\bopen\s*\([^)]*['"][wa]\+?b?['"]/,      // python open(path, 'w')
+  /\bio\.open\s*\([^)]*['"][wa]/,           // python io.open(path, 'w')
+  /\.write_text\s*\(/,                      // pathlib
+  /\bwriteFileSync\b/,
+  /\bappendFileSync\b/,
+  /\bcreateWriteStream\b/,
+  /\bfs\.promises\.writeFile\b/,
+  /\bFile\.write\b/,                        // ruby
+];
+
+/** A heredoc redirected straight into a file: `cat > x.ts <<'EOF'`. */
+const HEREDOC_TO_FILE = /(?:^|[;&|]\s*)(?:cat|tee)\s+[^<|;&]*>>?\s*\S+[^<]*<</;
+
+/**
+ * shell-write guard: fires PreToolUse on Bash.
+ *
+ * Warns when file content is written through a shell rather than with the Write
+ * or Edit tools. Advisory only, once per session.
+ *
+ * Escaping in shell-inline scripts mangled a write three times in one session on
+ * this repo, the second and third after the first was already recorded in a
+ * scorecard — documentation alone did not fix it. `python -c` with backticks had
+ * them substituted by bash, silently deleting every code span from a markdown
+ * rule; a heredoc twice emitted a real newline where a literal \\n was wanted,
+ * producing unterminated TypeScript string literals. All three exited 0 with wrong
+ * content, so nothing failed loudly.
+ *
+ * Deliberately keyed on a file-write call, not on the interpreter: inline scripting
+ * that only reads, computes or prints has one escaping layer and was used
+ * constantly and correctly.
+ */
+export async function shellWriteGuard(input: HookInput, cwd: string): Promise<GuardResult> {
+  if (input.tool_name !== 'Bash') return { metricReason: 'irrelevant-tool' };
+
+  const command = typeof input.tool_input?.command === 'string' ? input.tool_input.command : '';
+  if (!command) return { metricReason: 'no-command' };
+
+  const reason = describeShellWrite(command);
+  if (!reason) return { metricReason: 'no-match' };
+
+  const message = [
+    `SLOPE advisory (non-blocking) — ${reason}`,
+    'Use the Write tool for new files and Edit for changes; both take literal content with no escaping layer.',
+    'If scripting is genuinely needed, write the script to a file and run it — never inline it.',
+    'Read back anything a script wrote: this class of failure exits 0 with wrong content.',
+  ].join('\n');
+
+  const dedup = dedupGuardContext(cwd, input.session_id, 'shell-write', message);
+  if (dedup === '') return { metricReason: 'budget-exhausted' };
+  return { metricReason: 'matched', context: dedup ?? message };
+}
+
+/** Describe how a command writes file content through a shell, or null. */
+export function describeShellWrite(command: string): string | null {
+  if (HEREDOC_TO_FILE.test(command)) {
+    return 'this redirects a heredoc into a file, so the shell processes the content on its way to disk.';
+  }
+
+  const interpreter = INLINE_INTERPRETER.some(pattern => pattern.test(command));
+  if (!interpreter) return null;
+
+  const writes = FILE_WRITE_CALL.some(pattern => pattern.test(command));
+  if (!writes) return null;
+
+  return 'this runs an inline script that writes a file, stacking shell and script escaping.';
+}

--- a/src/core/guard.ts
+++ b/src/core/guard.ts
@@ -94,6 +94,7 @@ export type GuardName =
   | 'hazard'
   | 'commit-nudge'
   | 'scope-drift'
+  | 'shell-write'
   | 'compaction'
   | 'stop-check'
   | 'subagent-gate'
@@ -207,6 +208,15 @@ export const GUARD_DEFINITIONS: GuardDefinition[] = [
     hookEvent: 'PreToolUse',
     toolCategories: ['write_file'],
     matcher: 'Edit|Write',
+    level: 'full',
+    guardType: 'advisory',
+  },
+  {
+    name: 'shell-write',
+    description: 'Warn when file content is written through a shell instead of the Write/Edit tools',
+    hookEvent: 'PreToolUse',
+    toolCategories: ['execute_command'],
+    matcher: 'Bash',
     level: 'full',
     guardType: 'advisory',
   },

--- a/src/core/roadmap-sources.ts
+++ b/src/core/roadmap-sources.ts
@@ -549,9 +549,19 @@ export function findRoadmapProjectionDivergence(
   const compiledPhases = new Set((compiled.phases ?? []).map(phase => phase.name));
   const diskPhases = Array.isArray(disk.phases) ? disk.phases : [];
   const phases = diskPhases
-    .map(phase => (phase && typeof phase === 'object' ? (phase as { name?: unknown }).name : undefined))
-    .filter((name): name is string => typeof name === 'string')
-    .filter(name => !compiledPhases.has(name));
+    .filter((phase): phase is { name?: unknown; sprints?: unknown } =>
+      !!phase && typeof phase === 'object')
+    .filter(phase => typeof phase.name === 'string' && !compiledPhases.has(phase.name))
+    // A phase whose sprints all still compile was renamed or reorganised, not
+    // lost. Reporting it as content loss made every phase rename look destructive
+    // and blocked the compile — the original #637 case lost the phase *and* its
+    // six sprints, so requiring an orphaned sprint keeps that caught.
+    .filter(phase => {
+      const ids = Array.isArray(phase.sprints) ? phase.sprints : [];
+      if (ids.length === 0) return true;
+      return ids.some(id => id != null && !compiledSprints.has(String(id)));
+    })
+    .map(phase => phase.name as string);
 
   if (sprints.length === 0 && phases.length === 0) return null;
   return { sprints: [...new Set(sprints)], phases: [...new Set(phases)] };

--- a/tests/cli/commands/guard.test.ts
+++ b/tests/cli/commands/guard.test.ts
@@ -165,7 +165,7 @@ describe('guardCommand dispatcher path', () => {
     vi.restoreAllMocks();
   });
 
-  it('emits advisory context, not ask, for claim-required on adhoc implementation writes (GH #643)', async () => {
+  it('emits advisory context, not ask, for claim-required implementation writes (GH #643, #650)', async () => {
     const output = await runGuardCommandWithInput(['claim-required'], makeHookInput(cwd));
     const parsed = JSON.parse(output);
 
@@ -173,7 +173,7 @@ describe('guardCommand dispatcher path', () => {
     // Adhoc mode advertises "sprint-workflow guards silenced", so the guard
     // reports but must not gate the host on every write.
     expect(parsed.hookSpecificOutput.permissionDecision).toBeUndefined();
-    expect(parsed.hookSpecificOutput.additionalContext).toContain('adhoc session');
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('not a permission request');
     expect(parsed.hookSpecificOutput.additionalContext).toContain('no active sprint state');
     expect(parsed.hookSpecificOutput.additionalContext).toContain('slope sprint start');
 

--- a/tests/cli/commands/hook-codex.test.ts
+++ b/tests/cli/commands/hook-codex.test.ts
@@ -62,7 +62,7 @@ describe('slope hook add --harness=codex', () => {
     await hookCommand(['add', '--level=full', '--harness=codex']);
 
     const output = log.mock.calls.map(call => call.join(' ')).join('\n');
-    expect(output).toContain('Installed 30 of 31 guard hooks (level: full)');
+    expect(output).toContain('Installed 31 of 32 guard hooks (level: full)');
     expect(output).toContain('compaction');
     expect(output).toContain('unsupported by harness');
   });

--- a/tests/cli/guards/claim-required.test.ts
+++ b/tests/cli/guards/claim-required.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../src/cli/guards/claim-required.js';
 import type { HookInput } from '../../../src/core/index.js';
 import { createStore } from '../../../src/store/index.js';
-import { setSessionMode } from '../../../src/cli/session-state.js';
+import { createSprintState, saveSprintState } from '../../../src/cli/sprint-state.js';
 
 function makeInput(cwd: string, filePath: string): HookInput {
   return {
@@ -173,31 +173,35 @@ describe('isImplementationWritePath', () => {
 });
 
 describe('claimRequiredGuard', () => {
-  describe('adhoc mode (GH #643)', () => {
-    it('emits advisory context instead of gating the host', async () => {
-      const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-adhoc-'));
+  describe('implementation-write policy (GH #643, #650)', () => {
+    function writeConfigWithPolicy(cwd: string, policy: string): void {
+      mkdirSync(join(cwd, '.slope'), { recursive: true });
+      writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({
+        scorecardDir: 'docs/retros',
+        guidance: { requireSprintForImplementationWrites: policy },
+      }));
+    }
+
+    it('emits advisory context rather than gating under the default ask policy', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-policy-'));
       try {
         writeConfig(cwd);
-        setSessionMode(cwd, 'test-session', 'adhoc');
-
         const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
 
-        // Adhoc advertises "sprint-workflow guards silenced", so no ask/deny.
+        // Every remedy this guard prints is agent-actionable, so it must not ask
+        // the operator to approve it.
         expect(result.decision).toBeUndefined();
-        expect(result.context).toContain('adhoc session');
+        expect(result.context).toContain('not a permission request');
         expect(result.context).toContain('src/foo.ts');
-        expect(result.context).toContain('slope sprint start');
       } finally {
         rmSync(cwd, { recursive: true, force: true });
       }
     });
 
     it('warns once per session rather than on every write', async () => {
-      const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-adhoc-'));
+      const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-policy-'));
       try {
         writeConfig(cwd);
-        setSessionMode(cwd, 'test-session', 'adhoc');
-
         const first = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
         const second = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/bar.ts')), cwd);
 
@@ -208,45 +212,72 @@ describe('claimRequiredGuard', () => {
       }
     });
 
-    it('still gates with ask when the session is not adhoc', async () => {
-      const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-sprint-'));
+    // These deny assertions are the coverage whose absence let an earlier attempt
+    // at this change silently disable strict mode (GH #650).
+    it('still blocks under the deny policy when no sprint state exists', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-deny-'));
       try {
-        writeConfig(cwd);
-        setSessionMode(cwd, 'test-session', 'sprint');
-
+        writeConfigWithPolicy(cwd, 'deny');
         const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
 
-        expect(result.decision).toBe('ask');
+        expect(result.decision).toBe('deny');
+        expect(result.blockReason).toContain('no active sprint state');
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it('still blocks under the deny policy when the sprint is not implementing', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-deny-'));
+      try {
+        writeConfigWithPolicy(cwd, 'deny');
+        saveSprintState(cwd, createSprintState(300, 'scoring'));
+        const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+
+        expect(result.decision).toBe('deny');
+        expect(result.blockReason).toContain('scoring');
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+
+    it('stays silent under the off policy', async () => {
+      const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-off-'));
+      try {
+        writeConfigWithPolicy(cwd, 'off');
+        const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
+
+        expect(result).toEqual({});
       } finally {
         rmSync(cwd, { recursive: true, force: true });
       }
     });
   });
 
-  it('asks before implementation writes when no sprint state is active', async () => {
+  it('reports implementation writes without gating when no sprint state is active', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
     try {
       writeConfig(cwd);
       const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
 
-      expect(result.decision).toBe('ask');
-      expect(result.context).toContain('SLOPE permission request');
+      expect(result.decision).toBeUndefined();
+      expect(result.context).toContain('not a permission request');
       expect(result.context).toContain('no active sprint state');
       expect(result.context).toContain('slope sprint start');
       expect(result.context).toContain('slope claim');
-      expect(result.context).toContain('does not replace the host permission policy');
+      expect(result.context).toContain('deny');
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
   });
 
-  it('asks before Codex apply_patch implementation writes when no sprint state is active', async () => {
+  it('reports Codex apply_patch implementation writes without gating when no sprint state is active', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
     try {
       writeConfig(cwd);
       const result = await claimRequiredGuard(makeApplyPatchInput(cwd, join(cwd, 'src/foo.ts')), cwd);
 
-      expect(result.decision).toBe('ask');
+      expect(result.decision).toBeUndefined();
       expect(result.context).toContain('src/foo.ts');
       expect(result.context).toContain('no active sprint state');
       expect(result.context).toContain('slope claim');
@@ -297,7 +328,7 @@ describe('claimRequiredGuard', () => {
       writeInsertedRoadmap(cwd);
       const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
 
-      expect(result.decision).toBe('ask');
+      expect(result.decision).toBeUndefined();
       expect(result.context).toContain('Detected likely sprint context: S43.5');
       expect(result.context).toContain('slope sprint start --number=435 --phase=implementing');
     } finally {
@@ -330,14 +361,14 @@ describe('claimRequiredGuard', () => {
     }
   });
 
-  it('asks before implementation writes when sprint is not in implementing phase', async () => {
+  it('reports implementation writes without gating when sprint is not in implementing phase', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'slope-claim-required-'));
     try {
       writeConfig(cwd);
       writeSprintState(cwd, 'planning');
       const result = await claimRequiredGuard(makeInput(cwd, join(cwd, 'src/foo.ts')), cwd);
 
-      expect(result.decision).toBe('ask');
+      expect(result.decision).toBeUndefined();
       expect(result.context).toContain('planning phase');
     } finally {
       rmSync(cwd, { recursive: true, force: true });

--- a/tests/cli/guards/shell-write.test.ts
+++ b/tests/cli/guards/shell-write.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describeShellWrite, shellWriteGuard } from '../../../src/cli/guards/shell-write.js';
+import type { HookInput } from '../../../src/core/index.js';
+
+const LF = String.fromCharCode(10);
+const SQ = String.fromCharCode(39);
+
+function heredoc(...lines: string[]): string {
+  return lines.join(LF);
+}
+
+function workspace(): string {
+  const cwd = mkdtempSync(join(tmpdir(), 'slope-shell-write-'));
+  mkdirSync(join(cwd, '.slope'), { recursive: true });
+  writeFileSync(join(cwd, '.slope', 'config.json'), JSON.stringify({ scorecardDir: 'docs/retros' }));
+  return cwd;
+}
+
+function bash(command: string): HookInput {
+  return {
+    session_id: 'shell-write-test',
+    cwd: process.cwd(),
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    tool_input: { command },
+  } as unknown as HookInput;
+}
+
+describe('describeShellWrite', () => {
+  describe('flags writing file content through a shell', () => {
+    it('flags python -c that opens a file for writing', () => {
+      // The real failure: backticks in the script were substituted by bash,
+      // silently deleting every code span from a markdown rule.
+      const command = `python -c "import io; io.open(${SQ}x.md${SQ}, ${SQ}w${SQ}).write(s)"`;
+      expect(describeShellWrite(command)).toContain('inline script that writes a file');
+    });
+
+    it('flags a heredoc-fed interpreter that writes a file', () => {
+      // The real failure, twice: a literal newline escape became a real newline,
+      // producing unterminated TypeScript string literals.
+      const command = heredoc(
+        `python - <<${SQ}EOF${SQ}`,
+        `io.open(${SQ}t.ts${SQ}, ${SQ}w${SQ}, encoding=${SQ}utf-8${SQ}).write(out)`,
+        'EOF',
+      );
+      expect(describeShellWrite(command)).toContain('inline script that writes a file');
+    });
+
+    it('flags a heredoc redirected straight into a file', () => {
+      const command = heredoc(`cat > tests/foo.test.ts <<${SQ}EOF${SQ}`, 'content', 'EOF');
+      expect(describeShellWrite(command)).toContain('redirects a heredoc into a file');
+    });
+
+    it.each([
+      [`node -e "require(${SQ}fs${SQ}).writeFileSync(${SQ}a.ts${SQ}, s)"`, 'writeFileSync'],
+      [`node -e "require(${SQ}fs${SQ}).appendFileSync(${SQ}a.ts${SQ}, s)"`, 'appendFileSync'],
+      [`python -c "from pathlib import Path; Path(${SQ}a.md${SQ}).write_text(s)"`, 'pathlib write_text'],
+    ])('flags %s', command => {
+      expect(describeShellWrite(command)).not.toBeNull();
+    });
+  });
+
+  describe('leaves legitimate inline scripting alone', () => {
+    // Reading, computing and printing inline has one escaping layer and is correct.
+    // Flagging it would make the guard noise, which is what killed scope-drift's
+    // signal (GH #651).
+    it.each([
+      [`python -c "import json; print(json.load(open(${SQ}package.json${SQ}))[${SQ}version${SQ}])"`, 'read and print'],
+      ['node -e "console.log(process.version)"', 'print only'],
+      ['node dist/cli/index.js roadmap compile', 'running a built CLI'],
+      ['python scripts/foo.py', 'running a script file — the recommended path'],
+      ['grep -rn "pattern" src/ | head -5', 'plain shell'],
+    ])('stays silent for %s', command => {
+      expect(describeShellWrite(command)).toBeNull();
+    });
+
+    it('stays silent for a heredoc feeding a commit message rather than a file', () => {
+      const command = `git commit -q -m "$(cat <<EOF${LF}message body${LF}EOF${LF})"`;
+      expect(describeShellWrite(command)).toBeNull();
+    });
+  });
+});
+
+describe('shellWriteGuard', () => {
+  it('emits advisory context, never a decision', async () => {
+    const cwd = workspace();
+    try {
+      const command = `python -c "import io; io.open(${SQ}x.md${SQ}, ${SQ}w${SQ}).write(s)"`;
+      const result = await shellWriteGuard(bash(command), cwd);
+
+      expect(result.decision).toBeUndefined();
+      expect(result.context).toContain('Write tool');
+      expect(result.context).toContain('Read back anything a script wrote');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('warns once per session', async () => {
+    const cwd = workspace();
+    try {
+      const command = `python -c "import io; io.open(${SQ}x.md${SQ}, ${SQ}w${SQ}).write(s)"`;
+      const first = await shellWriteGuard(bash(command), cwd);
+      const second = await shellWriteGuard(bash(command), cwd);
+
+      expect(first.context).toBeTruthy();
+      expect(second.context ?? '').not.toBe(first.context);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores non-Bash tools', async () => {
+    const cwd = workspace();
+    try {
+      const input = { ...bash('irrelevant'), tool_name: 'Write' } as HookInput;
+      const result = await shellWriteGuard(input, cwd);
+
+      expect(result.context).toBeUndefined();
+      expect(result.metricReason).toBe('irrelevant-tool');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli/roadmap-sources.test.ts
+++ b/tests/cli/roadmap-sources.test.ts
@@ -883,3 +883,50 @@ describe('generated-file marker (GH #644)', () => {
     expect(stripRoadmapProjectionMarker(store.projection)).toBe(store.projection);
   });
 });
+
+describe('projection divergence ignores phase renames (GH #637 follow-up)', () => {
+  const compiled = {
+    name: 'r',
+    phases: [{ name: 'Phase 58 — Current Name', sprints: [254] }],
+    sprints: [{ id: 254, theme: 'T', par: 3 as const, slope: 1, type: 'feature', tickets: [] }],
+  };
+
+  it('does not treat a renamed phase as content loss when its sprints survive', () => {
+    // Renaming a phase in the source used to look destructive, because phases were
+    // matched by name — which blocked the compile on any rename.
+    const disk = JSON.stringify({
+      phases: [{ name: 'Phase 58 — Previous Name', sprints: [254] }],
+      sprints: [{ id: 254 }],
+    });
+
+    expect(findRoadmapProjectionDivergence(disk, compiled)).toBeNull();
+  });
+
+  it('still reports a phase whose sprints exist only in the projection', () => {
+    // The original #637 loss: a phase plus six sprints that no source produced.
+    const disk = JSON.stringify({
+      phases: [
+        { name: 'Phase 58 — Current Name', sprints: [254] },
+        { name: 'Phase 49 — Authored Only', sprints: [464, 465] },
+      ],
+      sprints: [{ id: 254 }, { id: 464 }, { id: 465 }],
+    });
+
+    const divergence = findRoadmapProjectionDivergence(disk, compiled);
+    expect(divergence?.phases).toEqual(['Phase 49 — Authored Only']);
+    expect(divergence?.sprints).toEqual(['464', '465']);
+  });
+
+  it('still reports a projection-only phase that declares no sprints', () => {
+    const disk = JSON.stringify({
+      phases: [
+        { name: 'Phase 58 — Current Name', sprints: [254] },
+        { name: 'Phase 99 — Empty Authored', sprints: [] },
+      ],
+      sprints: [{ id: 254 }],
+    });
+
+    expect(findRoadmapProjectionDivergence(disk, compiled)?.phases)
+      .toEqual(['Phase 99 — Empty Authored']);
+  });
+});

--- a/tests/core/guard.test.ts
+++ b/tests/core/guard.test.ts
@@ -12,7 +12,7 @@ import '../../src/core/adapters/claude-code.js';
 
 describe('GUARD_DEFINITIONS', () => {
   it('has 31 guard definitions', () => {
-    expect(GUARD_DEFINITIONS).toHaveLength(31);
+    expect(GUARD_DEFINITIONS).toHaveLength(32);
   });
 
   it('all guards have required fields', () => {


### PR DESCRIPTION
Phase 58 — make two process failures mechanical, because documentation demonstrably did not fix them. **Targets `main` directly.**

## #650 — stop asking the operator to approve an agent-actionable fix

`claim-required` returned `ask` on every implementation write whenever sprint state was absent or in a non-implementing phase — including the `scoring` phase `slope pr` sets the moment a PR merges. With the default policy that is a host permission prompt per edit, and every remedy it prints (`slope sprint start`, `slope claim`) is agent-actionable. The operator was being asked to approve a fix only the agent could apply. They objected **four times** across this session.

Keyed off the policy now, not the session mode:

```
deny  / no state       -> deny
deny  / scoring phase  -> deny
ask   / no state       -> advisory context, no decision
ask   / scoring phase  -> advisory context, no decision
off   / no state       -> silent
```

This exact change was attempted in S252 and **reverted**, because it appeared to break `deny`. It had not — the earlier probe went through the CLI, and the failure was a probe artifact. Calling the guard directly shows `deny` blocking on both branches. This lands with the deny coverage whose absence made that revert unresolvable. Five existing tests asserted the old `ask` contract (two of them mine, from S249/S253); all updated.

Verified through the real hook path in this repo: no output reaches the operator.

## Shell-write guard — make the no-shell-inline-writes convention mechanical

The convention (Write/Edit tools, or a script file — never `python -c` or a heredoc) was recorded in an S248 scorecard, recurred twice, then recurred a **third time immediately after it was merged as a rule in #653**. Documentation was not going to fix this.

The guard fires PreToolUse on Bash when an inline interpreter also contains a file-write call, or when a heredoc is redirected straight into a file. Advisory, once per session. Deliberately keyed on the **write**, not the interpreter — read/compute/print inline has one escaping layer and was used constantly and correctly all session; flagging it would make noise, which is what killed scope-drift's signal (#651). 11/11 against three real failures and six legitimate patterns, no false positives.

It caught its own author within a minute of being wired up, on an inline python file write. That is the mechanism working: the signal reaches the agent, not the operator.

## Phase-rename false positive in the #637 divergence check

Wiring the guard required re-planning Phase 58, and **renaming it blocked `slope roadmap compile`** — my own #637 protection matched phases by name, so a rename looked like authored content vanishing. A false positive in a data-protection check is expensive: it blocks legitimate work and pushes operators toward `--force`, which is what the check exists to prevent.

Divergence now requires an orphaned sprint. A phase whose sprints still compile is treated as renamed; the original #637 case (a phase *plus* six sprints only in the projection) is still caught, as is a projection-only phase with no sprints.

## Verification

Build, typecheck, full suite clean — 250 files, **4165 tests** (up from 4147). Guard count 31 → 32. Each fix probed before and after through the real hook path.

## Review status

⚠️ Gates are `self_review` (weaker) — no subagents per operator direction. Self review's main catch this sprint was that the S252 revert of the #650 fix was wrong: the regression never existed, and a direct-call harness settled it immediately.

Closes #650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
