### PR TITLE
chore: normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,13 @@
+# Normalize all text files to LF, in the repo and in the working tree.
+#
+# core.autocrlf=true on Windows otherwise rewrites tracked text to CRLF on every
+# checkout. That did two kinds of damage:
+#   - a "LF will be replaced by CRLF" warning on literally every commit, and
+#   - changed content hashes, which invalidated rollover audits and hard-blocked
+#     the sprint lifecycle (GH #649).
+# eol=lf forces LF on checkout regardless of a contributor's autocrlf setting, so
+# the working tree matches what CI (Linux) sees.
+* text=auto eol=lf
+
+# Shell scripts must be LF to run; kept explicit even though text=auto covers it.
 *.sh text eol=lf


### PR DESCRIPTION
Removes the root cause behind #649 and the `LF will be replaced by CRLF` warning that appeared on **every commit** this session.

## What was actually wrong

The repo blobs were **already LF** — `git ls-files --eol` shows `i/lf` for every file. But `core.autocrlf=true` rewrote the working tree to CRLF on checkout (`w/crlf`), so:
- git warned on every commit that it would convert the CRLF working-tree bytes back to LF, and
- the CRLF working-tree bytes hashed differently from the LF blob, which invalidated rollover audits and hard-blocked the sprint lifecycle (#649, fixed defensively there — this removes the root cause).

## The fix, and why it's tiny

`* text=auto eol=lf` forces LF in the working tree regardless of a contributor's `autocrlf`, matching what CI (Linux) sees. **Blast radius is just `.gitattributes`** — `git add --renormalize .` staged nothing else, because the committed content was already LF. There is no mass file rewrite; the working tree flips CRLF→LF on next checkout, and the warnings stop.

Verified: after re-checkout, `git ls-files --eol` reports `w/lf`, and `git add` on a touched file produces no CRLF warning. Build clean; the byte-sensitive suites (sprint-rollover, roadmap-sources, repo-roadmap-sources — 86 tests) pass.

Kept the existing explicit `*.sh text eol=lf` since shell scripts must be LF to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)