### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slope-dev/slope",
-  "version": "1.64.1",
+  "version": "2.0.0",
   "description": "Quantified sprint metrics for AI-assisted development. Scorecards, handicap tracking, and real-time agent guidance for Claude Code, Cursor, Windsurf, Cline, and OpenCode.",
   "type": "module",
   "main": "./dist/index.js",

--- a/templates/codex/plugins/slope/.codex-plugin/plugin.json
+++ b/templates/codex/plugins/slope/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "slope",
-  "version": "1.64.1",
+  "version": "2.0.0",
   "description": "SLOPE sprint tracking, guard hooks, and Codex workflow skills.",
   "author": {
     "name": "SLOPE",


### PR DESCRIPTION
Version bump from 1.64.1 to 2.0.0 after the S267 canonical sprint-ID migration release train.

Release policy requires a major version because opening an existing SQLite or PostgreSQL store applies schema migrations that change persisted sprint identity to canonical strings.

Validation:
- S267 PR #681 passed CI, PostgreSQL integration, CodeQL, and secret scanning
- local `npm pack --dry-run` produced `@slope-dev/slope@2.0.0`
- package and bundled Codex plugin versions both report 2.0.0

After merge and main CI, GitHub release `v2.0.0` will trigger trusted npm publishing.