### PR TITLE
Phase 59: cleanups — gitignore .codex, consolidate claim-area matcher, pin no-operator-ask invariant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 *.tsbuildinfo
 .DS_Store
 .slope/
+.codex/
 .env
 .aider*
 .claude/worktrees/

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -499,6 +499,15 @@
       ],
       "status": "in_progress",
       "note": "Re-planned mid-sprint. The phase began as a single shell-write guard ticket; the permission prompt then recurred a fourth time — immediately after the process rule for it was merged — which made clear that #650 was the priority and that process docs were not going to fix either hazard. #650 landed first."
+    },
+    {
+      "name": "Phase 59 — Cleanups",
+      "description": "Three low-risk items surfaced while reviewing the session: the generated .codex bundle showing as untracked on every status, duplicated claim-area matching logic that both needed the same #651 fix, and an audit of which guards prompt the operator. The audit's conclusion is a regression test rather than a downgrade.",
+      "sprints": [
+        256
+      ],
+      "status": "in_progress",
+      "note": "The ask/deny guard audit found only claim-required ever emitted an operator ask (fixed in #650); every other guard uses deny, which blocks the tool and returns to the agent, not the operator. Nothing to downgrade — the deliverable is a fleet-level invariant test so the pattern cannot silently reappear."
     }
   ],
   "sprints": [
@@ -6595,6 +6604,35 @@
           "depends_on": [
             "S254-3"
           ]
+        }
+      ]
+    },
+    {
+      "id": 256,
+      "theme": "Cleanups",
+      "par": 4,
+      "slope": 2,
+      "type": "chore + maintainability",
+      "status": "planned",
+      "note": ".codex is the slope-init generated plugin bundle, the exact sibling of the already-ignored .slope, but it was not gitignored, so it showed as untracked on every git status and was nearly committed by accident during the Phase 56 merge. isWithinClaimedArea (scope-drift) and claimOverlapsPath (claim-required) are two copies of area-matching that both needed the identical #651 root-claim fix. The guard-ask audit found the #650 pattern in exactly one guard, already fixed.",
+      "tickets": [
+        {
+          "key": "S256-1",
+          "title": "Gitignore the generated .codex bundle, matching how .slope is treated",
+          "club": "putter",
+          "complexity": "trivial"
+        },
+        {
+          "key": "S256-2",
+          "title": "Consolidate the duplicated claim-area matcher into one shared function",
+          "club": "short_iron",
+          "complexity": "standard"
+        },
+        {
+          "key": "S256-3",
+          "title": "Pin the invariant that no guard prompts the operator for an agent-actionable fix (#650)",
+          "club": "wedge",
+          "complexity": "small"
         }
       ]
     }

--- a/docs/backlog/roadmap.json
+++ b/docs/backlog/roadmap.json
@@ -6613,7 +6613,7 @@
       "par": 4,
       "slope": 2,
       "type": "chore + maintainability",
-      "status": "planned",
+      "status": "complete",
       "note": ".codex is the slope-init generated plugin bundle, the exact sibling of the already-ignored .slope, but it was not gitignored, so it showed as untracked on every git status and was nearly committed by accident during the Phase 56 merge. isWithinClaimedArea (scope-drift) and claimOverlapsPath (claim-required) are two copies of area-matching that both needed the identical #651 root-claim fix. The guard-ask audit found the #650 pattern in exactly one guard, already fixed.",
       "tickets": [
         {

--- a/docs/retros/rollovers/sprint-254-to-256-c211c348c983c954.json
+++ b/docs/retros/rollovers/sprint-254-to-256-c211c348c983c954.json
@@ -1,0 +1,264 @@
+{
+  "version": 1,
+  "kind": "sprint_rollover",
+  "transition_id": "8c721f121207a1b5",
+  "from_sprint": 254,
+  "to_sprint": 256,
+  "from_label": "S254",
+  "to_label": "S256",
+  "recorded_at": "2026-07-25T19:03:22.780Z",
+  "actor": {
+    "name": "srbry",
+    "source": "env:USERNAME"
+  },
+  "request": {
+    "from": 254,
+    "to": 256,
+    "force": false
+  },
+  "forced": false,
+  "eligibility": {
+    "from_terminal": true,
+    "target_dependency_eligible": true,
+    "blocking_dependencies": [],
+    "target_dependencies": [],
+    "completion_evidence": {
+      "roadmap_complete": [
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        114.5,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        137.5,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        143.5,
+        143.6,
+        143.7,
+        143.8,
+        143.9,
+        143.95,
+        143.97,
+        143.98,
+        143.99,
+        144,
+        145,
+        146,
+        146.1,
+        146.2,
+        146.3,
+        148,
+        149,
+        150,
+        151,
+        151.1,
+        152,
+        152.1,
+        153,
+        154,
+        216,
+        217,
+        218,
+        219,
+        220,
+        221,
+        222,
+        223,
+        224,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        233,
+        234,
+        235,
+        236,
+        241,
+        242,
+        243,
+        244,
+        246,
+        247,
+        248,
+        249,
+        250,
+        251,
+        252,
+        253,
+        254
+      ],
+      "scorecards": [],
+      "local_terminal": [
+        254
+      ]
+    },
+    "scorecard_artifacts": [],
+    "expected_next": 256
+  },
+  "roadmap": {
+    "path": "docs/backlog/roadmap.json",
+    "sha256": "e16d75d67bbebf947ae122b2acfb9119a9080f151de390d905c4d5481e281436",
+    "from_status": "complete",
+    "to_status": "planned"
+  },
+  "prior_state_sha256": "79bbfe26ba9706806326a4983763a0c982f32fd027e578e6de980053003e7547",
+  "prior_state": {
+    "sprint": 254,
+    "phase": "scoring",
+    "gates": {
+      "tests": true,
+      "code_review": true,
+      "architect_review": true,
+      "scorecard": true,
+      "review_md": true
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local self review; no subagents per operator direction. Caught that the S252 revert of this same change was an unverified probe artifact — the guard blocks deny correctly when called directly. Landed with the deny coverage whose absence made the earlier revert unresolvable. Evidence: 4165 tests, tsc clean, guard verified through the real hook path, shell-write 11/11 against real failures and legitimate patterns.",
+        "updated_at": "2026-07-25T18:38:03.708Z"
+      },
+      "architect_review": {
+        "provenance": "self_review",
+        "evidence": [],
+        "notes": "Local architecture self review of the policy-keyed advisory boundary, the eight-site guard registration surface, and the phase-rename false positive in the #637 divergence check.",
+        "updated_at": "2026-07-25T18:38:04.043Z"
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T18:11:11.038Z",
+    "updated_at": "2026-07-25T18:41:29.753Z",
+    "rollover": {
+      "transition_id": "1fa3f2fc089b769d",
+      "from_sprint": 253,
+      "audit_path": "docs/retros/rollovers/sprint-253-to-254-2f4bbfce0adb77e1.json",
+      "recorded_at": "2026-07-25T18:11:11.038Z",
+      "forced": false
+    }
+  },
+  "next_state": {
+    "sprint": 256,
+    "phase": "planning",
+    "gates": {
+      "tests": false,
+      "code_review": false,
+      "architect_review": false,
+      "scorecard": false,
+      "review_md": false
+    },
+    "review_gates": {
+      "code_review": {
+        "provenance": "pending",
+        "evidence": []
+      },
+      "architect_review": {
+        "provenance": "pending",
+        "evidence": []
+      }
+    },
+    "review_requirements": {
+      "code_review": {
+        "priority": "unspecified"
+      },
+      "architect_review": {
+        "priority": "unspecified"
+      }
+    },
+    "started_at": "2026-07-25T19:03:22.780Z",
+    "updated_at": "2026-07-25T19:03:22.780Z",
+    "rollover": {
+      "transition_id": "8c721f121207a1b5",
+      "from_sprint": 254,
+      "audit_path": "docs/retros/rollovers/sprint-254-to-256-c211c348c983c954.json",
+      "recorded_at": "2026-07-25T19:03:22.780Z",
+      "forced": false
+    }
+  },
+  "claims_policy": "unchanged",
+  "sessions_policy": "unchanged"
+}

--- a/docs/retros/sprint-256-review.md
+++ b/docs/retros/sprint-256-review.md
@@ -1,0 +1,41 @@
+
+## Sprint 256 Review: Cleanups
+
+### SLOPE Scorecard Summary
+
+| Metric | Value |
+|---|---|
+| Par | 4 |
+| Slope | 2 |
+| Score | 4 |
+| Label | Par |
+| Fairway % | 100% (3/3) |
+| GIR % | 100% (3/3) |
+| Putts | 0 |
+| Penalties | 0 |
+
+### Shot-by-Shot (Tickets Delivered: 3)
+
+| Ticket | Club | Result | Hazards | Notes |
+|---|---|---|---|---|
+| S256-1 | Putter | In the Hole | -- | .codex is slope-init generated output, the exact sibling of the already-ignored .slope. It had shown as untracked on every git status all session and was nearly committed during the Phase 56 merge. One line. |
+| S256-2 | Short Iron | Green | -- | isWithinClaimedArea and claimOverlapsPath were two copies that both needed the identical #651 whole-repo fix. Extracted claim-area.ts; both delegate. Behaviour preserved (35 claim-required tests pass), with a small consistency gain (backslash target normalization). New module has its own 18-test suite. |
+| S256-3 | Wedge | Green | Rough: The audit's premise (10 ask/deny guards to review) was wrong: only claim-required ever emitted ask, and #650 fixed it. That fix also left a dead decision: 'ask' branch, which the invariant test would have failed on until removed. Verifying the premise before writing code saved building a downgrade for guards that were correct deny gates. | Source-level test asserts no guard emits decision: 'ask'. The remaining deny guards return to the agent, not the operator, and are legitimate safety gates. Removed the now-unreachable ask branch from implementationWritePolicyResult, replacing it with an advisory fallback rather than deleting it. |
+
+### Conditions
+
+| Condition | Impact | Description |
+|---|---|---|
+| undefined | undefined | undefined |
+
+### Hazards Discovered
+
+| Type | Ticket | Description |
+|---|---|---|
+| Rough | S256-3 | The audit's premise (10 ask/deny guards to review) was wrong: only claim-required ever emitted ask, and #650 fixed it. That fix also left a dead decision: 'ask' branch, which the invariant test would have failed on until removed. Verifying the premise before writing code saved building a downgrade for guards that were correct deny gates. |
+
+### Course Management Notes
+
+- The 'audit the 10 guards' ask turned out to need no downgrade — verifying the premise (which guards actually emit ask vs deny) converted a speculative refactor into a one-line invariant test plus a dead-code removal.
+- A guard firing on its own author (shell-write earlier; the advisory claim-required message this sprint) is the mechanism working — the signal reaches the agent, not the operator.
+

--- a/docs/retros/sprint-256.json
+++ b/docs/retros/sprint-256.json
@@ -1,0 +1,66 @@
+{
+  "sprint_number": 256,
+  "theme": "Cleanups",
+  "par": 4,
+  "slope": 2,
+  "score": 4,
+  "score_label": "par",
+  "date": "2026-07-25",
+  "shots": [
+    {
+      "ticket_key": "S256-1",
+      "title": "Gitignore the generated .codex bundle, matching how .slope is treated",
+      "club": "putter",
+      "result": "in_the_hole",
+      "hazards": [],
+      "notes": ".codex is slope-init generated output, the exact sibling of the already-ignored .slope. It had shown as untracked on every git status all session and was nearly committed during the Phase 56 merge. One line."
+    },
+    {
+      "ticket_key": "S256-2",
+      "title": "Consolidate the duplicated claim-area matcher into one shared function",
+      "club": "short_iron",
+      "result": "green",
+      "hazards": [],
+      "notes": "isWithinClaimedArea and claimOverlapsPath were two copies that both needed the identical #651 whole-repo fix. Extracted claim-area.ts; both delegate. Behaviour preserved (35 claim-required tests pass), with a small consistency gain (backslash target normalization). New module has its own 18-test suite."
+    },
+    {
+      "ticket_key": "S256-3",
+      "title": "Pin the invariant that no guard prompts the operator for an agent-actionable fix (#650)",
+      "club": "wedge",
+      "result": "green",
+      "hazards": [
+        {
+          "type": "rough",
+          "severity": "minor",
+          "description": "The audit's premise (10 ask/deny guards to review) was wrong: only claim-required ever emitted ask, and #650 fixed it. That fix also left a dead decision: 'ask' branch, which the invariant test would have failed on until removed. Verifying the premise before writing code saved building a downgrade for guards that were correct deny gates.",
+          "gotcha_id": "self:verify-premise"
+        }
+      ],
+      "notes": "Source-level test asserts no guard emits decision: 'ask'. The remaining deny guards return to the agent, not the operator, and are legitimate safety gates. Removed the now-unreachable ask branch from implementationWritePolicyResult, replacing it with an advisory fallback rather than deleting it."
+    }
+  ],
+  "stats": {
+    "fairways_hit": 3,
+    "fairways_total": 3,
+    "greens_in_regulation": 3,
+    "greens_total": 3,
+    "putts": 0,
+    "penalties": 0,
+    "hazards_hit": 1,
+    "hazard_penalties": 0,
+    "miss_directions": { "long": 0, "short": 0, "left": 0, "right": 0 }
+  },
+  "conditions": [
+    "Landed on the .gitattributes-normalized tree, so no CRLF churn — the first sprint this session with a genuinely quiet git status."
+  ],
+  "special_plays": [],
+  "bunker_locations": [],
+  "yardage_book_updates": [
+    "Claim-area membership lives in src/cli/guards/claim-area.ts; both claim-required and scope-drift delegate. Change area/root/sprint matching there once.",
+    "No guard should emit decision: 'ask' — that prompts the operator. Use deny (agent-facing block) or advisory context. tests/cli/guards/no-operator-ask.test.ts enforces it."
+  ],
+  "course_management_notes": [
+    "The 'audit the 10 guards' ask turned out to need no downgrade — verifying the premise (which guards actually emit ask vs deny) converted a speculative refactor into a one-line invariant test plus a dead-code removal.",
+    "A guard firing on its own author (shell-write earlier; the advisory claim-required message this sprint) is the mechanism working — the signal reaches the agent, not the operator."
+  ]
+}

--- a/docs/roadmap/phases/phase-59.yaml
+++ b/docs/roadmap/phases/phase-59.yaml
@@ -12,7 +12,7 @@ sprints:
     par: 4
     slope: 2
     type: chore + maintainability
-    status: planned
+    status: complete
     note: ".codex is the slope-init generated plugin bundle, the exact sibling of the already-ignored .slope, but it was not gitignored, so it showed as untracked on every git status and was nearly committed by accident during the Phase 56 merge. isWithinClaimedArea (scope-drift) and claimOverlapsPath (claim-required) are two copies of area-matching that both needed the identical #651 root-claim fix. The guard-ask audit found the #650 pattern in exactly one guard, already fixed."
     tickets:
       - key: S256-1
@@ -27,3 +27,5 @@ sprints:
         title: "Pin the invariant that no guard prompts the operator for an agent-actionable fix (#650)"
         club: wedge
         complexity: small
+scorecards:
+  "256": docs/retros/sprint-256.json

--- a/docs/roadmap/phases/phase-59.yaml
+++ b/docs/roadmap/phases/phase-59.yaml
@@ -1,0 +1,29 @@
+version: "1"
+phase:
+  name: Phase 59 — Cleanups
+  description: "Three low-risk items surfaced while reviewing the session: the generated .codex bundle showing as untracked on every status, duplicated claim-area matching logic that both needed the same #651 fix, and an audit of which guards prompt the operator. The audit's conclusion is a regression test rather than a downgrade."
+  sprints:
+    - 256
+  status: in_progress
+  note: "The ask/deny guard audit found only claim-required ever emitted an operator ask (fixed in #650); every other guard uses deny, which blocks the tool and returns to the agent, not the operator. Nothing to downgrade — the deliverable is a fleet-level invariant test so the pattern cannot silently reappear."
+sprints:
+  - id: 256
+    theme: Cleanups
+    par: 4
+    slope: 2
+    type: chore + maintainability
+    status: planned
+    note: ".codex is the slope-init generated plugin bundle, the exact sibling of the already-ignored .slope, but it was not gitignored, so it showed as untracked on every git status and was nearly committed by accident during the Phase 56 merge. isWithinClaimedArea (scope-drift) and claimOverlapsPath (claim-required) are two copies of area-matching that both needed the identical #651 root-claim fix. The guard-ask audit found the #650 pattern in exactly one guard, already fixed."
+    tickets:
+      - key: S256-1
+        title: Gitignore the generated .codex bundle, matching how .slope is treated
+        club: putter
+        complexity: trivial
+      - key: S256-2
+        title: Consolidate the duplicated claim-area matcher into one shared function
+        club: short_iron
+        complexity: standard
+      - key: S256-3
+        title: "Pin the invariant that no guard prompts the operator for an agent-actionable fix (#650)"
+        club: wedge
+        complexity: small

--- a/docs/roadmap/project.yaml
+++ b/docs/roadmap/project.yaml
@@ -101,3 +101,5 @@ sources:
     kind: phase
   - path: phases/phase-58.yaml
     kind: phase
+  - path: phases/phase-59.yaml
+    kind: phase

--- a/src/cli/guards/claim-area.ts
+++ b/src/cli/guards/claim-area.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared claim-area matching, used by both claim-required (cross-session overlap)
+ * and scope-drift (out-of-scope edits).
+ *
+ * These two guards each carried their own copy of this logic, and both needed the
+ * identical whole-repo fix in #651 — the prefix match built `./`, which no
+ * relative path starts with, so a `--target=.` area claim covered nothing. One
+ * home means the next change lands once.
+ */
+
+/** True for a whole-sprint claim like `sprint:S143.5`, which covers every path. */
+export function isWholeSprintClaim(target: string): boolean {
+  return /^sprint:S\d+(?:\.\d+)?$/i.test(target);
+}
+
+/**
+ * True when an area claim covers the whole working tree.
+ *
+ * `slope claim --target=. --scope=area` is the natural way to say "I am working
+ * across this repo" (GH #651).
+ */
+export function isWholeRepoClaim(target: string): boolean {
+  const normalized = normalizeArea(target);
+  return normalized === '.' || normalized === '' || normalized === '/';
+}
+
+/** Normalize an area target: backslashes to forward slashes, no trailing slash. */
+function normalizeArea(target: string): string {
+  return target.replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+/**
+ * True when `relativePath` falls within the claimed `target` area.
+ *
+ * Handles the two area-claim special cases (whole sprint, whole repo) and,
+ * otherwise, an anchored prefix match: a claim on `src/core` matches `src/core`
+ * and `src/core/x.ts` but not `src/core-helpers`.
+ */
+export function pathWithinClaimedArea(relativePath: string, target: string): boolean {
+  if (isWholeSprintClaim(target)) return true;
+  if (isWholeRepoClaim(target)) return true;
+
+  const normalizedTarget = normalizeArea(target);
+  const normalizedPath = relativePath.replace(/\\/g, '/');
+  return normalizedPath === normalizedTarget || normalizedPath.startsWith(`${normalizedTarget}/`);
+}

--- a/src/cli/guards/claim-required.ts
+++ b/src/cli/guards/claim-required.ts
@@ -8,6 +8,7 @@ import { loadSprintState } from '../sprint-state.js';
 import { loadSessionState, updateSessionState } from '../session-state.js';
 import { resolveStore } from '../store.js';
 import { normalizeTouchedPath, resolveTouchedPaths, toAbsoluteTouchedPath } from './hook-input.js';
+import { pathWithinClaimedArea } from './claim-area.js';
 
 const IMPLEMENTATION_DIRS = [
   'app/',
@@ -251,12 +252,14 @@ function implementationWritePolicyResult(
       ].join('\n'),
     };
   }
+
+  // Only "deny" produces a decision. Everything short of it is advisory: the guard
+  // must not raise an operator permission prompt for a fix the agent can apply
+  // (GH #650). Reached only if a caller omits ctx; the ctx path above dedups.
   return {
-    decision: 'ask',
     context: [
-      'SLOPE permission request — the configured implementation-write policy is "ask".',
+      'SLOPE advisory (non-blocking) — addressed to the agent, not a permission request.',
       ...lines,
-      'A SLOPE claim records work scope but does not replace the host permission policy; the host decides whether to allow this edit.',
     ].join('\n'),
   };
 }
@@ -304,13 +307,7 @@ export function claimOverlapsPath(
   fileArea: string,
 ): boolean {
   if (scope !== 'area') return relativePath === target;
-  if (isWholeSprintClaim(target)) return true;
-  if (isWholeRepoClaim(target)) return true;
-  const areaPrefix = target.endsWith('/') ? target : `${target}/`;
-  return (
-    relativePath === target || relativePath.startsWith(areaPrefix) ||
-    fileArea === target || fileArea.startsWith(areaPrefix)
-  );
+  return pathWithinClaimedArea(relativePath, target) || pathWithinClaimedArea(fileArea, target);
 }
 
 /**
@@ -367,19 +364,3 @@ async function loadSprintClaims(cwd: string, sprintNumber: number): Promise<Spri
   }
 }
 
-function isWholeSprintClaim(target: string): boolean {
-  return /^sprint:S\d+(?:\.\d+)?$/i.test(target);
-}
-
-/**
- * True when an area claim covers the whole working tree.
- *
- * `slope claim --target=. --scope=area` is the natural way to say "I am working
- * across this repo", but the prefix match built `./`, which no relative path
- * starts with — so a root claim silenced nothing and every write was reported as
- * scope drift (GH #651).
- */
-function isWholeRepoClaim(target: string): boolean {
-  const normalized = target.replace(/\\/g, '/').replace(/\/+$/, '');
-  return normalized === '.' || normalized === '' || normalized === '/';
-}

--- a/src/cli/guards/scope-drift.ts
+++ b/src/cli/guards/scope-drift.ts
@@ -4,6 +4,7 @@ import type { HookInput, GuardResult } from '../../core/index.js';
 import { loadConfig } from '../config.js';
 import type { SlopeConfig } from '../config.js';
 import { loadSprintState } from '../sprint-state.js';
+import { pathWithinClaimedArea } from './claim-area.js';
 import { resolveStore } from '../store.js';
 import { dedupGuardContext } from '../session-state.js';
 import { normalizeTouchedPath, resolveTouchedPaths } from './hook-input.js';
@@ -141,12 +142,5 @@ function resolveCurrentSprint(cwd: string, config: SlopeConfig): number | undefi
 }
 
 function isWithinClaimedArea(relativePath: string, target: string): boolean {
-  const normalizedTarget = target.replace(/\\/g, '/').replace(/\/$/, '');
-  if (/^sprint:S\d+(?:\.\d+)?$/i.test(normalizedTarget)) return true;
-  // `slope claim --target=. --scope=area` is the natural way to say "working
-  // across this repo", but the prefix test built `./`, which no relative path
-  // starts with — so a root claim silenced nothing and every write was reported
-  // as drift (GH #651).
-  if (normalizedTarget === '.' || normalizedTarget === '' || normalizedTarget === '/') return true;
-  return relativePath === normalizedTarget || relativePath.startsWith(`${normalizedTarget}/`);
+  return pathWithinClaimedArea(relativePath, target);
 }

--- a/tests/cli/guards/claim-area.test.ts
+++ b/tests/cli/guards/claim-area.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isWholeRepoClaim,
+  isWholeSprintClaim,
+  pathWithinClaimedArea,
+} from '../../../src/cli/guards/claim-area.js';
+
+describe('claim-area matching (shared by claim-required and scope-drift)', () => {
+  describe('isWholeSprintClaim', () => {
+    it.each(['sprint:S143', 'sprint:S143.5', 'SPRINT:s60'])('accepts %s', target => {
+      expect(isWholeSprintClaim(target)).toBe(true);
+    });
+    it.each(['src/core', 'sprint:143', 'sprintish'])('rejects %s', target => {
+      expect(isWholeSprintClaim(target)).toBe(false);
+    });
+  });
+
+  describe('isWholeRepoClaim (GH #651)', () => {
+    it.each(['.', './', '', '/', '.\\'])('accepts %j', target => {
+      expect(isWholeRepoClaim(target)).toBe(true);
+    });
+    it.each(['src', 'src/core', './src'])('rejects %j', target => {
+      expect(isWholeRepoClaim(target)).toBe(false);
+    });
+  });
+
+  describe('pathWithinClaimedArea', () => {
+    it('covers everything for a whole-repo or whole-sprint claim', () => {
+      expect(pathWithinClaimedArea('src/core/roadmap.ts', '.')).toBe(true);
+      expect(pathWithinClaimedArea('anything.ts', 'sprint:S143.5')).toBe(true);
+    });
+
+    it('anchors the prefix so src/core does not match src/core-helpers', () => {
+      expect(pathWithinClaimedArea('src/core', 'src/core')).toBe(true);
+      expect(pathWithinClaimedArea('src/core/memory.ts', 'src/core')).toBe(true);
+      expect(pathWithinClaimedArea('src/core-helpers/x.ts', 'src/core')).toBe(false);
+    });
+
+    it('normalizes backslashes and trailing slashes on both sides', () => {
+      expect(pathWithinClaimedArea('src\\core\\x.ts', 'src/core')).toBe(true);
+      expect(pathWithinClaimedArea('src/core/x.ts', 'src/core/')).toBe(true);
+    });
+
+    it('does not match an unrelated area', () => {
+      expect(pathWithinClaimedArea('src/core/x.ts', 'src/cli')).toBe(false);
+    });
+  });
+});

--- a/tests/cli/guards/no-operator-ask.test.ts
+++ b/tests/cli/guards/no-operator-ask.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const guardsDir = join(dirname(fileURLToPath(import.meta.url)), '../../../src/cli/guards');
+
+/**
+ * Fleet-level invariant for GH #650.
+ *
+ * `decision: 'ask'` surfaces a host permission prompt to the *operator*. A guard
+ * must never do that for a fix the agent can apply itself — every remedy a guard
+ * prints (`slope sprint start`, `slope map`, `git checkout -b`) is agent-actionable.
+ * The operator-facing choice belongs to `deny` (a hard block the agent reads and
+ * self-corrects) or to advisory `context`.
+ *
+ * claim-required was the only guard that ever emitted `ask`; #650 made it
+ * advisory. This test pins that so the pattern cannot silently return in any
+ * guard.
+ */
+describe('no guard prompts the operator with decision: ask (GH #650)', () => {
+  const guardFiles = readdirSync(guardsDir)
+    .filter(name => name.endsWith('.ts') && !name.endsWith('.test.ts'));
+
+  it('finds guard source files to check', () => {
+    expect(guardFiles.length).toBeGreaterThan(10);
+  });
+
+  it.each(guardFiles)('%s does not emit decision: ask', file => {
+    const source = readFileSync(join(guardsDir, file), 'utf8');
+    // Match the object-literal decision, tolerant of quote style and whitespace.
+    const emitsAsk = /decision\s*:\s*['"]ask['"]/.test(source);
+    expect(emitsAsk, `${file} emits decision: 'ask' — route it to deny or advisory context (GH #650)`).toBe(false);
+  });
+});


### PR DESCRIPTION
Three low-risk items surfaced reviewing the session. **Targets `main` directly.**

## `.codex/` gitignored
It's the `slope init` generated plugin bundle — the exact sibling of the already-ignored `.slope/` — but wasn't ignored, so it showed as untracked on **every** `git status` this session and was nearly committed during the Phase 56 merge (had to `git rm --cached` it out). One line.

## Claim-area matching consolidated
`isWithinClaimedArea` (scope-drift) and `claimOverlapsPath` (claim-required) were two copies of area membership, and both needed the *identical* whole-repo fix in #651. Extracted `src/cli/guards/claim-area.ts` (`isWholeSprintClaim`, `isWholeRepoClaim`, `pathWithinClaimedArea`); both guards delegate. Behaviour preserved — all 35 claim-required tests pass — with a small consistency gain (backslash targets now normalize too). New module has its own 18-test suite.

## No-operator-ask invariant pinned
The "audit the 10 ask/deny guards" ask turned out to need **no downgrade**, and verifying that first was the point:

- Only `claim-required` ever emitted `decision: 'ask'` — the host permission prompt that interrupted the operator (#650) — and #650 made it advisory.
- Every other guard uses `decision: 'deny'`, which blocks the tool and returns to the **agent**, not the operator (like `branch-before-commit` did — I branched and continued; nobody was prompted). Those are legitimate safety gates; downgrading them would weaken real protection.

So the deliverable is a source-level test asserting **no guard emits `decision: 'ask'`**, so the #650 pattern can't silently reappear anywhere in the fleet. Also removed the now-unreachable `ask` branch #650 left dead in `implementationWritePolicyResult` (replaced with an advisory fallback, not deleted, so a future ctx-less caller stays advisory).

## Verification
Build, typecheck, full suite clean — 252 files, **4218 tests** (up from 4165). First sprint this session to land on a quiet `git status`, thanks to #655.

## Review status
⚠️ Gates `self_review` (weaker) — no subagents per operator direction. Self review's catch was that the audit premise was wrong before any code got written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)